### PR TITLE
feat: mgmt pool prompt, snapshot explicit guards, CAPI credential rename

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -83,7 +83,17 @@ func main() {
 	//
 	// Fill-empty-only semantics: env values that were explicitly
 	// set survive the merge.
-	_ = kindsync.MergeBootstrapConfigFromKind(cfg)
+	//
+	// When no cluster name was provided (no env var, no flag), scan
+	// every running kind cluster for a yage-system/bootstrap-config
+	// Secret and use the first match. This lets `yage` start from
+	// saved config regardless of the cluster name chosen at xapiri
+	// time, without requiring the user to pass --kind-cluster-name.
+	if cfg.KindClusterName == "" {
+		kindsync.MergeBootstrapConfigFromFirstKindCluster(cfg)
+	} else {
+		_ = kindsync.MergeBootstrapConfigFromKind(cfg)
+	}
 
 	// Hand cost-estimation credentials + currency preferences to
 	// the pricing package once at startup. Values come from
@@ -132,7 +142,10 @@ func main() {
 	//   --xapiri   walks the user through on-prem/cloud and sets it
 	//   --print-pricing-setup is informational, not a deploy
 	if cfg.Xapiri {
-		os.Exit(xapiri.Run(os.Stdout, cfg))
+		if rc := xapiri.Run(os.Stdout, cfg); rc != 0 || !cfg.XapiriDeployNow {
+			os.Exit(rc)
+		}
+		// User answered "deploy now? y" — fall through to orchestrator.Run.
 	}
 	if cfg.PrintPricingSetup != "" {
 		switch cfg.PrintPricingSetup {

--- a/internal/capi/manifest/patches.go
+++ b/internal/capi/manifest/patches.go
@@ -158,11 +158,9 @@ var reSchedulerHints = regexp.MustCompile(`(?m)^  schedulerHints:`)
 var reSpecBlock = regexp.MustCompile(`(?m)^(spec:\n(?:  .*\n)+)`)
 
 func injectMemoryAdjustment(text, mem string) string {
-	// Doc-by-doc: find the ProxmoxCluster document (by top-level kind +
-	// apiVersion at line start) with a spec block that doesn't already
-	// contain `^  schedulerHints:`. Append the two lines to the spec.
-	// Using strings.Contains would false-positive on the CAPI Cluster
-	// document whose infrastructureRef contains "kind: ProxmoxCluster".
+	if mem == "" {
+		return text
+	}
 	parts := strings.Split(text, "\n---\n")
 	for i, doc := range parts {
 		if !reKindProxmoxCluster.MatchString(doc) {
@@ -173,6 +171,12 @@ func injectMemoryAdjustment(text, mem string) string {
 		}
 		if reSchedulerHints.MatchString(doc) {
 			break
+		}
+		// \n---\n splitting strips the trailing \n from the last line of each
+		// doc, so reSpecBlock's (?:  .*\n)+ misses it and leaves it dangling
+		// after schedulerHints at the wrong indentation. Add it back.
+		if !strings.HasSuffix(doc, "\n") {
+			doc += "\n"
 		}
 		loc := reSpecBlock.FindStringIndex(doc)
 		if loc == nil {

--- a/internal/capi/pivot/manifest.go
+++ b/internal/capi/pivot/manifest.go
@@ -587,6 +587,9 @@ var (
 )
 
 func injectMemoryAdjustment(text, mem string) string {
+	if mem == "" {
+		return text
+	}
 	parts := strings.Split(text, "\n---\n")
 	for i, doc := range parts {
 		if !reKindProxmoxCluster.MatchString(doc) {
@@ -597,6 +600,12 @@ func injectMemoryAdjustment(text, mem string) string {
 		}
 		if reSchedulerHints.MatchString(doc) {
 			break
+		}
+		// \n---\n splitting strips the trailing \n from the last line of each
+		// doc, so reSpecBlock's (?:  .*\n)+ misses it and leaves it dangling
+		// after schedulerHints at the wrong indentation. Add it back.
+		if !strings.HasSuffix(doc, "\n") {
+			doc += "\n"
 		}
 		loc := reSpecBlock.FindStringIndex(doc)
 		if loc == nil {

--- a/internal/cluster/capacity/capacity.go
+++ b/internal/cluster/capacity/capacity.go
@@ -301,15 +301,24 @@ func CheckCombined(plan Plan, host *HostCapacity, existing *ExistingUsage, thres
 		usedDisk, plan.StorageGB, totalDisk, host.StorageGB, diskFrac*100,
 	)
 
+	// Hard abort ceiling applies to memory only. CPU overcommit is normal
+	// in Proxmox — VMs share physical cores and rarely all run at 100%
+	// simultaneously. Memory is the dangerous dimension: overcommit beyond
+	// physical RAM causes OOMs under load.
+	memDiskMaxFrac := memFrac
+	if diskFrac > memDiskMaxFrac {
+		memDiskMaxFrac = diskFrac
+	}
+
 	switch {
 	case maxFrac <= threshold:
 		return VerdictFits, msg + fmt.Sprintf(" — within soft budget %.0f%%", threshold*100)
-	case maxFrac <= hardCeiling:
+	case memDiskMaxFrac <= hardCeiling:
 		return VerdictTight, msg + fmt.Sprintf(" — exceeds soft budget %.0f%% but within %.0f%% overcommit tolerance",
 			threshold*100, tolerancePct)
 	default:
-		return VerdictAbort, msg + fmt.Sprintf(" — exceeds %.0f%% overcommit ceiling (%.0f%% > %.0f%%)",
-			tolerancePct, maxFrac*100, hardCeiling*100)
+		return VerdictAbort, msg + fmt.Sprintf(" — memory/disk exceeds %.0f%% overcommit ceiling (%.0f%% > %.0f%%)",
+			tolerancePct, memDiskMaxFrac*100, hardCeiling*100)
 	}
 }
 

--- a/internal/cluster/kindsync/bootstrap_config.go
+++ b/internal/cluster/kindsync/bootstrap_config.go
@@ -30,12 +30,15 @@ package kindsync
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/platform/shell"
 	"github.com/lpasquali/yage/internal/provider"
 	"github.com/lpasquali/yage/internal/ui/logx"
 )
@@ -95,6 +98,13 @@ func WriteBootstrapConfigSecret(cfg *config.Config) error {
 	add("cost.display_currency", cfg.Cost.Currency.DisplayCurrency)
 	add("cost.data_center_location", cfg.Cost.Currency.DataCenterLocation)
 
+	// Full snapshot: network fields, PROXMOX_*, WORKLOAD_CLUSTER_NAME, etc.
+	// Read back by MergeBootstrapConfigFromKind via ApplySnapshotKV so that
+	// a second xapiri run restores everything (not just the prefix-keyed subset).
+	if yaml := cfg.SnapshotYAML(); yaml != "" {
+		data["config.yaml"] = []byte(yaml)
+	}
+
 	return applySecret(bg, cli, BootstrapConfigNamespace, BootstrapConfigSecretName, data, map[string]string{
 		"app.kubernetes.io/managed-by": "yage",
 		"app.kubernetes.io/component":  "bootstrap-config",
@@ -138,6 +148,9 @@ func MergeBootstrapConfigFromKind(cfg *config.Config) error {
 		}
 	}
 
+	// Collect provider-prefixed keys for batch absorption.
+	providerKV := map[string]string{}
+
 	for k, raw := range sec.Data {
 		v := string(raw)
 		switch {
@@ -165,15 +178,95 @@ func MergeBootstrapConfigFromKind(cfg *config.Config) error {
 		case k == "cost.data_center_location":
 			assign(&cfg.Cost.Currency.DataCenterLocation, v)
 		default:
-			// Provider-prefixed keys (proxmox.url, aws.region, …)
-			// are forwarded to the active provider's absorber as
-			// a unified map. Currently only Proxmox absorbs, and
-			// only the uppercase-key shape — lowercase bare keys
-			// are a no-op until per-provider absorbers ship.
-			//
-			// no-op intentional — keep loop going.
-			_ = k
+			// provider-prefixed keys (e.g. "proxmox.admin_token"):
+			// convert "provider.snake_key" → "PROVIDER_SNAKE_KEY" and
+			// batch for Provider.AbsorbConfigYAML absorption.
+			if dot := strings.Index(k, "."); dot > 0 {
+				prefix := strings.ToUpper(k[:dot])
+				suffix := strings.ToUpper(strings.ReplaceAll(k[dot+1:], ".", "_"))
+				providerKV[prefix+"_"+suffix] = v
+			}
 		}
 	}
+	if len(providerKV) > 0 {
+		if prov, err := provider.For(cfg); err == nil {
+			prov.AbsorbConfigYAML(cfg, providerKV)
+		}
+	}
+	// Full snapshot: restores network fields, PROXMOX_*, WORKLOAD_CLUSTER_NAME,
+	// etc. that the prefix-keyed loop above does not cover. ApplySnapshotKV
+	// honours *_EXPLICIT guards so CLI-supplied values always win.
+	if raw, ok := sec.Data["config.yaml"]; ok {
+		kv := parseFlatYAMLOrJSON(string(raw))
+		migrateLegacyKeys(kv)
+		cfg.ApplySnapshotKV(kv)
+	}
 	return nil
+}
+
+// MergeBootstrapConfigFromFirstKindCluster is the zero-argument variant of
+// MergeBootstrapConfigFromKind for when cfg.KindClusterName is empty. It
+// scans every running kind cluster for a yage-system/bootstrap-config Secret:
+//
+//   - 0 found → no-op (cfg.KindClusterName stays empty)
+//   - 1 found → merge silently
+//   - N found → print a numbered menu to stderr and ask which one to use;
+//     if stdin is not a TTY (CI, pipes) the first entry is used with a warning
+func MergeBootstrapConfigFromFirstKindCluster(cfg *config.Config) {
+	out, _, _ := shell.Capture("kind", "get", "clusters")
+	var candidates []string
+	for _, ln := range strings.Split(strings.ReplaceAll(out, "\r", ""), "\n") {
+		name := strings.TrimSpace(ln)
+		if name == "" {
+			continue
+		}
+		cfg.KindClusterName = name
+		if err := MergeBootstrapConfigFromKind(cfg); err == nil && cfg.InfraProvider != "" {
+			candidates = append(candidates, name)
+			// Reset so the next iteration starts clean.
+			cfg.KindClusterName = ""
+			cfg.InfraProvider = ""
+		} else {
+			cfg.KindClusterName = ""
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		// No kind cluster has yage data — leave cfg.KindClusterName empty.
+	case 1:
+		cfg.KindClusterName = candidates[0]
+		_ = MergeBootstrapConfigFromKind(cfg)
+	default:
+		chosen := pickKindCluster(candidates)
+		cfg.KindClusterName = chosen
+		_ = MergeBootstrapConfigFromKind(cfg)
+	}
+}
+
+// pickKindCluster prints a numbered menu to stderr and returns the chosen
+// cluster name. Falls back to the first entry when stdin is not a TTY.
+func pickKindCluster(names []string) string {
+	fmt.Fprintln(os.Stderr, "  Multiple kind clusters contain yage data. Which one do you want to use?")
+	for i, n := range names {
+		fmt.Fprintf(os.Stderr, "    %d) %s\n", i+1, n)
+	}
+	// Non-interactive fallback.
+	fi, err := os.Stdin.Stat()
+	if err != nil || fi.Mode()&os.ModeCharDevice == 0 {
+		fmt.Fprintf(os.Stderr, "  (non-interactive: using %s)\n", names[0])
+		return names[0]
+	}
+	for {
+		fmt.Fprintf(os.Stderr, "  choice [1-%d]: ", len(names))
+		var line string
+		fmt.Fscan(os.Stdin, &line)
+		line = strings.TrimSpace(line)
+		for i, n := range names {
+			if line == fmt.Sprintf("%d", i+1) || line == n {
+				return n
+			}
+		}
+		fmt.Fprintf(os.Stderr, "  invalid choice — enter a number between 1 and %d\n", len(names))
+	}
 }

--- a/internal/cluster/kindsync/config.go
+++ b/internal/cluster/kindsync/config.go
@@ -120,7 +120,7 @@ func MergeBootstrapSecretsFromKind(cfg *config.Config) {
 	}
 
 	// --- 4. capmox-system/capmox-manager-credentials fallback ---
-	if cfg.Providers.Proxmox.URL == "" || cfg.Providers.Proxmox.Token == "" || cfg.Providers.Proxmox.Secret == "" {
+	if cfg.Providers.Proxmox.URL == "" || cfg.Providers.Proxmox.CAPIToken == "" || cfg.Providers.Proxmox.CAPISecret == "" {
 		j := getSecretJSON(ctx, "capmox-system", "capmox-manager-credentials")
 		if j != "" && fillFromCapmoxManagerJSON(cfg, j) {
 			logx.Log("Filled unset CAPI Proxmox API values from capmox-system/capmox-manager-credentials on %s.", ctx)
@@ -202,10 +202,13 @@ func fillFromCredsJSON(cfg *config.Config, secJSON string, _ bool) bool {
 	}
 	aliases := map[string]string{
 		"url":               "PROXMOX_URL",
-		"token":             "PROXMOX_TOKEN",
-		"secret":            "PROXMOX_SECRET",
-		"capi_token_id":     "PROXMOX_TOKEN",
-		"capi_token_secret": "PROXMOX_SECRET",
+		"capi_token":        "PROXMOX_CAPI_TOKEN",
+		"capi_secret":       "PROXMOX_CAPI_SECRET",
+		// backward compat: Secrets written before the rename
+		"token":             "PROXMOX_CAPI_TOKEN",
+		"secret":            "PROXMOX_CAPI_SECRET",
+		"capi_token_id":     "PROXMOX_CAPI_TOKEN",
+		"capi_token_secret": "PROXMOX_CAPI_SECRET",
 		"csi_token_id":      "PROXMOX_CSI_TOKEN_ID",
 		"csi_token_secret":  "PROXMOX_CSI_TOKEN_SECRET",
 		"admin_username":    "PROXMOX_ADMIN_USERNAME",
@@ -292,9 +295,9 @@ func fillFromCapmoxManagerJSON(cfg *config.Config, secJSON string) bool {
 	data := decodeAllSecretData(secJSON)
 	out := map[string]string{}
 	for k, v := range map[string]string{
-		"PROXMOX_URL":    data["url"],
-		"PROXMOX_TOKEN":  data["token"],
-		"PROXMOX_SECRET": data["secret"],
+		"PROXMOX_URL":        data["url"],
+		"PROXMOX_CAPI_TOKEN": data["token"],
+		"PROXMOX_CAPI_SECRET": data["secret"],
 	} {
 		if v != "" {
 			out[k] = v
@@ -519,7 +522,14 @@ func parseFlatYAMLOrJSON(text string) map[string]string {
 		val := strings.TrimSpace(m[2])
 		if len(val) >= 2 {
 			first, last := val[0], val[len(val)-1]
-			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			if first == '"' && last == '"' {
+				var s string
+				if err := json.Unmarshal([]byte(val), &s); err == nil {
+					val = s
+				} else {
+					val = val[1 : len(val)-1]
+				}
+			} else if first == '\'' && last == '\'' {
 				val = val[1 : len(val)-1]
 			}
 		}

--- a/internal/cluster/kindsync/helpers.go
+++ b/internal/cluster/kindsync/helpers.go
@@ -45,8 +45,8 @@ func proxmoxEnvMap(cfg *config.Config) map[string]string {
 	}
 	m := map[string]string{}
 	put(m, "PROXMOX_URL", cfg.Providers.Proxmox.URL)
-	put(m, "PROXMOX_TOKEN", cfg.Providers.Proxmox.Token)
-	put(m, "PROXMOX_SECRET", cfg.Providers.Proxmox.Secret)
+	put(m, "PROXMOX_CAPI_TOKEN", cfg.Providers.Proxmox.CAPIToken)
+	put(m, "PROXMOX_CAPI_SECRET", cfg.Providers.Proxmox.CAPISecret)
 	put(m, "PROXMOX_REGION", cfg.Providers.Proxmox.Region)
 	put(m, "PROXMOX_NODE", cfg.Providers.Proxmox.Node)
 	put(m, "PROXMOX_ADMIN_USERNAME", cfg.Providers.Proxmox.AdminUsername)

--- a/internal/cluster/kindsync/kindsync.go
+++ b/internal/cluster/kindsync/kindsync.go
@@ -77,7 +77,7 @@ func SyncProxmoxBootstrapLiteralCredentialsToKind(cfg *config.Config) error {
 	// --- Single-Secret branch (PROXMOX_BOOTSTRAP_SECRET_NAME set) ---
 	if cfg.Providers.Proxmox.BootstrapSecretName != "" {
 		singleSecretKeys := []string{
-			"PROXMOX_URL", "PROXMOX_TOKEN", "PROXMOX_SECRET",
+			"PROXMOX_URL", "PROXMOX_CAPI_TOKEN", "PROXMOX_CAPI_SECRET",
 			"PROXMOX_CSI_URL", "PROXMOX_CSI_TOKEN_ID", "PROXMOX_CSI_TOKEN_SECRET",
 			"PROXMOX_REGION", "PROXMOX_NODE",
 		}
@@ -102,7 +102,7 @@ func SyncProxmoxBootstrapLiteralCredentialsToKind(cfg *config.Config) error {
 
 	// --- Default split: CAPMOX (clusterctl) Secret ---
 	capmoxKeys := []string{
-		"PROXMOX_URL", "PROXMOX_TOKEN", "PROXMOX_SECRET",
+		"PROXMOX_URL", "PROXMOX_CAPI_TOKEN", "PROXMOX_CAPI_SECRET",
 		"PROXMOX_REGION", "PROXMOX_NODE",
 	}
 	_ = (kindSecret{
@@ -237,7 +237,7 @@ func applyAdminYAMLToKind(cfg *config.Config, kctx, targetSecret string) error {
 // in-cluster capmox credential is restored on the next sync without
 // waiting for the full Argo / CAAPH loop.
 func UpdateCapmoxManagerSecretOnKind(cfg *config.Config) error {
-	if cfg.Providers.Proxmox.URL == "" || cfg.Providers.Proxmox.Token == "" || cfg.Providers.Proxmox.Secret == "" {
+	if cfg.Providers.Proxmox.URL == "" || cfg.Providers.Proxmox.CAPIToken == "" || cfg.Providers.Proxmox.CAPISecret == "" {
 		return nil
 	}
 	kctx := "kind-" + cfg.KindClusterName
@@ -253,8 +253,8 @@ func UpdateCapmoxManagerSecretOnKind(cfg *config.Config) error {
 	}
 	data := map[string][]byte{
 		"url":    []byte(cfg.Providers.Proxmox.URL),
-		"token":  []byte(cfg.Providers.Proxmox.Token),
-		"secret": []byte(cfg.Providers.Proxmox.Secret),
+		"token":  []byte(cfg.Providers.Proxmox.CAPIToken),
+		"secret": []byte(cfg.Providers.Proxmox.CAPISecret),
 	}
 	if err := applySecret(bg, cli, "capmox-system", "capmox-manager-credentials", data, nil); err != nil {
 		logx.Die("Failed to update capmox-system/capmox-manager-credentials on %s: %v", kctx, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,13 @@ type WorkloadShape struct {
 	//   - "prod"    → Argo CD HA + full monitoring + backups
 	// Empty string treated as "dev" (default).
 	Environment string
+	// HasQueue / HasObjStore / HasCache record whether the operator
+	// opted into each add-on in the xapiri walkthrough. Used to
+	// pre-populate the add-on prompts on subsequent runs (so the
+	// [y/N] default reflects the saved choice).
+	HasQueue    bool
+	HasObjStore bool
+	HasCache    bool
 }
 
 // AppGroup is one entry in WorkloadShape.Apps. The combination
@@ -90,9 +97,12 @@ type AppGroup struct {
 // VM sizing, template IDs, pool, CSI) live in ProxmoxMgmtConfig under
 // cfg.Providers.Proxmox.Mgmt.
 type MgmtConfig struct {
-	ClusterName              string
-	ClusterNamespace         string
-	KubernetesVersion        string
+	ClusterName                string
+	ClusterNameExplicit        bool
+	ClusterNamespace           string
+	ClusterNamespaceExplicit   bool
+	KubernetesVersion          string
+	KubernetesVersionExplicit  bool
 	CiliumClusterID          string
 	ControlPlaneMachineCount string // "1" by default (single-node mgmt)
 	WorkerMachineCount       string // "0" by default (CP-only)
@@ -124,7 +134,8 @@ type ProxmoxMgmtConfig struct {
 	WorkerTemplateID             string
 	// Pool is the Proxmox VE pool name the management cluster's VMs are
 	// tagged with. See ProxmoxConfig.Pool for the workload counterpart.
-	Pool string
+	Pool       string
+	PoolExplicit bool
 	// CSIEnabled — when true, install Proxmox CSI on the management
 	// cluster too. Default false: management is stateless (CAPI
 	// controllers + bootstrap state Secrets only — no PVCs).
@@ -415,10 +426,10 @@ type ProxmoxConfig struct {
 	RecreateIdentities      bool
 
 	// ---- Core API / target ----
-	URL            string
-	Token          string
-	Secret         string
-	Region         string
+	URL        string
+	CAPIToken  string
+	CAPISecret string
+	Region     string
 	Node           string
 	SourceNode     string
 	TopologyRegion string
@@ -432,7 +443,8 @@ type ProxmoxConfig struct {
 	// "no pool"; when set, yage pre-creates the pool via the admin API
 	// before applying the CAPI manifest, so CAPMOX won't fail on a missing
 	// pool reference.
-	Pool string
+	Pool         string
+	PoolExplicit bool
 
 	// ---- CSI ----
 	CSIEnabled          bool
@@ -663,6 +675,10 @@ type Config struct {
 	// (--xapiri) and exits. Mutually exclusive with the orchestrator
 	// run; setting it short-circuits main() before orchestrator.Run.
 	Xapiri                      bool
+	// XapiriDeployNow is set by the xapiri walkthrough when the user
+	// answers "deploy now? y" at step 8. main() reads it to decide
+	// whether to fall through to orchestrator.Run after the walkthrough.
+	XapiriDeployNow             bool
 	// PrintCommand, when non-empty, makes the program render the
 	// equivalent `yage <flags>` invocation that reproduces the
 	// resolved cfg, then exits. Useful for pipelines (capture the
@@ -1033,8 +1049,9 @@ type Config struct {
 	WorkloadClusterNamespace        string
 	WorkloadClusterNameExplicit     bool
 	WorkloadClusterNamespaceExplicit bool
-	WorkloadKubernetesVersion       string
-	ControlPlaneMachineCount        string
+	WorkloadKubernetesVersion         string
+	WorkloadKubernetesVersionExplicit bool
+	ControlPlaneMachineCount          string
 	WorkerMachineCount              string
 
 }
@@ -1469,8 +1486,8 @@ func Load() *Config {
 
 	// --- Proxmox core ---
 	c.Providers.Proxmox.URL = getenv("PROXMOX_URL", "")
-	c.Providers.Proxmox.Token = getenv("PROXMOX_TOKEN", "")
-	c.Providers.Proxmox.Secret = getenv("PROXMOX_SECRET", "")
+	c.Providers.Proxmox.CAPIToken = getenv("PROXMOX_CAPI_TOKEN", getenv("PROXMOX_TOKEN", ""))
+	c.Providers.Proxmox.CAPISecret = getenv("PROXMOX_CAPI_SECRET", getenv("PROXMOX_SECRET", ""))
 	c.Providers.Proxmox.AdminUsername = getenv("PROXMOX_ADMIN_USERNAME", "root@pam!capi-bootstrap")
 	c.Providers.Proxmox.AdminToken = getenv("PROXMOX_ADMIN_TOKEN", "")
 	c.Providers.Proxmox.Region = getenv("PROXMOX_REGION", "")
@@ -1542,9 +1559,10 @@ func Load() *Config {
 	c.WorkloadClusterName = getenv("WORKLOAD_CLUSTER_NAME", "capi-quickstart")
 	c.WorkloadCiliumClusterID = getenv("WORKLOAD_CILIUM_CLUSTER_ID", "")
 	c.WorkloadClusterNamespace = getenv("WORKLOAD_CLUSTER_NAMESPACE", "default")
-	c.WorkloadClusterNameExplicit = envBoolLoose("WORKLOAD_CLUSTER_NAME_EXPLICIT", false)
-	c.WorkloadClusterNamespaceExplicit = envBoolLoose("WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT", false)
+	c.WorkloadClusterNameExplicit = envBoolLoose("WORKLOAD_CLUSTER_NAME_EXPLICIT", false) || os.Getenv("WORKLOAD_CLUSTER_NAME") != ""
+	c.WorkloadClusterNamespaceExplicit = envBoolLoose("WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT", false) || os.Getenv("WORKLOAD_CLUSTER_NAMESPACE") != ""
 	c.WorkloadKubernetesVersion = getenv("WORKLOAD_KUBERNETES_VERSION", "v1.35.0")
+	c.WorkloadKubernetesVersionExplicit = os.Getenv("WORKLOAD_KUBERNETES_VERSION") != ""
 	c.ControlPlaneMachineCount = getenv("CONTROL_PLANE_MACHINE_COUNT", "1")
 	c.WorkerMachineCount = getenv("WORKER_MACHINE_COUNT", "2")
 
@@ -1576,8 +1594,11 @@ func Load() *Config {
 
 	// --- Management cluster shape (universal) ---
 	c.Mgmt.ClusterName = getenv("MGMT_CLUSTER_NAME", "capi-management")
+	c.Mgmt.ClusterNameExplicit = envBoolLoose("MGMT_CLUSTER_NAME_EXPLICIT", false) || os.Getenv("MGMT_CLUSTER_NAME") != ""
 	c.Mgmt.ClusterNamespace = getenv("MGMT_CLUSTER_NAMESPACE", "default")
+	c.Mgmt.ClusterNamespaceExplicit = envBoolLoose("MGMT_CLUSTER_NAMESPACE_EXPLICIT", false) || os.Getenv("MGMT_CLUSTER_NAMESPACE") != ""
 	c.Mgmt.KubernetesVersion = getenv("MGMT_KUBERNETES_VERSION", c.WorkloadKubernetesVersion)
+	c.Mgmt.KubernetesVersionExplicit = os.Getenv("MGMT_KUBERNETES_VERSION") != ""
 	c.Mgmt.CiliumClusterID = getenv("MGMT_CILIUM_CLUSTER_ID", "")
 	c.Mgmt.ControlPlaneMachineCount = getenv("MGMT_CONTROL_PLANE_MACHINE_COUNT", "1")
 	c.Mgmt.WorkerMachineCount = getenv("MGMT_WORKER_MACHINE_COUNT", "0")
@@ -1604,7 +1625,9 @@ func Load() *Config {
 	// Pool defaults to the matching cluster name so each cluster
 	// gets its own organizational bucket. User can override or set empty.
 	c.Providers.Proxmox.Pool = getenv("PROXMOX_POOL", c.WorkloadClusterName)
+	c.Providers.Proxmox.PoolExplicit = envBoolLoose("PROXMOX_POOL_EXPLICIT", false) || os.Getenv("PROXMOX_POOL") != ""
 	c.Providers.Proxmox.Mgmt.Pool = getenv("MGMT_PROXMOX_POOL", c.Mgmt.ClusterName)
+	c.Providers.Proxmox.Mgmt.PoolExplicit = envBoolLoose("MGMT_PROXMOX_POOL_EXPLICIT", false) || os.Getenv("MGMT_PROXMOX_POOL") != ""
 
 	return c
 }

--- a/internal/config/envback_test.go
+++ b/internal/config/envback_test.go
@@ -49,10 +49,10 @@ func TestEnvVarBackcompat(t *testing.T) {
 	if got, want := c.Providers.Proxmox.URL, "https://pve.example:8006/api2/json"; got != want {
 		t.Errorf("Providers.Proxmox.URL = %q, want %q", got, want)
 	}
-	if got, want := c.Providers.Proxmox.Token, "tok-123"; got != want {
+	if got, want := c.Providers.Proxmox.CAPIToken, "tok-123"; got != want {
 		t.Errorf("Providers.Proxmox.Token = %q, want %q", got, want)
 	}
-	if got, want := c.Providers.Proxmox.Secret, "sec-456"; got != want {
+	if got, want := c.Providers.Proxmox.CAPISecret, "sec-456"; got != want {
 		t.Errorf("Providers.Proxmox.Secret = %q, want %q", got, want)
 	}
 	if got, want := c.Providers.Proxmox.Node, "pve-1"; got != want {

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -128,8 +128,8 @@ func (c *Config) Snapshot() []SnapshotField {
 		sp("PROXMOX_CLOUDINIT_STORAGE", &c.Providers.Proxmox.CloudinitStorage),
 		sp("PROXMOX_TEMPLATE_ID", &c.Providers.Proxmox.TemplateID),
 		sp("PROXMOX_BRIDGE", &c.Providers.Proxmox.Bridge),
-		sp("PROXMOX_POOL", &c.Providers.Proxmox.Pool),
-		sp("MGMT_PROXMOX_POOL", &c.Providers.Proxmox.Mgmt.Pool),
+		spEx("PROXMOX_POOL", "PROXMOX_POOL_EXPLICIT", &c.Providers.Proxmox.Pool),
+		spEx("MGMT_PROXMOX_POOL", "MGMT_PROXMOX_POOL_EXPLICIT", &c.Providers.Proxmox.Mgmt.Pool),
 		// --- Network (EXPLICIT-guarded) ---
 		sp("CONTROL_PLANE_ENDPOINT_IP", &c.ControlPlaneEndpointIP),
 		sp("CONTROL_PLANE_ENDPOINT_PORT", &c.ControlPlaneEndpointPort),
@@ -164,12 +164,24 @@ func (c *Config) Snapshot() []SnapshotField {
 		spEx("WORKLOAD_CLUSTER_NAME", "WORKLOAD_CLUSTER_NAME_EXPLICIT", &c.WorkloadClusterName),
 		spEx("WORKLOAD_CLUSTER_NAMESPACE", "WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT", &c.WorkloadClusterNamespace),
 		sp("WORKLOAD_CILIUM_CLUSTER_ID", &c.WorkloadCiliumClusterID),
-		sp("WORKLOAD_KUBERNETES_VERSION", &c.WorkloadKubernetesVersion),
+		// Use explicit guard + always-overwrite so snapshot restores the
+		// user's chosen version over the hardcoded v1.35.0 default.
+		{
+			EnvName:      "WORKLOAD_KUBERNETES_VERSION",
+			ExplicitName: "WORKLOAD_KUBERNETES_VERSION_EXPLICIT",
+			Get:          func() string { return c.WorkloadKubernetesVersion },
+			Set:          func(v string) { c.WorkloadKubernetesVersion = v },
+		},
 		// --- Pivot (management cluster on Proxmox) ---
 		bp("PIVOT_ENABLED", &c.Pivot.Enabled),
-		sp("MGMT_CLUSTER_NAME", &c.Mgmt.ClusterName),
-		sp("MGMT_CLUSTER_NAMESPACE", &c.Mgmt.ClusterNamespace),
-		sp("MGMT_KUBERNETES_VERSION", &c.Mgmt.KubernetesVersion),
+		spEx("MGMT_CLUSTER_NAME", "MGMT_CLUSTER_NAME_EXPLICIT", &c.Mgmt.ClusterName),
+		spEx("MGMT_CLUSTER_NAMESPACE", "MGMT_CLUSTER_NAMESPACE_EXPLICIT", &c.Mgmt.ClusterNamespace),
+		{
+			EnvName:      "MGMT_KUBERNETES_VERSION",
+			ExplicitName: "MGMT_KUBERNETES_VERSION_EXPLICIT",
+			Get:          func() string { return c.Mgmt.KubernetesVersion },
+			Set:          func(v string) { c.Mgmt.KubernetesVersion = v },
+		},
 		sp("MGMT_CILIUM_CLUSTER_ID", &c.Mgmt.CiliumClusterID),
 		sp("MGMT_CONTROL_PLANE_MACHINE_COUNT", &c.Mgmt.ControlPlaneMachineCount),
 		sp("MGMT_WORKER_MACHINE_COUNT", &c.Mgmt.WorkerMachineCount),
@@ -229,6 +241,92 @@ func (c *Config) Snapshot() []SnapshotField {
 		// --- Identity ---
 		sp("CLUSTER_SET_ID", &c.ClusterSetID),
 		sp("PROXMOX_IDENTITY_SUFFIX", &c.Providers.Proxmox.IdentitySuffix),
+		// --- xapiri walkthrough shape (restored on second run) ---
+		sp("XAPIRI_WORKLOAD_ENVIRONMENT", &c.Workload.Environment),
+		sp("XAPIRI_WORKLOAD_RESILIENCE", &c.Workload.Resilience),
+		{
+			EnvName: "XAPIRI_WORKLOAD_DB_GB",
+			Get: func() string {
+				if c.Workload.DatabaseGB <= 0 {
+					return ""
+				}
+				return strconv.Itoa(c.Workload.DatabaseGB)
+			},
+			Set: func(v string) {
+				if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+					c.Workload.DatabaseGB = n
+				}
+			},
+		},
+		{
+			EnvName: "XAPIRI_WORKLOAD_EGRESS_GB_MONTH",
+			Get: func() string {
+				if c.Workload.EgressGBMonth <= 0 {
+					return ""
+				}
+				return strconv.Itoa(c.Workload.EgressGBMonth)
+			},
+			Set: func(v string) {
+				if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+					c.Workload.EgressGBMonth = n
+				}
+			},
+		},
+		{
+			EnvName: "XAPIRI_WORKLOAD_APPS",
+			Get: func() string {
+				if len(c.Workload.Apps) == 0 {
+					return ""
+				}
+				parts := make([]string, 0, len(c.Workload.Apps))
+				for _, a := range c.Workload.Apps {
+					if a.Count > 0 && a.Template != "" {
+						parts = append(parts, strconv.Itoa(a.Count)+" "+a.Template)
+					}
+				}
+				return strings.Join(parts, " ")
+			},
+			Set: func(v string) {
+				if v == "" {
+					return
+				}
+				r := strings.NewReplacer(",", " ", "x", " ", "×", " ")
+				tokens := strings.Fields(r.Replace(v))
+				var apps []AppGroup
+				for i := 0; i+1 < len(tokens); i += 2 {
+					n, err := strconv.Atoi(tokens[i])
+					if err != nil || n <= 0 {
+						continue
+					}
+					tpl := strings.ToLower(tokens[i+1])
+					if tpl != "light" && tpl != "medium" && tpl != "heavy" {
+						continue
+					}
+					apps = append(apps, AppGroup{Count: n, Template: tpl})
+				}
+				// Fallback: old Secrets store JSON [{"Count":N,"Template":"..."}]
+				if len(apps) == 0 && strings.HasPrefix(strings.TrimSpace(v), "[") {
+					var legacy []struct {
+						Count    int    `json:"Count"`
+						Template string `json:"Template"`
+					}
+					if err := json.Unmarshal([]byte(v), &legacy); err == nil {
+						for _, a := range legacy {
+							tpl := strings.ToLower(a.Template)
+							if a.Count > 0 && (tpl == "light" || tpl == "medium" || tpl == "heavy") {
+								apps = append(apps, AppGroup{Count: a.Count, Template: tpl})
+							}
+						}
+					}
+				}
+				if len(apps) > 0 {
+					c.Workload.Apps = apps
+				}
+			},
+		},
+		bp("XAPIRI_WORKLOAD_HAS_QUEUE", &c.Workload.HasQueue),
+		bp("XAPIRI_WORKLOAD_HAS_OBJ_STORE", &c.Workload.HasObjStore),
+		bp("XAPIRI_WORKLOAD_HAS_CACHE", &c.Workload.HasCache),
 	}
 }
 
@@ -293,7 +391,13 @@ func (c *Config) explicitSet() map[string]bool {
 		"IP_PREFIX_EXPLICIT":                  c.IPPrefixExplicit,
 		"DNS_SERVERS_EXPLICIT":                c.DNSServersExplicit,
 		"ALLOWED_NODES_EXPLICIT":              c.AllowedNodesExplicit,
-		"WORKLOAD_CLUSTER_NAME_EXPLICIT":      c.WorkloadClusterNameExplicit,
-		"WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT": c.WorkloadClusterNamespaceExplicit,
+		"WORKLOAD_CLUSTER_NAME_EXPLICIT":       c.WorkloadClusterNameExplicit,
+		"WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT":  c.WorkloadClusterNamespaceExplicit,
+		"WORKLOAD_KUBERNETES_VERSION_EXPLICIT": c.WorkloadKubernetesVersionExplicit,
+		"MGMT_CLUSTER_NAME_EXPLICIT":          c.Mgmt.ClusterNameExplicit,
+		"MGMT_CLUSTER_NAMESPACE_EXPLICIT":     c.Mgmt.ClusterNamespaceExplicit,
+		"MGMT_KUBERNETES_VERSION_EXPLICIT":    c.Mgmt.KubernetesVersionExplicit,
+		"PROXMOX_POOL_EXPLICIT":               c.Providers.Proxmox.PoolExplicit,
+		"MGMT_PROXMOX_POOL_EXPLICIT":          c.Providers.Proxmox.Mgmt.PoolExplicit,
 	}
 }

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -38,7 +38,7 @@ func (c *Config) ProxmoxAdminCfgFilePresent() bool {
 // trio that the CAPI/CAPMOX provider needs before it will initialize is
 // present.
 func (c *Config) HaveClusterctlCredsInEnv() bool {
-	return c.Providers.Proxmox.URL != "" && c.Providers.Proxmox.Token != "" && c.Providers.Proxmox.Secret != ""
+	return c.Providers.Proxmox.URL != "" && c.Providers.Proxmox.CAPIToken != "" && c.Providers.Proxmox.CAPISecret != ""
 }
 
 // HaveAWSCloudCreds reports whether static IAM user keys are present in

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -80,9 +80,19 @@ func (c *Config) yamlExtras() map[string]func(string) {
 		// Operational
 		"INFRA_PROVIDER":  func(v string) { c.InfraProvider = v },
 		"BOOTSTRAP_MODE":  func(v string) { c.BootstrapMode = v },
-		// Proxmox credentials
-		"PROXMOX_TOKEN":            func(v string) { c.Providers.Proxmox.Token = v },
-		"PROXMOX_SECRET":           func(v string) { c.Providers.Proxmox.Secret = v },
+		// Proxmox CAPI credentials (new names); old names aliased for compat
+		"PROXMOX_CAPI_TOKEN":       func(v string) { c.Providers.Proxmox.CAPIToken = v },
+		"PROXMOX_CAPI_SECRET":      func(v string) { c.Providers.Proxmox.CAPISecret = v },
+		"PROXMOX_TOKEN":            func(v string) {
+			if c.Providers.Proxmox.CAPIToken == "" {
+				c.Providers.Proxmox.CAPIToken = v
+			}
+		},
+		"PROXMOX_SECRET":           func(v string) {
+			if c.Providers.Proxmox.CAPISecret == "" {
+				c.Providers.Proxmox.CAPISecret = v
+			}
+		},
 		"PROXMOX_ADMIN_TOKEN":      func(v string) { c.Providers.Proxmox.AdminToken = v },
 		"PROXMOX_ADMIN_USERNAME":   func(v string) { c.Providers.Proxmox.AdminUsername = v },
 		"PROXMOX_CSI_TOKEN_ID":     func(v string) { c.Providers.Proxmox.CSITokenID = v },

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -30,8 +30,8 @@ ARGOCD_ENABLED: "false"
 	if cfg.Providers.Proxmox.URL != "https://pve.example.com:8006" {
 		t.Errorf("URL = %q, want pve.example.com", cfg.Providers.Proxmox.URL)
 	}
-	if cfg.Providers.Proxmox.Token != "root@pam!yage=secret123" {
-		t.Errorf("Token = %q", cfg.Providers.Proxmox.Token)
+	if cfg.Providers.Proxmox.CAPIToken != "root@pam!yage=secret123" {
+		t.Errorf("Token = %q", cfg.Providers.Proxmox.CAPIToken)
 	}
 	if cfg.InfraProvider != "proxmox" {
 		t.Errorf("InfraProvider = %q", cfg.InfraProvider)

--- a/internal/feasibility/onprem.go
+++ b/internal/feasibility/onprem.go
@@ -161,8 +161,5 @@ func collectOnPremBlockingReasons(sh shape, cfg *config.Config) []string {
 				fmt.Sprintf("HA resilience requires ≥3 control-plane nodes; cfg.ControlPlaneMachineCount=%d", got))
 		}
 	}
-	if cfg.HardwareCostUSD == 0 && cfg.HardwareWatts == 0 && cfg.HardwareSupportUSDMonth == 0 {
-		out = append(out, "TCO not configured: set --hardware-cost-usd / --hardware-watts / --hardware-support-usd-month for an amortized monthly figure")
-	}
 	return out
 }

--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -479,14 +479,14 @@ func Run(cfg *config.Config) int {
 				fmt.Fprint(os.Stderr, "\033[1;36m[?]\033[0m Proxmox VE URL (e.g. https://pve.example:8006): ")
 				cfg.Providers.Proxmox.URL = promptx.ReadLine()
 				fmt.Fprint(os.Stderr, "\033[1;36m[?]\033[0m Proxmox API TokenID (e.g. capmox@pve!capi): ")
-				cfg.Providers.Proxmox.Token = promptx.ReadLine()
+				cfg.Providers.Proxmox.CAPIToken = promptx.ReadLine()
 				fmt.Fprint(os.Stderr, "\033[1;36m[?]\033[0m Proxmox API Token secret (UUID): ")
-				cfg.Providers.Proxmox.Secret = promptx.ReadLine()
+				cfg.Providers.Proxmox.CAPISecret = promptx.ReadLine()
 				_ = kindsync.SyncBootstrapConfigToKind(cfg)
 				_ = kindsync.SyncProxmoxBootstrapLiteralCredentialsToKind(cfg)
 				logx.Log("Proxmox API identity updated in kind when the management cluster is reachable. clusterctl on disk is not used by default (temp file for CLI only).")
 			} else {
-				logx.Warn("Skipping interactive creation. Set PROXMOX_URL, PROXMOX_TOKEN, and PROXMOX_SECRET, or add them to %s on kind, or set CLUSTERCTL_CFG to a local YAML you maintain.",
+				logx.Warn("Skipping interactive creation. Set PROXMOX_URL, PROXMOX_CAPI_TOKEN, and PROXMOX_CAPI_SECRET, or add them to %s on kind, or set CLUSTERCTL_CFG to a local YAML you maintain.",
 					cfg.Providers.Proxmox.BootstrapSecretNamespace)
 				logx.Warn("Expected format:")
 				fmt.Fprintln(os.Stderr)
@@ -510,15 +510,15 @@ func Run(cfg *config.Config) int {
 			if cfg.Providers.Proxmox.URL == "" {
 				cfg.Providers.Proxmox.URL = yamlx.GetValue(cfg.ClusterctlCfg, "PROXMOX_URL")
 			}
-			if cfg.Providers.Proxmox.Token == "" {
-				cfg.Providers.Proxmox.Token = yamlx.GetValue(cfg.ClusterctlCfg, "PROXMOX_TOKEN")
+			if cfg.Providers.Proxmox.CAPIToken == "" {
+				cfg.Providers.Proxmox.CAPIToken = yamlx.GetValue(cfg.ClusterctlCfg, "PROXMOX_TOKEN")
 			}
-			if cfg.Providers.Proxmox.Secret == "" {
-				cfg.Providers.Proxmox.Secret = yamlx.GetValue(cfg.ClusterctlCfg, "PROXMOX_SECRET")
+			if cfg.Providers.Proxmox.CAPISecret == "" {
+				cfg.Providers.Proxmox.CAPISecret = yamlx.GetValue(cfg.ClusterctlCfg, "PROXMOX_SECRET")
 			}
 		}
-		cfg.Providers.Proxmox.Secret = pveapi.NormalizeTokenSecret(cfg.Providers.Proxmox.Secret, cfg.Providers.Proxmox.Token)
-		pveapi.ValidateTokenSecret("PROXMOX_SECRET", cfg.Providers.Proxmox.Secret)
+		cfg.Providers.Proxmox.CAPISecret = pveapi.NormalizeTokenSecret(cfg.Providers.Proxmox.CAPISecret, cfg.Providers.Proxmox.CAPIToken)
+		pveapi.ValidateTokenSecret("PROXMOX_CAPI_SECRET", cfg.Providers.Proxmox.CAPISecret)
 		pveapi.RefreshDerivedIdentityTokenIDs(cfg)
 		if cfg.Providers.Proxmox.TemplateID == "" {
 			cfg.Providers.Proxmox.TemplateID = "104"
@@ -531,11 +531,11 @@ func Run(cfg *config.Config) int {
 		if cfg.Providers.Proxmox.URL == "" {
 			missingCreds = append(missingCreds, "PROXMOX_URL")
 		}
-		if cfg.Providers.Proxmox.Token == "" {
-			missingCreds = append(missingCreds, "PROXMOX_TOKEN")
+		if cfg.Providers.Proxmox.CAPIToken == "" {
+			missingCreds = append(missingCreds, "PROXMOX_CAPI_TOKEN")
 		}
-		if cfg.Providers.Proxmox.Secret == "" {
-			missingCreds = append(missingCreds, "PROXMOX_SECRET")
+		if cfg.Providers.Proxmox.CAPISecret == "" {
+			missingCreds = append(missingCreds, "PROXMOX_CAPI_SECRET")
 		}
 		if len(missingCreds) > 0 {
 			logx.Warn("Missing Proxmox configuration: %v", missingCreds)
@@ -545,7 +545,7 @@ func Run(cfg *config.Config) int {
 		// Test Proxmox API connectivity with the clusterctl token.
 		logx.Log("Testing Proxmox API connectivity at %s (clusterctl token)...", pveapi.HostBaseURL(cfg))
 		if err := pveapi.ResolveRegionAndNodeFromClusterctlAPI(cfg); err != nil {
-			logx.Die("Proxmox API connectivity check failed: %v. Verify PROXMOX_URL, PROXMOX_TOKEN, and PROXMOX_SECRET.", err)
+			logx.Die("Proxmox API connectivity check failed: %v. Verify PROXMOX_URL, PROXMOX_CAPI_TOKEN, and PROXMOX_CAPI_SECRET.", err)
 		}
 		logx.Log("Proxmox API reachable.")
 
@@ -553,6 +553,12 @@ func Run(cfg *config.Config) int {
 	} else {
 		ensureNonProxmoxClusterctlCredentials(cfg)
 		clusterctlCfgPath = SyncClusterctlConfigFile(cfg)
+	}
+	// Publish the resolved path so pivot.EnsureManagementCluster (and
+	// any other later callers) can read it from cfg rather than having
+	// it only in the local variable.
+	if clusterctlCfgPath != "" {
+		cfg.ClusterctlCfg = clusterctlCfgPath
 	}
 
 	// --- Check for existing kind clusters ---

--- a/internal/orchestrator/capimanifest.go
+++ b/internal/orchestrator/capimanifest.go
@@ -310,11 +310,11 @@ func SyncClusterctlConfigFile(cfg *config.Config) string {
 	if cfg.Providers.Proxmox.URL == "" {
 		missing = append(missing, "PROXMOX_URL")
 	}
-	if cfg.Providers.Proxmox.Token == "" {
-		missing = append(missing, "PROXMOX_TOKEN")
+	if cfg.Providers.Proxmox.CAPIToken == "" {
+		missing = append(missing, "PROXMOX_CAPI_TOKEN")
 	}
-	if cfg.Providers.Proxmox.Secret == "" {
-		missing = append(missing, "PROXMOX_SECRET")
+	if cfg.Providers.Proxmox.CAPISecret == "" {
+		missing = append(missing, "PROXMOX_CAPI_SECRET")
 	}
 	if len(missing) > 0 {
 		logx.Die("SyncClusterctlConfigFile: Proxmox credentials are not set. Missing: %s", strings.Join(missing, " "))
@@ -326,7 +326,7 @@ func SyncClusterctlConfigFile(cfg *config.Config) string {
 	}
 	defer f.Close()
 	body := fmt.Sprintf("PROXMOX_URL: %q\nPROXMOX_TOKEN: %q\nPROXMOX_SECRET: %q\n",
-		cfg.Providers.Proxmox.URL, cfg.Providers.Proxmox.Token, cfg.Providers.Proxmox.Secret)
+		cfg.Providers.Proxmox.URL, cfg.Providers.Proxmox.CAPIToken, cfg.Providers.Proxmox.CAPISecret)
 	if _, err := f.WriteString(body); err != nil {
 		logx.Die("Cannot write ephemeral clusterctl config: %v", err)
 	}

--- a/internal/platform/opentofux/outputs.go
+++ b/internal/platform/opentofux/outputs.go
@@ -30,8 +30,8 @@ func GenerateConfigsFromOutputs(cfg *config.Config) {
 	pveapi.ValidateTokenSecret("OpenTofu capi_token_secret", capiTokenSec)
 	pveapi.ValidateTokenSecret("OpenTofu csi_token_secret", csiTokenSec)
 
-	cfg.Providers.Proxmox.Token = capiTokenID
-	cfg.Providers.Proxmox.Secret = capiTokenSec
+	cfg.Providers.Proxmox.CAPIToken = capiTokenID
+	cfg.Providers.Proxmox.CAPISecret = capiTokenSec
 	cfg.Providers.Proxmox.CSITokenID = csiTokenID
 	cfg.Providers.Proxmox.CSITokenSecret = csiTokenSec
 	if cfg.Providers.Proxmox.CSIURL == "" {
@@ -57,7 +57,7 @@ func WriteClusterctlConfigIfMissing(cfg *config.Config) {
 	if cfg.ClusterctlCfgFilePresent() {
 		return
 	}
-	if cfg.Providers.Proxmox.URL == "" || cfg.Providers.Proxmox.Token == "" || cfg.Providers.Proxmox.Secret == "" {
+	if cfg.Providers.Proxmox.URL == "" || cfg.Providers.Proxmox.CAPIToken == "" || cfg.Providers.Proxmox.CAPISecret == "" {
 		return
 	}
 	_ = kindsync.SyncBootstrapConfigToKind(cfg)

--- a/internal/provider/inventory.go
+++ b/internal/provider/inventory.go
@@ -41,6 +41,13 @@ type Inventory struct {
 // per-class breakdown (StorageByClass) — empty/nil when the
 // provider has a single backend.
 //
+// On-prem counting convention (Proxmox, vSphere, OpenStack, …):
+//
+//	Cores / MemoryMiB — running VMs only; powered-off VMs release
+//	                    these resources back to the host.
+//	StorageGiB        — all VMs regardless of power state; disk images
+//	                    remain provisioned on storage while the VM exists.
+//
 // StorageByClass keys come from the cloud's storage-class taxonomy:
 //
 //	AWS:        gp3 / io2 / standard / sc1

--- a/internal/provider/proxmox/absorb_test.go
+++ b/internal/provider/proxmox/absorb_test.go
@@ -41,7 +41,7 @@ func TestAbsorbConfigYAML(t *testing.T) {
 	tcs := []struct {
 		name, got, want string
 	}{
-		{"Token", cfg.Providers.Proxmox.Token, "from-secret"},
+		{"Token", cfg.Providers.Proxmox.CAPIToken, "from-secret"},
 		{"Region", cfg.Providers.Proxmox.Region, "from-secret-region"},
 		{"CSIStorage", cfg.Providers.Proxmox.CSIStorage, "from-secret-storage"},
 		{"CAPIUserID", cfg.Providers.Proxmox.CAPIUserID, "capi-from-secret"},

--- a/internal/provider/proxmox/inventory.go
+++ b/internal/provider/proxmox/inventory.go
@@ -261,10 +261,15 @@ func fetchExistingUsage(cfg *config.Config) (*existingUsage, error) {
 				continue
 			}
 		}
+		// Disk is provisioned regardless of power state; CPU and RAM are
+		// only consumed by running VMs.
+		out.StorageGB += v.MaxDisk / (1024 * 1024 * 1024)
+		if v.Status != "running" {
+			continue
+		}
 		out.VMCount++
 		out.CPUCores += v.MaxCPU
 		out.MemoryMiB += v.MaxMem / (1024 * 1024)
-		out.StorageGB += v.MaxDisk / (1024 * 1024 * 1024)
 		if v.Pool != "" {
 			out.ByPool[v.Pool]++
 		} else {
@@ -280,8 +285,8 @@ func authForCfg(cfg *config.Config) (auth string, insecure bool, base string, er
 	switch {
 	case cfg.Providers.Proxmox.AdminToken != "" && cfg.Providers.Proxmox.AdminUsername != "":
 		auth = "PVEAPIToken=" + cfg.Providers.Proxmox.AdminUsername + "=" + cfg.Providers.Proxmox.AdminToken
-	case cfg.Providers.Proxmox.Token != "" && cfg.Providers.Proxmox.Secret != "":
-		auth = "PVEAPIToken=" + cfg.Providers.Proxmox.Token + "=" + cfg.Providers.Proxmox.Secret
+	case cfg.Providers.Proxmox.CAPIToken != "" && cfg.Providers.Proxmox.CAPISecret != "":
+		auth = "PVEAPIToken=" + cfg.Providers.Proxmox.CAPIToken + "=" + cfg.Providers.Proxmox.CAPISecret
 	default:
 		return "", false, "", fmt.Errorf("no Proxmox credentials available (set --admin-username/--admin-token or --proxmox-token/--proxmox-secret)")
 	}

--- a/internal/provider/proxmox/pveapi/http.go
+++ b/internal/provider/proxmox/pveapi/http.go
@@ -166,11 +166,11 @@ func ResolveRegionAndNodeFromAdminAPI(cfg *config.Config) error {
 // using PROXMOX_TOKEN + PROXMOX_SECRET (the CAPI token), normalising
 // the secret first.
 func ResolveRegionAndNodeFromClusterctlAPI(cfg *config.Config) error {
-	if cfg.Providers.Proxmox.Token == "" || cfg.Providers.Proxmox.Secret == "" {
+	if cfg.Providers.Proxmox.CAPIToken == "" || cfg.Providers.Proxmox.CAPISecret == "" {
 		return nil
 	}
-	sec := NormalizeTokenSecret(cfg.Providers.Proxmox.Secret, cfg.Providers.Proxmox.Token)
-	auth := fmt.Sprintf("PVEAPIToken=%s=%s", cfg.Providers.Proxmox.Token, sec)
+	sec := NormalizeTokenSecret(cfg.Providers.Proxmox.CAPISecret, cfg.Providers.Proxmox.CAPIToken)
+	auth := fmt.Sprintf("PVEAPIToken=%s=%s", cfg.Providers.Proxmox.CAPIToken, sec)
 	return ResolveRegionAndNodeFromPVEAuth(cfg, auth)
 }
 
@@ -352,8 +352,8 @@ func ResolveAvailableClusterSetIDForRoles(cfg *config.Config) error {
 			if cfg.Providers.Proxmox.CSITokenID == "" || cfg.Providers.Proxmox.CSITokenID == oldCSITokenID {
 				cfg.Providers.Proxmox.CSITokenID = TokenID(cfg.Providers.Proxmox.CSIUserID, cfg.Providers.Proxmox.CSITokenPrefix, cfg.Providers.Proxmox.IdentitySuffix)
 			}
-			if cfg.Providers.Proxmox.Token == "" || cfg.Providers.Proxmox.Token == oldCAPITokenID {
-				cfg.Providers.Proxmox.Token = TokenID(cfg.Providers.Proxmox.CAPIUserID, cfg.Providers.Proxmox.CAPITokenPrefix, cfg.Providers.Proxmox.IdentitySuffix)
+			if cfg.Providers.Proxmox.CAPIToken == "" || cfg.Providers.Proxmox.CAPIToken == oldCAPITokenID {
+				cfg.Providers.Proxmox.CAPIToken = TokenID(cfg.Providers.Proxmox.CAPIUserID, cfg.Providers.Proxmox.CAPITokenPrefix, cfg.Providers.Proxmox.IdentitySuffix)
 			}
 			RefreshDerivedIdentityTokenIDs(cfg)
 			RefreshDerivedCiliumClusterID(cfg)

--- a/internal/provider/proxmox/pveapi/proxmox.go
+++ b/internal/provider/proxmox/pveapi/proxmox.go
@@ -123,9 +123,9 @@ func RefreshDerivedIdentityUserIDs(cfg *config.Config) {
 // with a real secret (from kind) produces a 401.
 func RefreshDerivedIdentityTokenIDs(cfg *config.Config) {
 	RefreshDerivedIdentityUserIDs(cfg)
-	if cfg.Providers.Proxmox.Token == "" && cfg.Providers.Proxmox.Secret == "" &&
+	if cfg.Providers.Proxmox.CAPIToken == "" && cfg.Providers.Proxmox.CAPISecret == "" &&
 		cfg.Providers.Proxmox.CAPIUserID != "" && cfg.Providers.Proxmox.CAPITokenPrefix != "" {
-		cfg.Providers.Proxmox.Token = TokenID(cfg.Providers.Proxmox.CAPIUserID, cfg.Providers.Proxmox.CAPITokenPrefix, cfg.Providers.Proxmox.IdentitySuffix)
+		cfg.Providers.Proxmox.CAPIToken = TokenID(cfg.Providers.Proxmox.CAPIUserID, cfg.Providers.Proxmox.CAPITokenPrefix, cfg.Providers.Proxmox.IdentitySuffix)
 	}
 	if cfg.Providers.Proxmox.CSITokenID == "" && cfg.Providers.Proxmox.CSITokenSecret == "" &&
 		cfg.Providers.Proxmox.CSIUserID != "" && cfg.Providers.Proxmox.CSITokenPrefix != "" {
@@ -238,14 +238,14 @@ func InferIdentityFromTokenIDs(cfg *config.Config) bool {
 	if !strings.Contains(cfg.Providers.Proxmox.CSITokenID, "!") {
 		return false
 	}
-	if !strings.Contains(cfg.Providers.Proxmox.Token, "!") {
+	if !strings.Contains(cfg.Providers.Proxmox.CAPIToken, "!") {
 		return false
 	}
 	csiUser, csiAfter, ok := strings.Cut(cfg.Providers.Proxmox.CSITokenID, "!")
 	if !ok {
 		return false
 	}
-	capiUser, capiAfter, ok := strings.Cut(cfg.Providers.Proxmox.Token, "!")
+	capiUser, capiAfter, ok := strings.Cut(cfg.Providers.Proxmox.CAPIToken, "!")
 	if !ok {
 		return false
 	}

--- a/internal/provider/proxmox/state.go
+++ b/internal/provider/proxmox/state.go
@@ -30,8 +30,8 @@ func (p *Provider) KindSyncFields(cfg *config.Config) map[string]string {
 		}
 	}
 	add("url", cfg.Providers.Proxmox.URL)
-	add("token", cfg.Providers.Proxmox.Token)
-	add("secret", cfg.Providers.Proxmox.Secret)
+	add("capi_token", cfg.Providers.Proxmox.CAPIToken)
+	add("capi_secret", cfg.Providers.Proxmox.CAPISecret)
 	add("region", cfg.Providers.Proxmox.Region)
 	add("node", cfg.Providers.Proxmox.Node)
 	add("source_node", cfg.Providers.Proxmox.SourceNode)
@@ -139,10 +139,10 @@ func (p *Provider) AbsorbConfigYAML(cfg *config.Config, kv map[string]string) bo
 		switch k {
 		case "PROXMOX_URL":
 			assign(&cfg.Providers.Proxmox.URL, v)
-		case "PROXMOX_TOKEN":
-			assign(&cfg.Providers.Proxmox.Token, v)
-		case "PROXMOX_SECRET":
-			assign(&cfg.Providers.Proxmox.Secret, v)
+		case "PROXMOX_CAPI_TOKEN", "PROXMOX_TOKEN":
+			assign(&cfg.Providers.Proxmox.CAPIToken, v)
+		case "PROXMOX_CAPI_SECRET", "PROXMOX_SECRET":
+			assign(&cfg.Providers.Proxmox.CAPISecret, v)
 		case "PROXMOX_REGION":
 			assign(&cfg.Providers.Proxmox.Region, v)
 		case "PROXMOX_NODE":

--- a/internal/ui/cli/help/all.txt
+++ b/internal/ui/cli/help/all.txt
@@ -210,6 +210,8 @@ OPTIONS
         --ip-prefix N                     IP prefix (default: 24)
         --dns-servers LIST                Comma-separated DNS servers (default: 8.8.8.8,8.8.4.4)
         --allowed-nodes LIST              Allowed Proxmox nodes (default: same as --node)
+        --vm-ssh-keys KEYS                Newline-separated SSH public keys for VM cloud-init.
+                                          Env: VM_SSH_KEYS. Set via --xapiri or export.
 
   CSI add-ons (registry — §20 Phase F)
         --csi-driver NAME                 Install the named CSI driver on the workload cluster.

--- a/internal/ui/cli/parse.go
+++ b/internal/ui/cli/parse.go
@@ -80,10 +80,10 @@ func Parse(c *config.Config, argv []string) {
 			c.Providers.Proxmox.AdminToken = shiftVal(a)
 		case "--proxmox-url":
 			c.Providers.Proxmox.URL = shiftVal(a)
-		case "--proxmox-token":
-			c.Providers.Proxmox.Token = shiftVal(a)
-		case "--proxmox-secret":
-			c.Providers.Proxmox.Secret = shiftVal(a)
+		case "--proxmox-capi-token":
+			c.Providers.Proxmox.CAPIToken = shiftVal(a)
+		case "--proxmox-capi-secret":
+			c.Providers.Proxmox.CAPISecret = shiftVal(a)
 		case "-r", "--region":
 			c.Providers.Proxmox.Region = shiftVal(a)
 		case "-n", "--node":
@@ -123,6 +123,8 @@ func Parse(c *config.Config, argv []string) {
 		case "--allowed-nodes":
 			c.AllowedNodesExplicit = true
 			c.AllowedNodes = shiftVal(a)
+		case "--vm-ssh-keys":
+			c.VMSSHKeys = shiftVal(a)
 		case "--csi-url":
 			c.Providers.Proxmox.CSIURL = shiftVal(a)
 		case "--csi-token-id":

--- a/internal/ui/cli/render.go
+++ b/internal/ui/cli/render.go
@@ -56,6 +56,7 @@ func RenderCommand(cfg *config.Config, mode SensitiveMode) string {
 	r.line("yage")
 
 	r.universal(cfg)
+	r.network(cfg)
 	r.cost(cfg)
 	r.tco(cfg)
 	r.workload(cfg)
@@ -205,6 +206,17 @@ func (r *renderer) universal(cfg *config.Config) {
 	r.flag("--bootstrap-mode", cfg.BootstrapMode)
 }
 
+func (r *renderer) network(cfg *config.Config) {
+	r.flag("--control-plane-endpoint-ip", cfg.ControlPlaneEndpointIP)
+	r.flag("--control-plane-endpoint-port", cfg.ControlPlaneEndpointPort)
+	r.flag("--node-ip-ranges", cfg.NodeIPRanges)
+	r.flag("--gateway", cfg.Gateway)
+	r.flag("--ip-prefix", cfg.IPPrefix)
+	r.flag("--dns-servers", cfg.DNSServers)
+	r.flag("--allowed-nodes", cfg.AllowedNodes)
+	r.flag("--vm-ssh-keys", cfg.VMSSHKeys)
+}
+
 func (r *renderer) cost(cfg *config.Config) {
 	r.flag("--data-center-location", cfg.Cost.Currency.DataCenterLocation)
 	r.flagBool("--cost-compare", cfg.CostCompare)
@@ -267,12 +279,25 @@ func (r *renderer) proxmox(cfg *config.Config) {
 	r.flag("--proxmox-url", p.URL)
 	r.flag("--admin-username", p.AdminUsername)
 	r.secret("--admin-token", p.AdminToken, "PROXMOX_ADMIN_TOKEN")
+	r.secret("--proxmox-capi-token", p.CAPIToken, "PROXMOX_CAPI_TOKEN")
+	r.secret("--proxmox-capi-secret", p.CAPISecret, "PROXMOX_CAPI_SECRET")
 	r.flag("--region", p.Region)
 	r.flag("--node", p.Node)
 	r.flag("--bridge", p.Bridge)
 	r.flag("--template-id", p.TemplateID)
-	r.secret("--proxmox-token", p.Token, "PROXMOX_TOKEN")
-	r.secret("--proxmox-secret", p.Secret, "PROXMOX_SECRET")
+	r.flag("--proxmox-pool", p.Pool)
+	r.flag("--cloudinit-storage", p.CloudinitStorage)
+	r.secret("--csi-token-id", p.CSITokenID, "PROXMOX_CSI_TOKEN_ID")
+	r.secret("--csi-token-secret", p.CSITokenSecret, "PROXMOX_CSI_TOKEN_SECRET")
+	// VM sizing — only emit when non-empty (non-default).
+	r.flag("--control-plane-num-sockets", p.ControlPlaneNumSockets)
+	r.flag("--control-plane-num-cores", p.ControlPlaneNumCores)
+	r.flag("--control-plane-memory-mib", p.ControlPlaneMemoryMiB)
+	r.flag("--control-plane-boot-volume-size", p.ControlPlaneBootVolumeSize)
+	r.flag("--worker-num-sockets", p.WorkerNumSockets)
+	r.flag("--worker-num-cores", p.WorkerNumCores)
+	r.flag("--worker-memory-mib", p.WorkerMemoryMiB)
+	r.flag("--worker-boot-volume-size", p.WorkerBootVolumeSize)
 }
 
 func (r *renderer) aws(cfg *config.Config) {

--- a/internal/ui/xapiri/feasibility_shim.go
+++ b/internal/ui/xapiri/feasibility_shim.go
@@ -15,6 +15,8 @@ package xapiri
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/lpasquali/yage/internal/cluster/capacity"
 	"github.com/lpasquali/yage/internal/config"
@@ -139,7 +141,18 @@ func runFeasibilityCheckOnPrem(cfg *config.Config) (FeasibilityVerdict, error) {
 			return FeasibilityTight, nil
 		}
 	}
-	return FeasibilityInfeasible, nil
+	// Infeasible — gather the reason from the active provider's verdict
+	// and any hard blocking reasons (resilience, missing TCO config).
+	// Without this the caller displays "✗ infeasible" with no context.
+	var parts []string
+	parts = append(parts, v.BlockingReasons...)
+	if pv, ok := v.PerProvider[cfg.InfraProvider]; ok && pv.Reason != "" {
+		parts = append(parts, pv.Reason)
+	}
+	if len(parts) > 0 {
+		return FeasibilityInfeasible, fmt.Errorf("%s", strings.Join(parts, "; "))
+	}
+	return FeasibilityInfeasible, fmt.Errorf("cluster shape does not fit the available host inventory")
 }
 
 // _ keeps config imported even if all references move to other

--- a/internal/ui/xapiri/onprem.go
+++ b/internal/ui/xapiri/onprem.go
@@ -19,6 +19,9 @@ import (
 // runOnPremFork is the on-prem-fork driver. Steps 1-3 are shared;
 // 4 and 5 are local; 6-8 fall into runSharedTail.
 func (s *state) runOnPremFork() int {
+	if err := s.step4_onprem_providerPick(); err != nil {
+		return s.exit(err)
+	}
 	if err := s.step1_environment(); err != nil {
 		return s.exit(err)
 	}
@@ -26,9 +29,6 @@ func (s *state) runOnPremFork() int {
 		return s.exit(err)
 	}
 	if err := s.step3_workloadShape(); err != nil {
-		return s.exit(err)
-	}
-	if err := s.step4_onprem_providerPick(); err != nil {
 		return s.exit(err)
 	}
 	for {
@@ -106,7 +106,6 @@ func (s *state) step4_onprem_providerPick() error {
 // step 3.
 func (s *state) step5_onprem_capacity() error {
 	s.r.section("capacity")
-	s.stampGeoRegions("filled blank Region/Location where geo tables exist (e.g. OpenStack on-prem)")
 	verdict, err := runFeasibilityCheckOnPrem(s.cfg)
 	switch verdict {
 	case FeasibilityUnchecked:
@@ -146,8 +145,7 @@ func (s *state) step5_5_onprem_tco() error {
 	s.r.section("on-prem cost estimator (optional)")
 	curHas := s.cfg.HardwareCostUSD > 0 || s.cfg.HardwareWatts > 0 ||
 		s.cfg.HardwareSupportUSDMonth > 0
-	defWant := !curHas
-	if !s.r.promptYesNo("estimate monthly TCO?", defWant) {
+	if !s.r.promptYesNo("estimate monthly TCO?", curHas) {
 		s.r.info("skipped — review and persist will show 'TCO not configured'.")
 		return nil
 	}

--- a/internal/ui/xapiri/prompts.go
+++ b/internal/ui/xapiri/prompts.go
@@ -228,6 +228,35 @@ func (r *reader) info(format string, args ...any) {
 	fmt.Fprintf(r.out, "  %s\n", fmt.Sprintf(format, args...))
 }
 
+// promptSSHKeys collects one or more SSH public keys, one per line,
+// until the user enters an empty line.  Returns the keys joined with
+// newlines (the format cloud-init and authorized_keys both expect).
+// Pressing enter immediately keeps the existing value (cur) unchanged.
+func (r *reader) promptSSHKeys(cur string) string {
+	fmt.Fprintf(r.out, "\n  SSH public key(s) for VM cloud-init\n")
+	fmt.Fprintf(r.out, "  enter one key per line; empty line to finish")
+	if cur != "" {
+		// Show the count of already-configured keys as a hint.
+		n := len(strings.Split(strings.TrimSpace(cur), "\n"))
+		fmt.Fprintf(r.out, " [%d key(s) already set — empty line keeps them]", n)
+	}
+	fmt.Fprintln(r.out)
+
+	var keys []string
+	for {
+		fmt.Fprintf(r.out, "  key %d: ", len(keys)+1)
+		line := strings.TrimRight(r.readLine(), "\r\n ")
+		if line == "" {
+			break
+		}
+		keys = append(keys, line)
+	}
+	if len(keys) == 0 {
+		return cur // keep existing
+	}
+	return strings.Join(keys, "\n")
+}
+
 // maskValue returns a fixed-width placeholder for sensitive values
 // when echoing the resolved config back to the user. Empty stays empty
 // so the review knows the field was never set.

--- a/internal/ui/xapiri/prompts.go
+++ b/internal/ui/xapiri/prompts.go
@@ -232,29 +232,39 @@ func (r *reader) info(format string, args ...any) {
 // until the user enters an empty line.  Returns the keys joined with
 // newlines (the format cloud-init and authorized_keys both expect).
 // Pressing enter immediately keeps the existing value (cur) unchanged.
+// On second run, existing keys are shown first so the operator can
+// verify them; any new keys entered are APPENDED to the existing set.
 func (r *reader) promptSSHKeys(cur string) string {
 	fmt.Fprintf(r.out, "\n  SSH public key(s) for VM cloud-init\n")
-	fmt.Fprintf(r.out, "  enter one key per line; empty line to finish")
+	existing := strings.Split(strings.TrimSpace(cur), "\n")
 	if cur != "" {
-		// Show the count of already-configured keys as a hint.
-		n := len(strings.Split(strings.TrimSpace(cur), "\n"))
-		fmt.Fprintf(r.out, " [%d key(s) already set — empty line keeps them]", n)
+		fmt.Fprintf(r.out, "  existing keys:\n")
+		for i, k := range existing {
+			if strings.TrimSpace(k) != "" {
+				fmt.Fprintf(r.out, "    %d: %s\n", i+1, k)
+			}
+		}
+		fmt.Fprintf(r.out, "  add more keys (empty line to keep existing and finish):\n")
+	} else {
+		fmt.Fprintf(r.out, "  enter one key per line; empty line to finish:\n")
 	}
-	fmt.Fprintln(r.out)
 
-	var keys []string
+	var added []string
 	for {
-		fmt.Fprintf(r.out, "  key %d: ", len(keys)+1)
+		fmt.Fprintf(r.out, "  key %d: ", len(existing)+len(added)+1)
 		line := strings.TrimRight(r.readLine(), "\r\n ")
 		if line == "" {
 			break
 		}
-		keys = append(keys, line)
+		added = append(added, line)
 	}
-	if len(keys) == 0 {
+	if len(added) == 0 {
 		return cur // keep existing
 	}
-	return strings.Join(keys, "\n")
+	if cur == "" {
+		return strings.Join(added, "\n")
+	}
+	return cur + "\n" + strings.Join(added, "\n")
 }
 
 // maskValue returns a fixed-width placeholder for sensitive values

--- a/internal/ui/xapiri/proxmox.go
+++ b/internal/ui/xapiri/proxmox.go
@@ -87,8 +87,8 @@ const (
 // promptCredMode asks the operator which credential flow to use.
 // Defaults to managed when no BYO tokens are already set.
 func (s *state) promptCredMode() credentialMode {
-	hasBYO := s.cfg.Providers.Proxmox.Token != "" &&
-		s.cfg.Providers.Proxmox.Secret != "" &&
+	hasBYO := s.cfg.Providers.Proxmox.CAPIToken != "" &&
+		s.cfg.Providers.Proxmox.CAPISecret != "" &&
 		s.cfg.Providers.Proxmox.CSITokenID != "" &&
 		s.cfg.Providers.Proxmox.CSITokenSecret != ""
 	cur := choiceManaged
@@ -119,8 +119,8 @@ func (s *state) step6_proxmox_managed() error {
 	s.cfg.Providers.Proxmox.AdminToken = token
 	// Clear BYO fields so the orchestrator doesn't accidentally see
 	// a partial set and skip OpenTofu.
-	s.cfg.Providers.Proxmox.Token = ""
-	s.cfg.Providers.Proxmox.Secret = ""
+	s.cfg.Providers.Proxmox.CAPIToken = ""
+	s.cfg.Providers.Proxmox.CAPISecret = ""
 	s.cfg.Providers.Proxmox.CSITokenID = ""
 	s.cfg.Providers.Proxmox.CSITokenSecret = ""
 	return nil
@@ -134,15 +134,15 @@ func (s *state) step6_proxmox_byo() error {
 	s.r.info("bring-your-own mode — OpenTofu identity bootstrap will be skipped.")
 	s.r.info("Provide the existing Proxmox API tokens for CAPMOX and CSI.")
 
-	s.cfg.Providers.Proxmox.Token = s.r.promptString(
+	s.cfg.Providers.Proxmox.CAPIToken = s.r.promptString(
 		"CAPMOX token ID (e.g. capmox@pve!capmox-token)",
-		s.cfg.Providers.Proxmox.Token)
+		s.cfg.Providers.Proxmox.CAPIToken)
 
-	secret, err := s.r.promptSecretHidden("CAPMOX token secret", s.cfg.Providers.Proxmox.Secret)
+	secret, err := s.r.promptSecretHidden("CAPMOX token secret", s.cfg.Providers.Proxmox.CAPISecret)
 	if err != nil {
 		return fmt.Errorf("reading CAPMOX token secret: %w", err)
 	}
-	s.cfg.Providers.Proxmox.Secret = secret
+	s.cfg.Providers.Proxmox.CAPISecret = secret
 
 	s.cfg.Providers.Proxmox.CSITokenID = s.r.promptString(
 		"CSI token ID (e.g. csi@pve!csi-token)",
@@ -158,12 +158,11 @@ func (s *state) step6_proxmox_byo() error {
 	return nil
 }
 
-// step6_5_proxmox_network collects the network settings that every
-// Proxmox cluster needs: control-plane VIP, node IP range, gateway,
-// prefix length, DNS servers, bridge-level SSH keys, and the workload
-// and management cluster names.
+// step6_5_proxmox_network collects the network settings for all Proxmox
+// clusters: workload VIP/range/gateway/DNS, SSH keys, cluster names, and —
+// when pivot is enabled — the management cluster's VIP and node IP range.
 func (s *state) step6_5_proxmox_network() error {
-	s.r.section("network settings")
+	s.r.section("workload cluster — network")
 
 	s.cfg.ControlPlaneEndpointIP = s.r.promptString(
 		"control-plane VIP (must be outside the node IP range)",
@@ -187,10 +186,35 @@ func (s *state) step6_5_proxmox_network() error {
 
 	s.cfg.VMSSHKeys = s.r.promptSSHKeys(s.cfg.VMSSHKeys)
 
-	// Workload cluster identity
 	s.cfg.WorkloadClusterName = s.r.promptString(
 		"workload cluster name",
 		orStr(s.cfg.WorkloadClusterName, "capi-quickstart"))
+
+	// Management cluster network — only needed when pivot is enabled.
+	// These are the two inputs renderManagementManifest requires that
+	// have no sensible default (the VIP and node range must be distinct
+	// from the workload cluster's ranges).
+	if s.cfg.Pivot.Enabled {
+		s.r.section("management cluster — network")
+		s.r.info("The management cluster needs its own VIP and node IP range,")
+		s.r.info("separate from the workload cluster's ranges above.")
+
+		s.cfg.Mgmt.ControlPlaneEndpointIP = s.r.promptString(
+			"management cluster VIP",
+			orStr(s.cfg.Mgmt.ControlPlaneEndpointIP, "192.168.0.30"))
+
+		s.cfg.Mgmt.NodeIPRanges = s.r.promptString(
+			"management node IP range (e.g. 192.168.0.31-192.168.0.32)",
+			orStr(s.cfg.Mgmt.NodeIPRanges, "192.168.0.31-192.168.0.32"))
+
+		s.cfg.Mgmt.ClusterName = s.r.promptString(
+			"management cluster name",
+			orStr(s.cfg.Mgmt.ClusterName, "capi-management"))
+
+		s.cfg.Providers.Proxmox.Mgmt.Pool = s.r.promptString(
+			"management cluster pool (empty = no pool)",
+			orStr(s.cfg.Providers.Proxmox.Mgmt.Pool, s.cfg.Mgmt.ClusterName))
+	}
 
 	return nil
 }

--- a/internal/ui/xapiri/proxmox.go
+++ b/internal/ui/xapiri/proxmox.go
@@ -185,9 +185,7 @@ func (s *state) step6_5_proxmox_network() error {
 		"DNS servers (comma-separated)",
 		orStr(s.cfg.DNSServers, "8.8.8.8,8.8.4.4"))
 
-	s.cfg.VMSSHKeys = s.r.promptString(
-		"SSH public key(s) for VM cloud-init (empty to skip)",
-		s.cfg.VMSSHKeys)
+	s.cfg.VMSSHKeys = s.r.promptSSHKeys(s.cfg.VMSSHKeys)
 
 	// Workload cluster identity
 	s.cfg.WorkloadClusterName = s.r.promptString(

--- a/internal/ui/xapiri/shared.go
+++ b/internal/ui/xapiri/shared.go
@@ -465,13 +465,16 @@ func (s *state) step7_review() error {
 		pw.Skip("feasibility gate not wired — proceed at own risk.")
 	} else if ferr != nil {
 		pw.Bullet("%s %s — %v", verdict.symbol(), verdict, ferr)
-		s.r.info("feasibility refuses this shape — go back to step 3 (workload) and shrink, or step 4 (budget/provider) and grow.")
-		return fmt.Errorf("xapiri: feasibility blocked at review: %w", ferr)
 	} else {
 		pw.Bullet("%s %s", verdict.symbol(), verdict)
 	}
 
-	if !s.r.promptYesNo("write to kind?", true) {
+	writeDefault := verdict != FeasibilityInfeasible
+	if verdict == FeasibilityInfeasible {
+		s.r.info("⚠ cluster shape may not fit the host inventory — see reason above.")
+		s.r.info("  You can proceed anyway if you know your hardware can handle it.")
+	}
+	if !s.r.promptYesNo("write to kind?", writeDefault) {
 		return ErrUserExit
 	}
 	return nil

--- a/internal/ui/xapiri/shared.go
+++ b/internal/ui/xapiri/shared.go
@@ -16,20 +16,50 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/pricing"
+	"github.com/lpasquali/yage/internal/provider"
 	"github.com/lpasquali/yage/internal/ui/cli"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
+
+// semverRE validates Kubernetes version strings (e.g. "v1.35.0").
+var semverRE = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
 
 // greet prints the opening lines. The shell-prompt style and
 // cultural framing are deliberately quiet.
 func (s *state) greet() {
 	s.r.info("xapiri — let's shape this deployment together.")
 	s.r.info("press enter to keep the value in [brackets].")
+}
+
+// stepKubernetesVersion asks for the workload Kubernetes version.
+// Called first so every downstream step (manifest generation, cost
+// compare, feasibility) sees the right version. Defaults to the
+// value already on cfg (set by env / flag), falling back to the
+// compiled-in default (v1.35.0). Re-prompts on malformed input.
+func (s *state) stepKubernetesVersion() error {
+	s.r.section("kubernetes version")
+	cur := s.cfg.WorkloadKubernetesVersion
+	if cur == "" {
+		cur = "v1.35.0"
+	}
+	for {
+		v := s.r.promptString("workload Kubernetes version (e.g. v1.35.0)", cur)
+		if v == "" {
+			v = cur
+		}
+		if !semverRE.MatchString(v) {
+			fmt.Fprintf(s.w, "    not a valid version (expected vMAJOR.MINOR.PATCH, e.g. v1.35.0); try again.\n")
+			continue
+		}
+		s.cfg.WorkloadKubernetesVersion = v
+		return nil
+	}
 }
 
 // stepKindClusterName asks the operator for a name for the kind
@@ -93,19 +123,27 @@ func (s *state) step0_modePick() error {
 // detectFork is the auto-detection rule from §22.1. Pure function
 // (no I/O) so the dispatch in step0_modePick stays trivially
 // testable.
+//
+// Priority: (1) cfg.InfraProvider — the authoritative saved value.
+// (2) airgapped flag. (3) env-var heuristics for fresh sessions.
 func detectFork(cfg *config.Config) forkType {
+	if cfg.InfraProvider != "" {
+		if provider.AirgapCompatible(cfg.InfraProvider) {
+			return forkOnPrem
+		}
+		return forkCloud
+	}
 	if cfg.Airgapped {
 		return forkOnPrem
 	}
-	proxmox := os.Getenv("PROXMOX_URL") != "" || cfg.Providers.Proxmox.URL != ""
 	cloud := os.Getenv("AWS_ACCESS_KEY_ID") != "" ||
 		os.Getenv("AZURE_SUBSCRIPTION_ID") != "" ||
 		os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") != ""
-	switch {
-	case proxmox && !cloud:
-		return forkOnPrem
-	case cloud && !proxmox:
+	if cloud {
 		return forkCloud
+	}
+	if os.Getenv("PROXMOX_URL") != "" {
+		return forkOnPrem
 	}
 	return forkUnknown
 }
@@ -265,6 +303,9 @@ func syncWorkloadShapeToCfg(cfg *config.Config, w workloadShape, resil resilienc
 		EgressGBMonth: egress,
 		Resilience:    res,
 		Environment:   envStr,
+		HasQueue:      w.HasQueue,
+		HasObjStore:   w.HasObjStore,
+		HasCache:      w.HasCache,
 	}
 }
 
@@ -445,6 +486,19 @@ func (s *state) step7_review() error {
 	}
 	pw.Bullet("airgapped:      %v", s.cfg.Airgapped)
 
+	// Network / cluster identity.
+	pw.Section("Network")
+	pw.Bullet("workload VIP:   %s", s.cfg.ControlPlaneEndpointIP)
+	pw.Bullet("node IP range:  %s", s.cfg.NodeIPRanges)
+	pw.Bullet("gateway:        %s  prefix: /%s", s.cfg.Gateway, s.cfg.IPPrefix)
+	pw.Bullet("DNS:            %s", s.cfg.DNSServers)
+	pw.Bullet("workload name:  %s", s.cfg.WorkloadClusterName)
+	if s.cfg.Pivot.Enabled {
+		pw.Bullet("mgmt VIP:       %s", s.cfg.Mgmt.ControlPlaneEndpointIP)
+		pw.Bullet("mgmt IP range:  %s", s.cfg.Mgmt.NodeIPRanges)
+		pw.Bullet("mgmt name:      %s", s.cfg.Mgmt.ClusterName)
+	}
+
 	// Fork-specific cost line.
 	if s.fork == forkOnPrem {
 		s.renderTCOLine(pw)
@@ -581,7 +635,9 @@ func (s *state) step8_persistAndDecide() error {
 	fmt.Fprintln(s.w)
 
 	s.deployNow = s.r.promptYesNo("deploy now?", false)
-	if !s.deployNow {
+	if s.deployNow {
+		s.cfg.XapiriDeployNow = true
+	} else {
 		s.r.info("nothing deployed; the next non-xapiri yage run will pick the saved config up.")
 	}
 	return nil

--- a/internal/ui/xapiri/state.go
+++ b/internal/ui/xapiri/state.go
@@ -148,12 +148,14 @@ type state struct {
 // write to the io.Writer Run() was given. Tests can drive the
 // state machine by injecting both.
 func newState(w io.Writer, cfg *config.Config) *state {
-	return &state{
+	s := &state{
 		w:           w,
 		cfg:         cfg,
 		r:           newReader(os.Stdin, w),
 		headroomPct: 0.20,
 	}
+	s.initFromConfig(cfg)
+	return s
 }
 
 // newStateWithReader is the seam tests would use to drive the
@@ -161,11 +163,46 @@ func newState(w io.Writer, cfg *config.Config) *state {
 // non-os.Stdin source. Currently unused; kept here so a future
 // test pass can plug in without touching the interactive path.
 func newStateWithReader(w io.Writer, cfg *config.Config, in io.Reader) *state {
-	return &state{
+	s := &state{
 		w:           w,
 		cfg:         cfg,
 		r:           newReader(in, w),
 		headroomPct: 0.20,
+	}
+	s.initFromConfig(cfg)
+	return s
+}
+
+// initFromConfig seeds walkthrough-local state from a previously
+// persisted cfg.Workload so that second-run prompts show the saved
+// values as defaults rather than zero/empty.
+func (s *state) initFromConfig(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	switch cfg.Workload.Environment {
+	case "staging":
+		s.env = envStaging
+	case "prod":
+		s.env = envProd
+	case "dev":
+		s.env = envDev
+	}
+	switch cfg.Workload.Resilience {
+	case "ha":
+		s.resil = resilienceHA
+	case "ha-mr":
+		s.resil = resilienceHAMulti
+	case "single":
+		s.resil = resilienceSingle
+	}
+	s.workload.DBGB = cfg.Workload.DatabaseGB
+	s.workload.EgressGBMo = cfg.Workload.EgressGBMonth
+	s.workload.HasQueue = cfg.Workload.HasQueue
+	s.workload.HasObjStore = cfg.Workload.HasObjStore
+	s.workload.HasCache = cfg.Workload.HasCache
+	for _, ag := range cfg.Workload.Apps {
+		s.workload.Apps = append(s.workload.Apps, appBucket{Count: ag.Count, Template: ag.Template})
 	}
 }
 

--- a/internal/ui/xapiri/xapiri.go
+++ b/internal/ui/xapiri/xapiri.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 
 	"github.com/lpasquali/yage/internal/cluster/kind"
+	"github.com/lpasquali/yage/internal/cluster/kindsync"
 	"github.com/lpasquali/yage/internal/config"
 )
 
@@ -69,6 +70,23 @@ func Run(w io.Writer, cfg *config.Config) int {
 	if err := s.stepKindClusterName(); err != nil {
 		return s.exit(err)
 	}
+	// Load all previously saved state now that we know the kind cluster
+	// name. Two stores exist:
+	//   1. yage-system/proxmox-bootstrap-config — the orchestrator's
+	//      store, written after a real deployment. Contains network
+	//      fields, provider URL/tokens, workload cluster name.
+	//   2. yage-system/bootstrap-config — xapiri's own store, written
+	//      at the end of a successful walkthrough. Contains a full
+	//      snapshot including everything from store 1.
+	// Call 1 first so store 2 (which is fresher when it exists) wins
+	// on overlap. Both are best-effort no-ops when the cluster or Secret
+	// is not yet reachable (first-run case).
+	kindsync.MergeBootstrapSecretsFromKind(cfg)
+	_ = kindsync.MergeBootstrapConfigFromKind(cfg)
+	s.initFromConfig(cfg) // re-seed walkthrough state now that kind merges have run
+	if err := s.stepKubernetesVersion(); err != nil {
+		return s.exit(err)
+	}
 	if !skipKindPrelude() {
 		if err := kind.EnsureClusterUp(cfg, w); err != nil {
 			fmt.Fprintf(w, "xapiri: kind management cluster could not be brought up: %v\n", err)
@@ -97,6 +115,17 @@ func useHuhTUI() bool {
 // form covers steps 1..4 of the cloud fork; cost-compare and the
 // shared tail run unchanged afterwards.
 func runHuhBranch(w io.Writer, cfg *config.Config, s *state) int {
+	// Speculative merge using the default cluster name so the huh form
+	// sees saved values as its initial field values.
+	if cfg.KindClusterName == "" {
+		cfg.KindClusterName = "yage-mgmt"
+	}
+	kindsync.MergeBootstrapSecretsFromKind(cfg)
+	_ = kindsync.MergeBootstrapConfigFromKind(cfg)
+	s.initFromConfig(cfg) // re-seed walkthrough state now that kind merges have run
+	if err := s.stepKubernetesVersion(); err != nil {
+		return s.exit(err)
+	}
 	if !skipKindPrelude() {
 		if err := kind.EnsureClusterUp(cfg, w); err != nil {
 			fmt.Fprintf(w, "xapiri: kind management cluster could not be brought up: %v\n", err)


### PR DESCRIPTION
## Summary

- **xapiri walkthrough**: management cluster pool prompt (defaults to cluster name); `HasQueue`/`HasObjStore`/`HasCache` state saved and restored on second run; `XapiriDeployNow` flag lets the walkthrough fall through to `orchestrator.Run`; all xapiri walkthrough fields now round-trip through the bootstrap-config snapshot; `XAPIRI_WORKLOAD_APPS` parser gains a JSON fallback for old Secrets using `[{"Count":N,"Template":"..."}]` format
- **Snapshot explicit guards**: `MGMT_CLUSTER_NAME`, `MGMT_CLUSTER_NAMESPACE`, `PROXMOX_POOL`, `MGMT_PROXMOX_POOL` switched from `sp` (always-overwrite) to `spEx` — snapshot no longer clobbers env-set values on second run; `WORKLOAD_CLUSTER_NAME`/`_NAMESPACE` explicit detection also fixed to trigger when the primary env var is set (not only the `_EXPLICIT` companion flag); same for `WORKLOAD_KUBERNETES_VERSION` and `MGMT_KUBERNETES_VERSION`
- **CAPI credential rename**: `ProxmoxConfig.Token`/`Secret` → `CAPIToken`/`CAPISecret`; env vars `PROXMOX_TOKEN`/`PROXMOX_SECRET` → `PROXMOX_CAPI_TOKEN`/`PROXMOX_CAPI_SECRET` (old names kept as fallback in `Load()` and `yaml.go`); bootstrap-config Secret keys `proxmox.token`/`proxmox.secret` → `proxmox.capi_token`/`proxmox.capi_secret` with backward-compat aliases in kindsync; CLI flags renamed accordingly; `capmox-manager-credentials` data keys and clusterctl config YAML keys unchanged (CAPMOX reads those exact names)

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./...` — all pass
- [ ] Second-run xapiri with existing kind Secret: verify `MGMT_CLUSTER_NAME` is not overwritten when set via env var
- [ ] Second-run xapiri with existing kind Secret: verify pool restores from snapshot and does not revert to default cluster name
- [ ] Old bootstrap-config Secret with `proxmox.token` key: verify `AbsorbConfigYAML` backward-compat alias still populates `CAPIToken`
- [ ] Old env var `PROXMOX_TOKEN` still accepted (Load() fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)