### PR TITLE
feat(#21,#22): internal/obs package + logx structured shim

### DIFF
--- a/internal/obs/context.go
+++ b/internal/obs/context.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import "context"
+
+// loggerKey is the unexported context key for a Logger.
+type loggerKey struct{}
+
+// runIDKey is the unexported context key for a run ID string.
+type runIDKey struct{}
+
+// WithLogger stores l in ctx and returns the child context.
+func WithLogger(ctx context.Context, l Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, l)
+}
+
+// FromCtx returns the Logger stored in ctx, or Global() if none is present.
+func FromCtx(ctx context.Context) Logger {
+	if l, ok := ctx.Value(loggerKey{}).(Logger); ok {
+		return l
+	}
+	return Global()
+}
+
+// WithRunID stores id in ctx and returns the child context.
+func WithRunID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, runIDKey{}, id)
+}
+
+// RunIDFromCtx returns the run ID stored in ctx, or "" if none is present.
+func RunIDFromCtx(ctx context.Context) string {
+	if id, ok := ctx.Value(runIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/internal/obs/fields.go
+++ b/internal/obs/fields.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import (
+	"log/slog"
+	"time"
+)
+
+// Field is a structured log attribute.
+type Field = slog.Attr
+
+// Str returns a string-valued Field.
+func Str(k, v string) Field { return slog.String(k, v) }
+
+// Int returns an int-valued Field.
+func Int(k string, v int) Field { return slog.Int(k, v) }
+
+// Bool returns a bool-valued Field.
+func Bool(k string, v bool) Field { return slog.Bool(k, v) }
+
+// Err returns a Field keyed "error" with the given error value.
+// If err is nil the field value is the string "<nil>".
+func Err(err error) Field { return slog.Any("error", err) }
+
+// Dur returns a duration-valued Field.
+func Dur(k string, d time.Duration) Field { return slog.Duration(k, d) }

--- a/internal/obs/handler.go
+++ b/internal/obs/handler.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+// PrettyHandler is a slog.Handler that emits emoji-prefixed, human-readable
+// log lines to the console.
+//
+// Output format (no attrs):
+//
+//	Info:  "✅ 🎉 <msg>\n"   → os.Stdout
+//	Warn:  "⚠️ 🙈 <msg>\n"   → os.Stderr
+//	Error: "❌ 💩 <msg>\n"   → os.Stderr
+//
+// When key=value attributes are present they are appended after the message:
+//
+//	"✅ 🎉 <msg>  key=value …\n"
+//
+// Color ANSI codes are emitted only when the output is a TTY and the NO_COLOR
+// environment variable is not set.
+type PrettyHandler struct {
+	mu      sync.Mutex
+	out     io.Writer // primary writer (stdout for Info)
+	errOut  io.Writer // writer for Warn/Error
+	noColor bool
+	attrs   []slog.Attr
+	group   string
+}
+
+// NewPrettyHandler creates a PrettyHandler that writes Info to stdout and
+// Warn/Error to stderr.  Color is auto-detected via TTY check and NO_COLOR.
+func NewPrettyHandler() *PrettyHandler {
+	return NewPrettyHandlerWithWriters(os.Stdout, os.Stderr, !isTTY(os.Stdout) || os.Getenv("NO_COLOR") != "")
+}
+
+// NewPrettyHandlerWithWriters creates a PrettyHandler with explicit writers and
+// color setting.  out receives Info-level records; errOut receives Warn and
+// Error records.  Set noColor=true to suppress ANSI escape codes.
+//
+// This constructor is intended for testing; production code should use
+// NewPrettyHandler.
+func NewPrettyHandlerWithWriters(out, errOut io.Writer, noColor bool) *PrettyHandler {
+	return &PrettyHandler{
+		out:     out,
+		errOut:  errOut,
+		noColor: noColor,
+	}
+}
+
+// isTTY reports whether w is a character device (a real terminal).
+func isTTY(w *os.File) bool {
+	fi, err := w.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// PrettyHandler handles Info and above.
+func (h *PrettyHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= slog.LevelInfo
+}
+
+// Handle formats and writes the log record.
+func (h *PrettyHandler) Handle(_ context.Context, r slog.Record) error {
+	var prefix, color, reset string
+
+	switch {
+	case r.Level >= slog.LevelError:
+		prefix = "❌ 💩"
+		if !h.noColor {
+			color = "\x1b[31m" // red
+			reset = "\x1b[0m"
+		}
+	case r.Level >= slog.LevelWarn:
+		prefix = "⚠️ 🙈"
+		if !h.noColor {
+			color = "\x1b[33m" // yellow
+			reset = "\x1b[0m"
+		}
+	default:
+		prefix = "✅ 🎉"
+		if !h.noColor {
+			color = "\x1b[32m" // green
+			reset = "\x1b[0m"
+		}
+	}
+
+	// Collect all attrs (handler-level + record-level).
+	allAttrs := make([]slog.Attr, 0, len(h.attrs)+r.NumAttrs())
+	allAttrs = append(allAttrs, h.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		allAttrs = append(allAttrs, a)
+		return true
+	})
+
+	var buf bytes.Buffer
+	buf.WriteString(color)
+	buf.WriteString(prefix)
+	buf.WriteByte(' ')
+	buf.WriteString(r.Message)
+
+	if len(allAttrs) > 0 {
+		for _, a := range allAttrs {
+			buf.WriteString("  ")
+			if h.group != "" {
+				buf.WriteString(h.group)
+				buf.WriteByte('.')
+			}
+			buf.WriteString(a.Key)
+			buf.WriteByte('=')
+			buf.WriteString(fmt.Sprintf("%v", a.Value.Any()))
+		}
+	}
+
+	buf.WriteString(reset)
+	buf.WriteByte('\n')
+
+	// Choose the right writer based on level.
+	var w io.Writer
+	if r.Level >= slog.LevelWarn {
+		w = h.errOut
+	} else {
+		w = h.out
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// WithAttrs returns a new handler whose output includes the given attributes.
+func (h *PrettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	merged := make([]slog.Attr, len(h.attrs)+len(attrs))
+	copy(merged, h.attrs)
+	copy(merged[len(h.attrs):], attrs)
+	return &PrettyHandler{
+		out:     h.out,
+		errOut:  h.errOut,
+		noColor: h.noColor,
+		attrs:   merged,
+		group:   h.group,
+	}
+}
+
+// WithGroup returns a new handler that qualifies key names with the given group.
+func (h *PrettyHandler) WithGroup(name string) slog.Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	g := name
+	if h.group != "" {
+		g = h.group + "." + name
+	}
+	return &PrettyHandler{
+		out:     h.out,
+		errOut:  h.errOut,
+		noColor: h.noColor,
+		attrs:   h.attrs,
+		group:   g,
+	}
+}
+
+// Ensure PrettyHandler implements slog.Handler at compile time.
+var _ slog.Handler = (*PrettyHandler)(nil)

--- a/internal/obs/logger.go
+++ b/internal/obs/logger.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Logger wraps *slog.Logger to expose a Field-based API that matches the rest
+// of the obs package.
+type Logger struct {
+	l *slog.Logger
+}
+
+// newLogger creates a Logger from a slog.Logger.
+func newLogger(sl *slog.Logger) Logger { return Logger{l: sl} }
+
+// NewLoggerFromHandler creates a Logger backed by the given slog.Handler.
+// This is useful for injecting custom handlers (e.g. in tests).
+func NewLoggerFromHandler(h slog.Handler) Logger {
+	return newLogger(slog.New(h))
+}
+
+// Info logs a message at INFO level.
+func (l Logger) Info(msg string, attrs ...slog.Attr) {
+	l.l.LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)
+}
+
+// Warn logs a message at WARN level.
+func (l Logger) Warn(msg string, attrs ...slog.Attr) {
+	l.l.LogAttrs(context.Background(), slog.LevelWarn, msg, attrs...)
+}
+
+// Error logs a message at ERROR level.  err may be nil.
+func (l Logger) Error(msg string, err error, attrs ...slog.Attr) {
+	if err != nil {
+		attrs = append([]slog.Attr{Err(err)}, attrs...)
+	}
+	l.l.LogAttrs(context.Background(), slog.LevelError, msg, attrs...)
+}
+
+// With returns a new Logger that always includes the given attributes.
+func (l Logger) With(attrs ...slog.Attr) Logger {
+	args := make([]any, len(attrs))
+	for i, a := range attrs {
+		args[i] = a
+	}
+	return Logger{l: l.l.With(args...)}
+}

--- a/internal/obs/obs.go
+++ b/internal/obs/obs.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package obs provides structured observability primitives for yage: a
+// Logger, a Tracer, Phase helpers, and context propagation utilities.
+//
+// By default the global Logger uses a PrettyHandler whose output is visually
+// identical to the legacy logx helpers:
+//
+//	Info  → "✅ 🎉 <msg>\n"  on stdout
+//	Warn  → "⚠️ 🙈 <msg>\n"  on stderr
+//	Error → "❌ 💩 <msg>\n"  on stderr
+//
+// Call SetGlobal or SetTracer to swap in a different backend (e.g. an OTEL
+// exporter) without touching call sites.
+package obs
+
+import (
+	"log/slog"
+	"sync"
+)
+
+var (
+	globalMu     sync.RWMutex
+	globalLogger Logger
+	globalTracer Tracer = NoopTracer{}
+)
+
+func init() {
+	globalLogger = newLogger(slog.New(NewPrettyHandler()))
+}
+
+// Global returns the process-wide Logger.
+func Global() Logger {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalLogger
+}
+
+// SetGlobal replaces the process-wide Logger.
+func SetGlobal(l Logger) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	globalLogger = l
+}
+
+// SetTracer replaces the process-wide Tracer used by StartPhase.
+func SetTracer(t Tracer) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	globalTracer = t
+}
+
+// globalTracerVal reads the current tracer under the read lock.
+func globalTracerVal() Tracer {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalTracer
+}

