### PR TITLE
feat(xapiri): structured Proxmox credential + network flow with hidden token input

### DIFF
--- a/internal/ui/xapiri/onprem.go
+++ b/internal/ui/xapiri/onprem.go
@@ -48,6 +48,21 @@ func (s *state) runOnPremFork() int {
 	if err := s.step5_5_onprem_tco(); err != nil {
 		return s.exit(err)
 	}
+	// Provider-specific credential + network steps.
+	// Proxmox gets a structured flow; other on-prem providers use
+	// the generic reflection walk.
+	if s.cfg.InfraProvider == "proxmox" {
+		if err := s.step6_proxmox(); err != nil {
+			return s.exit(err)
+		}
+		if err := s.step6_5_proxmox_network(); err != nil {
+			return s.exit(err)
+		}
+		if err := s.step7_review(); err != nil {
+			return s.exit(err)
+		}
+		return s.exit(s.step8_persistAndDecide())
+	}
 	if err := s.runSharedTail(); err != nil {
 		return s.exit(err)
 	}

--- a/internal/ui/xapiri/prompts.go
+++ b/internal/ui/xapiri/prompts.go
@@ -15,10 +15,13 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"golang.org/x/term"
 )
 
 // dns1123label is the validation regexp for Kubernetes-style names
@@ -69,17 +72,15 @@ func (r *reader) promptString(label, cur string) string {
 	return v
 }
 
-// promptSecret is the sensitive variant. We don't actually disable
-// terminal echo — that requires platform-specific code (golang.org/x/term)
-// and the spec explicitly asks only that we mark them sensitive *for
-// later display*. The prompt label gets a "(sensitive)" hint so the
-// user knows to be careful; the review step masks the value.
+// promptSecret is the sensitive variant used by the reflection-based
+// step6 (cloud providers / generic path). The prompt label gets a
+// "(sensitive)" hint so the user knows to be careful; the review step
+// masks the value.  Echo is NOT disabled here — promptSecretHidden
+// does that for the Proxmox-specific flow.
 func (r *reader) promptSecret(label, cur string) string {
-	display := ""
+	display := "unset"
 	if cur != "" {
 		display = "set"
-	} else {
-		display = "unset"
 	}
 	fmt.Fprintf(r.out, "  %s (sensitive) [%s]: ", label, display)
 	v := r.readLine()
@@ -87,6 +88,39 @@ func (r *reader) promptSecret(label, cur string) string {
 		return cur
 	}
 	return v
+}
+
+// promptSecretHidden disables terminal echo while the operator types a
+// sensitive value (token, password, API secret).  When stdin is not a
+// TTY (pipes, tests, CI) it falls back to the plain visible read so
+// automation can still drive the wizard.  Returns the entered value
+// (or cur on empty input) and any I/O error that isn't EOF.
+func (r *reader) promptSecretHidden(label, cur string) (string, error) {
+	display := "unset"
+	if cur != "" {
+		display = "set"
+	}
+	fmt.Fprintf(r.out, "  %s (hidden) [%s]: ", label, display)
+
+	fd := int(os.Stdin.Fd())
+	if term.IsTerminal(fd) {
+		raw, err := term.ReadPassword(fd)
+		fmt.Fprintln(r.out) // move past the prompt line after hidden input
+		if err != nil {
+			return cur, err
+		}
+		v := strings.TrimRight(string(raw), "\r\n")
+		if v == "" {
+			return cur, nil
+		}
+		return v, nil
+	}
+	// Non-TTY fallback: visible read (CI, piped tests).
+	v := r.readLine()
+	if v == "" {
+		return cur, nil
+	}
+	return v, nil
 }
 
 // promptInt asks for a non-negative integer. Empty input keeps cur;

