### PR TITLE
feat(xapiri): capacity-tests, overcommit prompt, kindsync (#9 #11 #12)

### DIFF
--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -88,10 +88,11 @@ const (
 // ─── toggle (bool) slot indices ──────────────────────────────────────────────
 
 const (
-	toiQueue    = 0
-	toiObjStore = 1
-	toiCache    = 2
-	toiCount    = 3
+	toiQueue      = 0
+	toiObjStore   = 1
+	toiCache      = 2
+	toiOvercommit = 3 // on-prem only: allow resource overcommit
+	toiCount      = 4
 )
 
 // ─── logical focus IDs (tab order) ───────────────────────────────────────────
@@ -117,10 +118,11 @@ const (
 	focCacheCPU           // 17
 	focCacheMem           // 18
 	focBootstrap          // 19
-	focDCLoc              // 20
-	focBudget             // 21
-	focHeadroom           // 22
-	focCount              // 23 — must be last
+	focOvercommit         // 20
+	focDCLoc              // 21
+	focBudget             // 22
+	focHeadroom           // 23
+	focCount              // 24 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -168,6 +170,7 @@ var dashFields = []fieldMeta{
 	{fkText, tiCacheMem, "  cache mem (Mi)", "", true},
 	// ── Bootstrap (on-prem only) ──────────────────────────────────────
 	{fkSelect, siBootstrap, "bootstrap mode", "Bootstrap", false},
+	{fkToggle, toiOvercommit, "allow overcommit", "", false},
 	// ── Geo + Budget (cloud only) ─────────────────────────────────────
 	{fkText, tiDCLoc, "data-center loc", "Geo", false},
 	{fkText, tiBudget, "budget USD/mo", "Budget", false},
@@ -312,6 +315,7 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.toggles[toiQueue] = s.workload.HasQueue
 	m.toggles[toiObjStore] = s.workload.HasObjStore
 	m.toggles[toiCache] = s.workload.HasCache
+	m.toggles[toiOvercommit] = cfg.Capacity.AllowOvercommit
 
 	// Focus the first visible input.
 	cmd := m.textInputs[tiKindName].Focus()
@@ -340,7 +344,7 @@ func (m *dashModel) isHidden(fid int) bool {
 		focHasQueue, focHasObjStore, focHasCache,
 		focDCLoc, focBudget, focHeadroom:
 		return !isCloud
-	case focBootstrap:
+	case focBootstrap, focOvercommit:
 		return isCloud // only visible on on-prem
 	case focQueueCPU, focQueueMem, focQueueVol:
 		return !isCloud || !m.toggles[toiQueue]
@@ -577,6 +581,7 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 	}
 
 	snap.BootstrapMode = m.selects[siBootstrap].value()
+	snap.Capacity.AllowOvercommit = m.toggles[toiOvercommit]
 
 	snap.Cost.Currency.DataCenterLocation = strings.ToUpper(strings.TrimSpace(m.textInputs[tiDCLoc].Value()))
 
@@ -662,6 +667,7 @@ func (m *dashModel) flushToCfg() {
 	m.cfg.CacheCPUMillicoresOverride = snap.CacheCPUMillicoresOverride
 	m.cfg.CacheMemoryMiBOverride = snap.CacheMemoryMiBOverride
 	m.cfg.BootstrapMode = snap.BootstrapMode
+	m.cfg.Capacity.AllowOvercommit = snap.Capacity.AllowOvercommit
 
 	// Derive s.fork / s.env / s.resil for the rest of the walkthrough.
 	if m.selects[siMode].value() == "on-prem" {

--- a/internal/ui/xapiri/onprem.go
+++ b/internal/ui/xapiri/onprem.go
@@ -119,9 +119,15 @@ func (s *state) step5_onprem_capacity() error {
 		s.r.info("✓ comfortable on the configured host pool.")
 		return nil
 	case FeasibilityTight:
-		s.r.info("⚠ tight on the configured host pool — proceeding anyway.")
+		s.r.info("⚠ tight on the configured host pool.")
 		if err != nil {
 			s.r.info("  detail: %v", err)
+		}
+		s.r.info("  Resource overcommit lets VMs exceed the soft capacity budget;")
+		s.r.info("  the hard ceiling (memory/disk) still applies.")
+		if s.r.promptYesNo("allow resource overcommit?", s.cfg.Capacity.AllowOvercommit) {
+			s.cfg.Capacity.AllowOvercommit = true
+			s.r.info("  ✓ overcommit enabled (equivalent to --allow-resource-overcommit)")
 		}
 		return nil
 	case FeasibilityInfeasible:

--- a/internal/ui/xapiri/shared.go
+++ b/internal/ui/xapiri/shared.go
@@ -554,6 +554,9 @@ func (s *state) step7_review() error {
 	pw.Bullet("provider:       %s", s.cfg.InfraProvider)
 	if s.fork == forkOnPrem {
 		pw.Bullet("bootstrap mode: %s", s.cfg.BootstrapMode)
+		if s.cfg.Capacity.AllowOvercommit {
+			pw.Bullet("overcommit:     allowed")
+		}
 	}
 	pw.Bullet("workload apps:  %s", formatAppBuckets(s.workload.Apps))
 	pw.Bullet("database GB:    %d", s.workload.DBGB)


### PR DESCRIPTION
## Summary

- **#11**: When the on-prem capacity check returns `FeasibilityTight`, offer an `allow resource overcommit?` prompt and stamp `cfg.Capacity.AllowOvercommit = true` so the orchestrator can proceed with overcommit enabled
- **#7** (already in main via #42): bootstrap-mode selection is referenced in the review step via the shared tail
- Closes #11

## Changes

- `internal/ui/xapiri/onprem.go`: `step5_onprem_capacity` prompts for overcommit on tight verdict; `stepBootstrapMode` in same commit
- `internal/ui/xapiri/shared.go`: review step 7 emits bootstrap mode + overcommit status for on-prem fork
- `internal/ui/xapiri/dashboard.go`: `siBootstrap` select + `toiOvercommit` toggle slots; on-prem-only via `isHidden`

## Test plan

- [ ] `make build` compiles clean
- [ ] `make test` passes
- [ ] Run `YAGE_XAPIRI_SKIP_KIND=1 ./bin/yage --xapiri`, on-prem fork, set cluster to tight → overcommit prompt appears
- [ ] Review step shows `bootstrap mode: k3s` and `overcommit: allowed` for on-prem

🤖 Generated with [Claude Code](https://claude.com/claude-code)