--- a/internal/obs/obs_test.go
+++ b/internal/obs/obs_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/obs"
+)
+
+// --- TestPrettyHandlerFormat ---
+
+// TestPrettyHandlerFormat verifies that PrettyHandler emits the correct emoji
+// prefix for Info, Warn, and Error records, and routes Info to out and
+// Warn/Error to errOut.
+func TestPrettyHandlerFormat(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+
+	// noColor=true so assertions don't have to strip ANSI codes.
+	h := obs.NewPrettyHandlerWithWriters(&outBuf, &errBuf, true)
+	obs.SetGlobal(obs.NewLoggerFromHandler(h))
+
+	obs.Global().Info("hello world")
+	obs.Global().Warn("something off")
+	obs.Global().Error("boom", nil)
+
+	if got := outBuf.String(); !strings.HasPrefix(got, "✅ 🎉") {
+		t.Errorf("Info prefix mismatch: got %q", got)
+	}
+	if !strings.Contains(outBuf.String(), "hello world") {
+		t.Errorf("Info message missing from stdout: %q", outBuf.String())
+	}
+
+	// Warn and Error must go to errOut (stderr), not outBuf (stdout).
+	if outBuf.String() != "✅ 🎉 hello world\n" {
+		t.Errorf("stdout contains unexpected content: %q", outBuf.String())
+	}
+
+	errStr := errBuf.String()
+	lines := strings.Split(strings.TrimRight(errStr, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines on stderr, got %d: %q", len(lines), errStr)
+	}
+	if !strings.HasPrefix(lines[0], "⚠️ 🙈") {
+		t.Errorf("Warn prefix mismatch: got %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "❌ 💩") {
+		t.Errorf("Error prefix mismatch: got %q", lines[1])
+	}
+}
+
+// --- TestNoopTracerAllocsZero ---
+
+// TestNoopTracerAllocsZero verifies that NoopTracer.Start causes no heap
+// allocations beyond the baseline.
+func TestNoopTracerAllocsZero(t *testing.T) {
+	tr := obs.NoopTracer{}
+	ctx := context.Background()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_, sp := tr.Start(ctx, "test")
+		sp.End()
+	})
+	if allocs > 0 {
+		t.Errorf("NoopTracer.Start allocated %v times, want 0", allocs)
+	}
+}
+
+// --- TestPhaseEndsClean ---
+
+// TestPhaseEndsClean verifies that StartPhase + End completes without panic.
+func TestPhaseEndsClean(t *testing.T) {
+	ctx := context.Background()
+	ctx, ph := obs.StartPhase(ctx, "test-phase", obs.Str("key", "val"))
+	_ = ctx
+	ph.End() // must not panic
+}
+
+// TestPhaseFailClean verifies that StartPhase + Fail completes without panic.
+func TestPhaseFailClean(t *testing.T) {
+	ctx := context.Background()
+	_, ph := obs.StartPhase(ctx, "failing-phase")
+	ph.Fail(io.ErrUnexpectedEOF) // must not panic
+}
+
+// --- TestRunIDPropagation ---
+
+// TestRunIDPropagation verifies that WithRunID and RunIDFromCtx round-trip.
+func TestRunIDPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	// No run ID set yet.
+	if got := obs.RunIDFromCtx(ctx); got != "" {
+		t.Errorf("expected empty run ID, got %q", got)
+	}
+
+	id := obs.NewRunID()
+	if id == "" {
+		t.Fatal("NewRunID returned empty string")
+	}
+
+	ctx = obs.WithRunID(ctx, id)
+	if got := obs.RunIDFromCtx(ctx); got != id {
+		t.Errorf("RunIDFromCtx = %q, want %q", got, id)
+	}
+}
+
+// TestNewRunIDFormat verifies the UUID v4 format.
+func TestNewRunIDFormat(t *testing.T) {
+	id := obs.NewRunID()
+	parts := strings.Split(id, "-")
+	if len(parts) != 5 {
+		t.Fatalf("expected 5 hyphen-separated parts, got %d in %q", len(parts), id)
+	}
+	lengths := []int{8, 4, 4, 4, 12}
+	for i, p := range parts {
+		if len(p) != lengths[i] {
+			t.Errorf("part[%d] len = %d, want %d (id=%q)", i, len(p), lengths[i], id)
+		}
+	}
+	// Version nibble must be '4'.
+	if id[14] != '4' {
+		t.Errorf("version nibble = %c, want '4' (id=%q)", id[14], id)
+	}
+}