--- a/internal/ui/xapiri/proxmox.go
+++ b/internal/ui/xapiri/proxmox.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package xapiri
+
+// proxmox.go — structured credential + network steps for the Proxmox
+// on-prem fork.  Replaces the reflection-driven step6_providerDetails
+// for this provider, which was too noisy (it asked for every empty
+// string field regardless of relevance) and lacked the managed-vs-BYO
+// credential fork.
+//
+// Two credential modes:
+//
+//	managed  — operator provides admin username + token; yage runs
+//	           OpenTofu to create CAPI (CAPMOX) and CSI identities.
+//	           The orchestrator's existing phase0IdentityBootstrap
+//	           logic fires automatically when Token/Secret/CSITokenID/
+//	           CSITokenSecret are all empty.
+//
+//	byo      — operator provides the CAPMOX token (URL + Token +
+//	           Secret) and CSI token (CSITokenID + CSITokenSecret)
+//	           directly; the orchestrator's HaveClusterctlCredsInEnv()
+//	           returns true and OpenTofu is skipped.
+
+import "fmt"
+
+// credentialMode is the local enum for the two Proxmox identity flows.
+type credentialMode int
+
+const (
+	credManaged credentialMode = iota
+	credBYO
+)
+
+// step6_proxmox collects the Proxmox-specific settings: core API
+// fields, then a managed-vs-BYO credential fork.
+func (s *state) step6_proxmox() error {
+	s.r.section("proxmox settings")
+
+	// --- Core fields (always asked) ---
+	s.cfg.Providers.Proxmox.URL = s.r.promptString(
+		"Proxmox URL (e.g. https://pve.example.com:8006)",
+		s.cfg.Providers.Proxmox.URL)
+
+	s.cfg.Providers.Proxmox.Node = s.r.promptString(
+		"Proxmox node name",
+		s.cfg.Providers.Proxmox.Node)
+
+	s.cfg.Providers.Proxmox.Region = s.r.promptString(
+		"region / datacenter label (used in CAPI topology tags)",
+		s.cfg.Providers.Proxmox.Region)
+
+	s.cfg.Providers.Proxmox.Bridge = s.r.promptString(
+		"VM network bridge",
+		orStr(s.cfg.Providers.Proxmox.Bridge, "vmbr0"))
+
+	s.cfg.Providers.Proxmox.Pool = s.r.promptString(
+		"Proxmox pool (empty = no pool)",
+		s.cfg.Providers.Proxmox.Pool)
+
+	s.cfg.Providers.Proxmox.CloudinitStorage = s.r.promptString(
+		"cloud-init storage name",
+		orStr(s.cfg.Providers.Proxmox.CloudinitStorage, "local"))
+
+	s.cfg.Providers.Proxmox.TemplateID = s.r.promptString(
+		"VM template ID",
+		orStr(s.cfg.Providers.Proxmox.TemplateID, "104"))
+
+	// --- Credential mode ---
+	s.r.info("")
+	mode := s.promptCredMode()
+
+	switch mode {
+	case credManaged:
+		return s.step6_proxmox_managed()
+	case credBYO:
+		return s.step6_proxmox_byo()
+	}
+	return nil
+}
+
+const (
+	choiceManaged = "managed     — provide admin creds; yage creates CAPI/CSI tokens via OpenTofu"
+	choiceBYO     = "bring-your-own — provide existing CAPI and CSI tokens directly"
+)
+
+// promptCredMode asks the operator which credential flow to use.
+// Defaults to managed when no BYO tokens are already set.
+func (s *state) promptCredMode() credentialMode {
+	hasBYO := s.cfg.Providers.Proxmox.Token != "" &&
+		s.cfg.Providers.Proxmox.Secret != "" &&
+		s.cfg.Providers.Proxmox.CSITokenID != "" &&
+		s.cfg.Providers.Proxmox.CSITokenSecret != ""
+	cur := choiceManaged
+	if hasBYO {
+		cur = choiceBYO
+	}
+	pick := s.r.promptChoice("credential mode:", []string{choiceManaged, choiceBYO}, cur)
+	if pick == choiceBYO {
+		return credBYO
+	}
+	return credManaged
+}
+
+// step6_proxmox_managed collects admin credentials for the OpenTofu
+// identity bootstrap path.  Token/Secret/CSITokenID/CSITokenSecret
+// are intentionally left empty so the orchestrator's
+// phase0IdentityBootstrap logic fires and creates them.
+func (s *state) step6_proxmox_managed() error {
+	s.r.info("managed mode — yage will run OpenTofu to create CAPI and CSI identities.")
+	s.cfg.Providers.Proxmox.AdminUsername = s.r.promptString(
+		"admin API username",
+		orStr(s.cfg.Providers.Proxmox.AdminUsername, "root@pam!capi-bootstrap"))
+
+	token, err := s.r.promptSecretHidden("admin API token", s.cfg.Providers.Proxmox.AdminToken)
+	if err != nil {
+		return fmt.Errorf("reading admin token: %w", err)
+	}
+	s.cfg.Providers.Proxmox.AdminToken = token
+	// Clear BYO fields so the orchestrator doesn't accidentally see
+	// a partial set and skip OpenTofu.
+	s.cfg.Providers.Proxmox.Token = ""
+	s.cfg.Providers.Proxmox.Secret = ""
+	s.cfg.Providers.Proxmox.CSITokenID = ""
+	s.cfg.Providers.Proxmox.CSITokenSecret = ""
+	return nil
+}
+
+// step6_proxmox_byo collects the CAPMOX and CSI tokens the operator
+// has already created on Proxmox.  When Token + Secret + CSITokenID +
+// CSITokenSecret are all non-empty, HaveClusterctlCredsInEnv() returns
+// true and the orchestrator skips the OpenTofu identity phase entirely.
+func (s *state) step6_proxmox_byo() error {
+	s.r.info("bring-your-own mode — OpenTofu identity bootstrap will be skipped.")
+	s.r.info("Provide the existing Proxmox API tokens for CAPMOX and CSI.")
+
+	s.cfg.Providers.Proxmox.Token = s.r.promptString(
+		"CAPMOX token ID (e.g. capmox@pve!capmox-token)",
+		s.cfg.Providers.Proxmox.Token)
+
+	secret, err := s.r.promptSecretHidden("CAPMOX token secret", s.cfg.Providers.Proxmox.Secret)
+	if err != nil {
+		return fmt.Errorf("reading CAPMOX token secret: %w", err)
+	}
+	s.cfg.Providers.Proxmox.Secret = secret
+
+	s.cfg.Providers.Proxmox.CSITokenID = s.r.promptString(
+		"CSI token ID (e.g. csi@pve!csi-token)",
+		s.cfg.Providers.Proxmox.CSITokenID)
+
+	csiSecret, err := s.r.promptSecretHidden("CSI token secret", s.cfg.Providers.Proxmox.CSITokenSecret)
+	if err != nil {
+		return fmt.Errorf("reading CSI token secret: %w", err)
+	}
+	s.cfg.Providers.Proxmox.CSITokenSecret = csiSecret
+	// Clear admin creds — they're not needed when BYO tokens are supplied.
+	s.cfg.Providers.Proxmox.AdminToken = ""
+	return nil
+}
+
+// step6_5_proxmox_network collects the network settings that every
+// Proxmox cluster needs: control-plane VIP, node IP range, gateway,
+// prefix length, DNS servers, bridge-level SSH keys, and the workload
+// and management cluster names.
+func (s *state) step6_5_proxmox_network() error {
+	s.r.section("network settings")
+
+	s.cfg.ControlPlaneEndpointIP = s.r.promptString(
+		"control-plane VIP (must be outside the node IP range)",
+		orStr(s.cfg.ControlPlaneEndpointIP, "192.168.0.20"))
+
+	s.cfg.NodeIPRanges = s.r.promptString(
+		"node IP range (e.g. 192.168.0.21-192.168.0.30)",
+		orStr(s.cfg.NodeIPRanges, "192.168.0.21-192.168.0.30"))
+
+	s.cfg.Gateway = s.r.promptString(
+		"default gateway",
+		orStr(s.cfg.Gateway, "192.168.0.1"))
+
+	s.cfg.IPPrefix = s.r.promptString(
+		"subnet prefix length (e.g. 24)",
+		orStr(s.cfg.IPPrefix, "24"))
+
+	s.cfg.DNSServers = s.r.promptString(
+		"DNS servers (comma-separated)",
+		orStr(s.cfg.DNSServers, "8.8.8.8,8.8.4.4"))
+
+	s.cfg.VMSSHKeys = s.r.promptString(
+		"SSH public key(s) for VM cloud-init (empty to skip)",
+		s.cfg.VMSSHKeys)
+
+	// Workload cluster identity
+	s.cfg.WorkloadClusterName = s.r.promptString(
+		"workload cluster name",
+		orStr(s.cfg.WorkloadClusterName, "capi-quickstart"))
+
+	return nil
+}
+
+// orStr returns s when non-empty, else def.
+func orStr(s, def string) string {
+	if s != "" {
+		return s
+	}
+	return def
+}


