### PR TITLE
refactor(#4): remove Proxmox-specific leaks from orchestrator plan.go

### DIFF
--- a/internal/orchestrator/plan.go
+++ b/internal/orchestrator/plan.go
@@ -63,7 +63,7 @@ func PrintPlanTo(w io.Writer, cfg *config.Config) {
 	describeIdentity(pw, cfg, prov, perr)
 	planPhase2Clusterctl(w, cfg)
 	planPhase2Kind(w, cfg)
-	planPhase2CAPI(w, cfg)
+	planPhase2CAPI(pw, w, cfg, prov, perr)
 	describeWorkload(pw, cfg, prov, perr)
 	describePivot(pw, cfg, prov, perr)
 	planPhase210ArgoCD(w, cfg)
@@ -126,10 +126,7 @@ func planPrePhase(w io.Writer, cfg *config.Config) {
 	if cfg.Purge {
 		bullet(w, "PURGE: delete generated files + Terraform state, kind workload Cluster, capi-manifest Secret")
 	}
-	if cfg.Providers.Proxmox.RecreateIdentities {
-		bullet(w, "RECREATE_PROXMOX_IDENTITIES: tear down + reapply CAPI/CSI identity Terraform")
-	}
-	bullet(w, "ClusterSetID = %s (identity suffix: %s)", firstNonEmptyStr(cfg.ClusterSetID, "<generated>"), firstNonEmptyStr(cfg.Providers.Proxmox.IdentitySuffix, "<derived>"))
+	bullet(w, "ClusterSetID = %s", firstNonEmptyStr(cfg.ClusterSetID, "<generated>"))
 }
 
 func planPhase1(w io.Writer, cfg *config.Config) {
@@ -172,7 +169,7 @@ func planPhase2Clusterctl(w io.Writer, cfg *config.Config) {
 	if cfg.ClusterctlCfg != "" {
 		bullet(w, "use explicit clusterctl config: %s", cfg.ClusterctlCfg)
 	} else {
-		bullet(w, "synthesize ephemeral clusterctl config from Proxmox env (URL/TOKEN/SECRET)")
+		bullet(w, "synthesize ephemeral clusterctl config from provider env vars")
 	}
 }
 
@@ -190,10 +187,13 @@ func planPhase2Kind(w io.Writer, cfg *config.Config) {
 	}
 }
 
-func planPhase2CAPI(w io.Writer, cfg *config.Config) {
+func planPhase2CAPI(pw plan.Writer, w io.Writer, cfg *config.Config, prov provider.Provider, perr error) {
 	section(w, "clusterctl init on kind")
 	bullet(w, "providers: infrastructure=%s, ipam=%s, addon=helm", cfg.InfraProvider, cfg.IPAMProvider)
-	bullet(w, "CAPMOX image: %s (build arm64 if needed)", firstNonEmptyStr(cfg.CAPMOXVersion, "<resolve from CAPMOX_REPO>"))
+	bullet(w, "infra provider image pinned/built if needed")
+	if perr == nil {
+		prov.DescribeClusterctlInit(pw, cfg)
+	}
 }
 
 // describeWorkload delegates to the provider's
@@ -351,13 +351,12 @@ func planCapacity(w io.Writer, cfg *config.Config) {
 func planAllocations(w io.Writer, cfg *config.Config) {
 	section(w, "Workload allocations (per-bucket budget on workers)")
 	a := capacity.AllocationsFor(cfg)
-	bullet(w, "total worker capacity:    %d millicores, %d MiB (workers=%s × %s sockets × %s cores × %s MiB)",
-		a.TotalCPUMillicores, a.TotalMemoryMiB,
-		cfg.WorkerMachineCount, cfg.Providers.Proxmox.WorkerNumSockets, cfg.Providers.Proxmox.WorkerNumCores, cfg.Providers.Proxmox.WorkerMemoryMiB)
+	bullet(w, "total worker capacity:    %d millicores, %d MiB (workers=%s)",
+		a.TotalCPUMillicores, a.TotalMemoryMiB, cfg.WorkerMachineCount)
 	bullet(w, "system-apps reserve:      %d millicores, %d MiB",
 		a.SystemAppsCPUMillicores, a.SystemAppsMemoryMiB)
 	bullet(w, "  ├─ argocd (operator + server + repo + redis), kyverno, cert-manager,")
-	bullet(w, "  ├─ proxmox-csi (controller), keycloak (SSO), external-secrets, infisical")
+	bullet(w, "  ├─ CSI controller (provider-specific), keycloak (SSO), external-secrets, infisical")
 	bullet(w, "  └─ tune via SYSTEM_APPS_CPU_MILLICORES / SYSTEM_APPS_MEMORY_MIB")
 	if a.IsOverReserved() {
 		bullet(w, "❌ system reserve (%d mCPU / %d MiB) exceeds total worker capacity (%d / %d)",

--- a/internal/orchestrator/testdata/plan/aws-default.golden
+++ b/internal/orchestrator/testdata/plan/aws-default.golden
@@ -3,7 +3,7 @@
 ────────────────────────────────────────────────────────────────────────────
 
 ▸ Pre-phase
-    • ClusterSetID = test-clusterset (identity suffix: <derived>)
+    • ClusterSetID = test-clusterset
 
 ▸ Dependency install — host CLIs for the operator
     • system packages: git, curl, python3 (apt/dnf/yum/apk)
@@ -23,14 +23,14 @@
     ◦ skip: CAPA bootstrap stack created out-of-band — `clusterawsadm bootstrap iam create-cloudformation-stack`
 
 ▸ clusterctl credentials
-    • synthesize ephemeral clusterctl config from Proxmox env (URL/TOKEN/SECRET)
+    • synthesize ephemeral clusterctl config from provider env vars
 
 ▸ kind cluster
     • create kind cluster 'capi-test' (config: <ephemeral default>)
 
 ▸ clusterctl init on kind
     • providers: infrastructure=aws, ipam=in-cluster, addon=helm
-    • CAPMOX image: v0.7.0 (build arm64 if needed)
+    • infra provider image pinned/built if needed
 
 ▸ Workload Cluster — AWS (mode: unmanaged)
     • Cluster: default/capi-quickstart, k8s v1.32.0, region us-east-1
@@ -58,10 +58,10 @@
     ◦ skip: provider "aws" has no flat-pool inventory model — preflight skipped (§13.4 #1)
 
 ▸ Workload allocations (per-bucket budget on workers)
-    • total worker capacity:    2000 millicores, 0 MiB (workers=2 ×  sockets ×  cores ×  MiB)
+    • total worker capacity:    2000 millicores, 0 MiB (workers=2)
     • system-apps reserve:      2000 millicores, 4096 MiB
     •   ├─ argocd (operator + server + repo + redis), kyverno, cert-manager,
-    •   ├─ proxmox-csi (controller), keycloak (SSO), external-secrets, infisical
+    •   ├─ CSI controller (provider-specific), keycloak (SSO), external-secrets, infisical
     •   └─ tune via SYSTEM_APPS_CPU_MILLICORES / SYSTEM_APPS_MEMORY_MIB
     • ❌ system reserve (2000 mCPU / 4096 MiB) exceeds total worker capacity (2000 / 0)
     •    grow worker count / sizing, OR untaint the control-plane node and let it host system pods

--- a/internal/orchestrator/testdata/plan/aws-eks.golden
+++ b/internal/orchestrator/testdata/plan/aws-eks.golden
@@ -3,7 +3,7 @@
 ────────────────────────────────────────────────────────────────────────────
 
 ▸ Pre-phase
-    • ClusterSetID = test-clusterset (identity suffix: <derived>)
+    • ClusterSetID = test-clusterset
 
 ▸ Dependency install — host CLIs for the operator
     • system packages: git, curl, python3 (apt/dnf/yum/apk)
@@ -23,14 +23,14 @@
     ◦ skip: CAPA bootstrap stack created out-of-band — `clusterawsadm bootstrap iam create-cloudformation-stack`
 
 ▸ clusterctl credentials
-    • synthesize ephemeral clusterctl config from Proxmox env (URL/TOKEN/SECRET)
+    • synthesize ephemeral clusterctl config from provider env vars
 
 ▸ kind cluster
     • create kind cluster 'capi-test' (config: <ephemeral default>)
 
 ▸ clusterctl init on kind
     • providers: infrastructure=aws, ipam=in-cluster, addon=helm
-    • CAPMOX image: v0.7.0 (build arm64 if needed)
+    • infra provider image pinned/built if needed
 
 ▸ Workload Cluster — AWS (mode: eks)
     • Cluster: default/capi-quickstart, k8s v1.32.0, region us-east-1
@@ -58,10 +58,10 @@
     ◦ skip: provider "aws" has no flat-pool inventory model — preflight skipped (§13.4 #1)
 
 ▸ Workload allocations (per-bucket budget on workers)
-    • total worker capacity:    2000 millicores, 0 MiB (workers=2 ×  sockets ×  cores ×  MiB)
+    • total worker capacity:    2000 millicores, 0 MiB (workers=2)
     • system-apps reserve:      2000 millicores, 4096 MiB
     •   ├─ argocd (operator + server + repo + redis), kyverno, cert-manager,
-    •   ├─ proxmox-csi (controller), keycloak (SSO), external-secrets, infisical
+    •   ├─ CSI controller (provider-specific), keycloak (SSO), external-secrets, infisical
     •   └─ tune via SYSTEM_APPS_CPU_MILLICORES / SYSTEM_APPS_MEMORY_MIB
     • ❌ system reserve (2000 mCPU / 4096 MiB) exceeds total worker capacity (2000 / 0)
     •    grow worker count / sizing, OR untaint the control-plane node and let it host system pods

--- a/internal/orchestrator/testdata/plan/hetzner-default.golden
+++ b/internal/orchestrator/testdata/plan/hetzner-default.golden
@@ -3,7 +3,7 @@
 ────────────────────────────────────────────────────────────────────────────
 
 ▸ Pre-phase
-    • ClusterSetID = test-clusterset (identity suffix: <derived>)
+    • ClusterSetID = test-clusterset
 
 ▸ Dependency install — host CLIs for the operator
     • system packages: git, curl, python3 (apt/dnf/yum/apk)
@@ -22,14 +22,14 @@
     ◦ skip: HCLOUD_TOKEN supplied via env (operator-managed, not minted by yage)
 
 ▸ clusterctl credentials
-    • synthesize ephemeral clusterctl config from Proxmox env (URL/TOKEN/SECRET)
+    • synthesize ephemeral clusterctl config from provider env vars
 
 ▸ kind cluster
     • create kind cluster 'capi-test' (config: <ephemeral default>)
 
 ▸ clusterctl init on kind
     • providers: infrastructure=hetzner, ipam=in-cluster, addon=helm
-    • CAPMOX image: v0.7.0 (build arm64 if needed)
+    • infra provider image pinned/built if needed
 
 ▸ Workload Cluster — Hetzner Cloud
     • Cluster: default/capi-quickstart, k8s v1.32.0, region fsn1
@@ -57,10 +57,10 @@
     ◦ skip: provider "hetzner" has no flat-pool inventory model — preflight skipped (§13.4 #1)
 
 ▸ Workload allocations (per-bucket budget on workers)
-    • total worker capacity:    2000 millicores, 0 MiB (workers=2 ×  sockets ×  cores ×  MiB)
+    • total worker capacity:    2000 millicores, 0 MiB (workers=2)
     • system-apps reserve:      2000 millicores, 4096 MiB
     •   ├─ argocd (operator + server + repo + redis), kyverno, cert-manager,
-    •   ├─ proxmox-csi (controller), keycloak (SSO), external-secrets, infisical
+    •   ├─ CSI controller (provider-specific), keycloak (SSO), external-secrets, infisical
     •   └─ tune via SYSTEM_APPS_CPU_MILLICORES / SYSTEM_APPS_MEMORY_MIB
     • ❌ system reserve (2000 mCPU / 4096 MiB) exceeds total worker capacity (2000 / 0)
     •    grow worker count / sizing, OR untaint the control-plane node and let it host system pods

--- a/internal/orchestrator/testdata/plan/proxmox-default.golden
+++ b/internal/orchestrator/testdata/plan/proxmox-default.golden
@@ -3,7 +3,7 @@
 ────────────────────────────────────────────────────────────────────────────
 
 ▸ Pre-phase
-    • ClusterSetID = test-clusterset (identity suffix: test)
+    • ClusterSetID = test-clusterset
 
 ▸ Dependency install — host CLIs for the operator
     • system packages: git, curl, python3 (apt/dnf/yum/apk)
@@ -25,13 +25,14 @@
     • outputs piped into clusterctl + CSI configs
 
 ▸ clusterctl credentials
-    • synthesize ephemeral clusterctl config from Proxmox env (URL/TOKEN/SECRET)
+    • synthesize ephemeral clusterctl config from provider env vars
 
 ▸ kind cluster
     • create kind cluster 'capi-test' (config: <ephemeral default>)
 
 ▸ clusterctl init on kind
     • providers: infrastructure=proxmox, ipam=in-cluster, addon=helm
+    • infra provider image pinned/built if needed
     • CAPMOX image: v0.7.0 (build arm64 if needed)
 
 ▸ Workload Cluster — Proxmox
@@ -65,10 +66,10 @@
     ◦ skip: host-capacity query: no Proxmox credentials available (set --admin-username/--admin-token or --proxmox-token/--proxmox-secret) (run with valid provider creds for live numbers)
 
 ▸ Workload allocations (per-bucket budget on workers)
-    • total worker capacity:    8000 millicores, 16384 MiB (workers=2 × 1 sockets × 4 cores × 8192 MiB)
+    • total worker capacity:    8000 millicores, 16384 MiB (workers=2)
     • system-apps reserve:      2000 millicores, 4096 MiB
     •   ├─ argocd (operator + server + repo + redis), kyverno, cert-manager,
-    •   ├─ proxmox-csi (controller), keycloak (SSO), external-secrets, infisical
+    •   ├─ CSI controller (provider-specific), keycloak (SSO), external-secrets, infisical
     •   └─ tune via SYSTEM_APPS_CPU_MILLICORES / SYSTEM_APPS_MEMORY_MIB
     • remaining after reserve:  6000 millicores, 12288 MiB
     •   ├─ database:           2000 millicores, 4096 MiB  (cnpg, postgres, redis, …)

--- a/internal/orchestrator/testdata/plan/proxmox-pivot.golden
+++ b/internal/orchestrator/testdata/plan/proxmox-pivot.golden
@@ -3,7 +3,7 @@
 ────────────────────────────────────────────────────────────────────────────
 
 ▸ Pre-phase
-    • ClusterSetID = test-clusterset (identity suffix: test)
+    • ClusterSetID = test-clusterset
 
 ▸ Dependency install — host CLIs for the operator
     • system packages: git, curl, python3 (apt/dnf/yum/apk)
@@ -25,13 +25,14 @@
     • outputs piped into clusterctl + CSI configs
 
 ▸ clusterctl credentials
-    • synthesize ephemeral clusterctl config from Proxmox env (URL/TOKEN/SECRET)
+    • synthesize ephemeral clusterctl config from provider env vars
 
 ▸ kind cluster
     • create kind cluster 'capi-test' (config: <ephemeral default>)
 
 ▸ clusterctl init on kind
     • providers: infrastructure=proxmox, ipam=in-cluster, addon=helm
+    • infra provider image pinned/built if needed
     • CAPMOX image: v0.7.0 (build arm64 if needed)
 
 ▸ Workload Cluster — Proxmox
@@ -76,10 +77,10 @@
     ◦ skip: host-capacity query: no Proxmox credentials available (set --admin-username/--admin-token or --proxmox-token/--proxmox-secret) (run with valid provider creds for live numbers)
 
 ▸ Workload allocations (per-bucket budget on workers)
-    • total worker capacity:    8000 millicores, 16384 MiB (workers=2 × 1 sockets × 4 cores × 8192 MiB)
+    • total worker capacity:    8000 millicores, 16384 MiB (workers=2)
     • system-apps reserve:      2000 millicores, 4096 MiB
     •   ├─ argocd (operator + server + repo + redis), kyverno, cert-manager,
-    •   ├─ proxmox-csi (controller), keycloak (SSO), external-secrets, infisical
+    •   ├─ CSI controller (provider-specific), keycloak (SSO), external-secrets, infisical
     •   └─ tune via SYSTEM_APPS_CPU_MILLICORES / SYSTEM_APPS_MEMORY_MIB
     • remaining after reserve:  6000 millicores, 12288 MiB
     •   ├─ database:           2000 millicores, 4096 MiB  (cnpg, postgres, redis, …)

--- a/internal/provider/minstub.go
+++ b/internal/provider/minstub.go
@@ -38,9 +38,10 @@ func (MinStub) PatchManifest(cfg *config.Config, manifestPath string, mgmt bool)
 // providers leave them as no-ops and the dry-run plan simply omits
 // their sections (acceptable per §8 — section absence == not
 // applicable to this provider).
-func (MinStub) DescribeIdentity(w PlanWriter, cfg *config.Config) {}
-func (MinStub) DescribeWorkload(w PlanWriter, cfg *config.Config) {}
-func (MinStub) DescribePivot(w PlanWriter, cfg *config.Config)    {}
+func (MinStub) DescribeIdentity(w PlanWriter, cfg *config.Config)      {}
+func (MinStub) DescribeWorkload(w PlanWriter, cfg *config.Config)      {}
+func (MinStub) DescribePivot(w PlanWriter, cfg *config.Config)         {}
+func (MinStub) DescribeClusterctlInit(w PlanWriter, cfg *config.Config) {}
 
 // KindSyncer default: no fields to persist. Most cost-only and
 // not-yet-implemented providers have nothing to round-trip through

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -275,13 +275,19 @@ type Purger interface {
 //     by every provider — this is the headline section.
 //   - DescribePivot prints the pivot section. For providers without
 //     a pivot story today, call w.Skip("...") with a reason.
+//   - DescribeClusterctlInit emits provider-specific bullets inside
+//     the "clusterctl init on kind" section — the orchestrator has
+//     already written the section header, so only w.Bullet / w.Skip
+//     calls are appropriate here (no w.Section). Providers that have
+//     nothing extra to say leave this as a no-op.
 //
-// All three return nothing: rendering errors are not actionable
+// All four return nothing: rendering errors are not actionable
 // from inside a Describe* hook.
 type PlanDescriber interface {
 	DescribeIdentity(w PlanWriter, cfg *config.Config)
 	DescribeWorkload(w PlanWriter, cfg *config.Config)
 	DescribePivot(w PlanWriter, cfg *config.Config)
+	DescribeClusterctlInit(w PlanWriter, cfg *config.Config)
 }
 
 // PlanWriter is provider's view of the plan-output seam. It's the

--- a/internal/provider/proxmox/plan.go
+++ b/internal/provider/proxmox/plan.go
@@ -20,6 +20,9 @@ import (
 // piped back into clusterctl + CSI configs.
 func (p *Provider) DescribeIdentity(w provider.PlanWriter, cfg *config.Config) {
 	w.Section("Identity bootstrap — Proxmox (OpenTofu)")
+	if cfg.Providers.Proxmox.RecreateIdentities {
+		w.Bullet("RECREATE_PROXMOX_IDENTITIES: tear down + reapply CAPI/CSI identity Terraform")
+	}
 	if cfg.Providers.Proxmox.AdminUsername == "" || cfg.Providers.Proxmox.AdminToken == "" {
 		w.Bullet("interactive prompt (PROXMOX_ADMIN_USERNAME / PROXMOX_ADMIN_TOKEN unset)")
 	} else {
@@ -30,6 +33,22 @@ func (p *Provider) DescribeIdentity(w provider.PlanWriter, cfg *config.Config) {
 	w.Bullet("tofu apply: create CSI user '%s' + token prefix '%s'",
 		cfg.Providers.Proxmox.CSIUserID, cfg.Providers.Proxmox.CSITokenPrefix)
 	w.Bullet("outputs piped into clusterctl + CSI configs")
+}
+
+// DescribeClusterctlInit emits the Proxmox-specific bullet inside
+// the "clusterctl init on kind" section (the orchestrator has already
+// written the section header — only w.Bullet / w.Skip here).
+func (p *Provider) DescribeClusterctlInit(w provider.PlanWriter, cfg *config.Config) {
+	w.Bullet("CAPMOX image: %s (build arm64 if needed)", firstNonEmptyStr(cfg.CAPMOXVersion, "<resolve from CAPMOX_REPO>"))
+}
+
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // DescribeWorkload emits the Proxmox workload-cluster plan section:


### PR DESCRIPTION
## Summary

Closes #4 (Phase B plan delegation).

- Added `DescribeClusterctlInit(w PlanWriter, cfg *config.Config)` to `PlanDescriber` interface; `MinStub` no-op default
- Proxmox provider absorbs: `RecreateIdentities` bullet (into `DescribeIdentity`), CAPMOX image bullet (into new `DescribeClusterctlInit`)
- Removed from `internal/orchestrator/plan.go`:
  - `planPrePhase`: `RecreateIdentities` bullet + `IdentitySuffix` from ClusterSetID line
  - `planPhase2Clusterctl`: "from Proxmox env" → "from provider env vars"
  - `planPhase2CAPI`: CAPMOX hardcode → generic + `prov.DescribeClusterctlInit` call
  - `planAllocations`: per-socket/core/MiB sizing strings + "proxmox-csi" → "CSI controller (provider-specific)"
- 5 golden fixtures updated to match repositioned output

## Verification

- `go build ./...` clean
- `go test ./...` green (45 packages, including golden fixtures)
- `grep 'cfg.Providers.Proxmox' internal/orchestrator/plan.go` → **0 hits**

🤖 Generated with [Claude Code](https://claude.com/claude-code)