--- a/internal/obs/phase.go
+++ b/internal/obs/phase.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import (
+	"context"
+	"time"
+)
+
+// Phase represents a named, timed phase of work within a run.  It captures a
+// Logger, a Span, and a start time so that callers can report duration and
+// outcome with a single method call.
+//
+// Note: the constructor is named StartPhase (not Phase) to avoid a name
+// collision between the type and the constructor function in the same package.
+type Phase struct {
+	name  string
+	start time.Time
+	span  Span
+	ctx   context.Context
+	log   Logger
+}
+
+// StartPhase begins a named phase: it logs an Info entry, opens a span via the
+// global Tracer, and returns a child context that carries the span plus the
+// *Phase value.
+//
+// Callers must close the phase with either End or Fail:
+//
+//	ctx, ph := obs.StartPhase(ctx, "bootstrap", obs.Str("env", env))
+//	if err := doWork(ctx); err != nil {
+//	    ph.Fail(err)
+//	    return err
+//	}
+//	ph.End()
+func StartPhase(ctx context.Context, name string, attrs ...Field) (context.Context, *Phase) {
+	log := FromCtx(ctx)
+	log.Info(name, attrs...)
+
+	childCtx, span := globalTracerVal().Start(ctx, name, attrs...)
+
+	return childCtx, &Phase{
+		name:  name,
+		start: time.Now(),
+		span:  span,
+		ctx:   childCtx,
+		log:   log,
+	}
+}
+
+// End marks the phase as successfully complete.  It logs elapsed time at Info
+// and closes the underlying span.
+func (p *Phase) End() {
+	elapsed := time.Since(p.start)
+	p.log.Info(p.name+" done", Dur("elapsed", elapsed))
+	p.span.End()
+}
+
+// Fail marks the phase as failed.  It logs the error at Error level, records
+// the error on the span, and closes the span.
+func (p *Phase) Fail(err error) {
+	elapsed := time.Since(p.start)
+	p.log.Error(p.name+" failed", err, Dur("elapsed", elapsed))
+	p.span.SetErr(err)
+	p.span.End()
+}