### PR DESCRIPTION
## Summary

- Replaces the reflection-driven generic step 6 for Proxmox with a purpose-built flow that asks only the fields that matter.
- Adds a **credential mode fork**: managed (admin creds → OpenTofu creates identities) vs bring-your-own (CAPMOX + CSI tokens directly → OpenTofu skipped).
- Adds a **network settings step** for control-plane VIP, node IP ranges, gateway, prefix, DNS, SSH keys, workload cluster name.
- **Token masking**: `promptSecretHidden` uses `golang.org/x/term.ReadPassword` when stdin is a TTY so secrets don't echo on screen.

## Credential mode behaviour

| Mode | What xapiri collects | OpenTofu identity phase |
|------|----------------------|-------------------------|
| managed | AdminUsername + AdminToken | **runs** — creates CAPMOX and CSI users/tokens |
| bring-your-own | Token + Secret + CSITokenID + CSITokenSecret | **skipped** — `HaveClusterctlCredsInEnv()` returns true |

No new flag or config field needed: the orchestrator's existing `phase0IdentityBootstrap` gate fires or doesn't fire based on which fields are populated.

## What disappeared

The old flow asked: `AdminConfig`, `AdminToken`, `URL`, `Token`, `Secret`, `Region`, `Node`, `SourceNode`, `TopologyRegion`, `TopologyZone`, `CSIConfig`, `CSIURL`, `CSITokenID`, `CSITokenSecret`, `CSIUserID`, `CAPIUserID` — all in a flat list with no context. Advanced fields (`SourceNode`, `TopologyRegion/Zone`, `CSIUserID`, `CAPIUserID`) are still settable via `--config yage.yaml` or env vars but are no longer asked in the wizard.

## DoD Level

- [x] **Level 2 — Test Infrastructure**

## Level 2 Checklist

- [x] Full test suite passes (`go build ./...` + `go test ./...`)
- [x] Coverage not degraded

## Breaking Changes

None for the orchestrator. The xapiri UX changes are intentional — operators who relied on being prompted for `SourceNode` / topology fields in the wizard must now set those via `--config yage.yaml` or env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)