--- a/internal/obs/run.go
+++ b/internal/obs/run.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// NewRunID returns a new random UUID v4 string formatted as
+// "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".
+func NewRunID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is extremely unlikely; return a deterministic
+		// placeholder so callers always get a non-empty string.
+		return "00000000-0000-4000-8000-000000000000"
+	}
+	// Set version (4) and variant bits (RFC 4122).
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+
+	return fmt.Sprintf(
+		"%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:],
+	)
+}

--- a/internal/obs/tracer.go
+++ b/internal/obs/tracer.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package obs
+
+import "context"
+
+// Span represents a single unit of work within a trace.
+type Span interface {
+	// End marks the span as completed successfully.
+	End()
+	// SetErr records an error on the span.
+	SetErr(error)
+	// Set attaches additional fields to the span.
+	Set(...Field)
+}
+
+// Tracer creates and manages Spans.
+type Tracer interface {
+	// Start opens a new span as a child of ctx. It returns a child context
+	// that carries the span plus the span itself.
+	Start(ctx context.Context, name string, attrs ...Field) (context.Context, Span)
+}
+
+// NoopSpan is a Span implementation that does nothing and allocates nothing.
+type NoopSpan struct{}
+
+func (NoopSpan) End()        {}
+func (NoopSpan) SetErr(error) {}
+func (NoopSpan) Set(...Field) {}
+
+// noopSpanVal is a package-level value used to return NoopSpan as a Span
+// interface without an allocation on the heap.
+var noopSpanVal Span = NoopSpan{}
+
+// NoopTracer is a Tracer that creates NoopSpans and does not modify the
+// context. It is the default tracer until SetTracer is called.
+type NoopTracer struct{}
+
+// Start returns the parent context unchanged and a zero-allocation NoopSpan.
+func (NoopTracer) Start(ctx context.Context, _ string, _ ...Field) (context.Context, Span) {
+	return ctx, noopSpanVal
+}

--- a/internal/ui/logx/logx.go
+++ b/internal/ui/logx/logx.go
@@ -4,35 +4,42 @@
 // Package logx provides log/warn/die helpers with emoji-prefixed
 // output that yage uses for all user-facing console messages.
 //
-// Output shapes:
+// Output shapes (produced by obs.PrettyHandler):
 //
 //	Log  -> "✅ 🎉 <msg>"  (stdout)
 //	Warn -> "⚠️ 🙈 <msg>"  (stderr)
+//	Err  -> "❌ 💩 <msg>"  (stderr)
 //	Die  -> "❌ 💩 <msg>"  (stderr, then os.Exit(1))
+//
+// The emoji prefixes are injected by obs.PrettyHandler — callers must not
+// add them manually.  All output is routed through obs.Global() so that the
+// backend can be swapped without changing call sites.
 package logx
 
 import (
 	"fmt"
 	"os"
+
+	"github.com/lpasquali/yage/internal/obs"
 )
 
 // Log prints a success message to stdout.
 func Log(format string, a ...any) {
-	fmt.Printf("✅ 🎉 %s\n", fmt.Sprintf(format, a...))
+	obs.Global().Info(fmt.Sprintf(format, a...))
 }
 
 // Warn prints a warning message to stderr.
 func Warn(format string, a ...any) {
-	fmt.Fprintf(os.Stderr, "⚠️ 🙈 %s\n", fmt.Sprintf(format, a...))
+	obs.Global().Warn(fmt.Sprintf(format, a...))
 }
 
 // Err prints an error message to stderr without exiting.
 func Err(format string, a ...any) {
-	fmt.Fprintf(os.Stderr, "❌ 💩 %s\n", fmt.Sprintf(format, a...))
+	obs.Global().Error(fmt.Sprintf(format, a...), nil)
 }
 
 // Die prints an error and exits with status 1.
 func Die(format string, a ...any) {
-	Err(format, a...)
+	obs.Global().Error(fmt.Sprintf(format, a...), nil)
 	os.Exit(1)
 }


### PR DESCRIPTION
## Summary

Closes #21, closes #22. Part of epic #16 (observability stack).

### `internal/obs` package (#21)

9 new files:
- `obs.go` — `Global()`, `SetGlobal()`, `SetTracer()` singletons; `init()` wires `PrettyHandler`
- `logger.go` — `Logger` wrapping `*slog.Logger`; `Info/Warn/Error/With`
- `context.go` — `WithLogger`/`FromCtx`; `WithRunID`/`RunIDFromCtx`
- `tracer.go` — `Span` + `Tracer` interfaces; `NoopTracer`/`NoopSpan` (zero allocs verified)
- `phase.go` — `Phase` type; `StartPhase(ctx, name, attrs...)` → `(context.Context, *Phase)`; `End()`/`Fail(err)`
- `fields.go` — `Field = slog.Attr`; `Str`, `Int`, `Bool`, `Err`, `Dur`
- `handler.go` — `PrettyHandler`: emoji prefix per level, TTY+`NO_COLOR` color detection; Info→stdout, Warn/Error→stderr
- `run.go` — `NewRunID()` UUID v4 from `crypto/rand`
- `obs_test.go` — 6 tests covering format, zero-alloc noop, phase lifecycle, run-ID propagation

### logx shim (#22)

`internal/ui/logx/logx.go` — `Log/Warn/Err/Die` now delegate to `obs.Global()`. Zero call-site changes across 577 uses.

**One observable behavior delta:** `PrettyHandler` emits ANSI color when stdout is a TTY and `NO_COLOR` is unset. Previous `fmt.Printf` had no color. Disable with `NO_COLOR=1`.

## Verification

- `go build ./...` clean
- `go test ./...` green (38 packages + 6 new obs tests)
- `TestNoopTracerAllocsZero` passes (zero allocs confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)