### PR TITLE
feat(provider): K3sTemplate + state for DigitalOcean, Linode, OCI (#18)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -316,28 +316,43 @@ type HetznerConfig struct {
 }
 
 // DigitalOceanConfig is the per-provider DigitalOcean (CAPDO) configuration.
-// API token comes from env DIGITALOCEAN_TOKEN — not from cfg.
+// API token comes from env DIGITALOCEAN_TOKEN — not from cfg (same as Hetzner
+// reading HCLOUD_TOKEN directly from the CAPI controller pod env).
 type DigitalOceanConfig struct {
 	Region           string
 	ControlPlaneSize string // s-2vcpu-4gb, s-4vcpu-8gb, ...
 	NodeSize         string
+	// VPCUUID optionally pins all droplets to a specific VPC. Empty = use
+	// the region default VPC (CAPDO's behaviour when the field is absent).
+	VPCUUID     string
+	OverheadTier string // "dev" | "prod" | "enterprise" — mirrors AWS/Azure
 }
 
 // LinodeConfig is the per-provider Linode/Akamai (CAPL) configuration.
-// Catalog is auth-free; provisioning needs LINODE_TOKEN.
+// Catalog is auth-free; provisioning needs LINODE_TOKEN from env.
 type LinodeConfig struct {
 	Region           string
 	ControlPlaneType string // g6-standard-2, g6-standard-4, ...
 	NodeType         string
+	OverheadTier     string // "dev" | "prod" | "enterprise"
 }
 
 // OCIConfig is the per-provider Oracle Cloud Infrastructure (CAPOCI)
 // configuration. Cost estimator JSON is auth-free; provisioning needs
-// OCI API key (not in cfg).
+// OCI API key credentials from env.
 type OCIConfig struct {
 	Region            string
 	ControlPlaneShape string // VM.Standard.E4.Flex, ...
 	NodeShape         string
+	// Provisioning-time fields — not secrets. OCI private key stays on-disk;
+	// only its path is tracked here (never the key material itself).
+	TenancyOCID      string
+	UserOCID         string
+	Fingerprint      string
+	CompartmentOCID  string
+	ImageID          string
+	PrivateKeyPath   string
+	OverheadTier     string // "dev" | "prod" | "enterprise"
 }
 
 // IBMCloudConfig is the per-provider IBM Cloud (CAPIBM) configuration.
@@ -533,6 +548,9 @@ type CostCredentials struct {
 	HetznerToken string
 	// DigitalOcean (env: YAGE_DO_TOKEN / DIGITALOCEAN_TOKEN).
 	DigitalOceanToken string
+	// Linode/Akamai (env: YAGE_LINODE_TOKEN / LINODE_TOKEN).
+	// Catalog calls are auth-free; token is only needed for provisioning.
+	LinodeToken string
 	// IBM Cloud (env: YAGE_IBMCLOUD_API_KEY / IBMCLOUD_API_KEY).
 	IBMCloudAPIKey string
 }
@@ -1176,6 +1194,10 @@ func Load() *Config {
 		os.Getenv("YAGE_DO_TOKEN"),
 		os.Getenv("DIGITALOCEAN_TOKEN"),
 	)
+	c.Cost.Credentials.LinodeToken = firstNonEmpty(
+		os.Getenv("YAGE_LINODE_TOKEN"),
+		os.Getenv("LINODE_TOKEN"),
+	)
 	c.Cost.Credentials.IBMCloudAPIKey = firstNonEmpty(
 		os.Getenv("YAGE_IBMCLOUD_API_KEY"),
 		os.Getenv("IBMCLOUD_API_KEY"),
@@ -1284,12 +1306,22 @@ func Load() *Config {
 	c.Providers.DigitalOcean.Region = getenv("DIGITALOCEAN_REGION", "nyc3")
 	c.Providers.DigitalOcean.ControlPlaneSize = getenv("DIGITALOCEAN_CONTROL_PLANE_SIZE", "s-2vcpu-4gb")
 	c.Providers.DigitalOcean.NodeSize = getenv("DIGITALOCEAN_NODE_SIZE", "s-2vcpu-4gb")
+	c.Providers.DigitalOcean.VPCUUID = getenv("DIGITALOCEAN_VPC_UUID", "")
+	c.Providers.DigitalOcean.OverheadTier = getenv("DIGITALOCEAN_OVERHEAD_TIER", "prod")
 	c.Providers.Linode.Region = getenv("LINODE_REGION", "us-east")
 	c.Providers.Linode.ControlPlaneType = getenv("LINODE_CONTROL_PLANE_TYPE", "g6-standard-2")
 	c.Providers.Linode.NodeType = getenv("LINODE_NODE_TYPE", "g6-standard-2")
+	c.Providers.Linode.OverheadTier = getenv("LINODE_OVERHEAD_TIER", "prod")
 	c.Providers.OCI.Region = getenv("OCI_REGION", "us-ashburn-1")
 	c.Providers.OCI.ControlPlaneShape = getenv("OCI_CONTROL_PLANE_SHAPE", "VM.Standard.E4.Flex")
 	c.Providers.OCI.NodeShape = getenv("OCI_NODE_SHAPE", "VM.Standard.E4.Flex")
+	c.Providers.OCI.TenancyOCID = getenv("OCI_TENANCY_OCID", "")
+	c.Providers.OCI.UserOCID = getenv("OCI_USER_OCID", "")
+	c.Providers.OCI.Fingerprint = getenv("OCI_FINGERPRINT", "")
+	c.Providers.OCI.CompartmentOCID = getenv("OCI_COMPARTMENT_OCID", "")
+	c.Providers.OCI.ImageID = getenv("OCI_IMAGE_ID", "")
+	c.Providers.OCI.PrivateKeyPath = getenv("OCI_PRIVATE_KEY_PATH", "")
+	c.Providers.OCI.OverheadTier = getenv("OCI_OVERHEAD_TIER", "prod")
 	c.Providers.IBMCloud.Region = getenv("IBMCLOUD_REGION", "us-south")
 	c.Providers.IBMCloud.ControlPlaneProfile = getenv("IBMCLOUD_CONTROL_PLANE_PROFILE", "bx2-2x8")
 	c.Providers.IBMCloud.NodeProfile = getenv("IBMCLOUD_NODE_PROFILE", "bx2-2x8")

--- a/internal/provider/digitalocean/digitalocean.go
+++ b/internal/provider/digitalocean/digitalocean.go
@@ -5,9 +5,15 @@
 // for the Cluster API DigitalOcean infrastructure provider (CAPDO —
 // kubernetes-sigs/cluster-api-provider-digitalocean).
 //
-// Status: cost-only stub. clusterctl init args + a working live
-// pricing fetcher are wired; K3sTemplate / PatchManifest / Ensure*
-// return ErrNotApplicable until the per-CRD k3s flavor is built.
+// What's wired:
+//
+//   - K3sTemplate: DOCluster + DOMachineTemplate with ${DO_*} placeholders.
+//   - KindSyncFields / AbsorbConfigYAML / TemplateVars: state.go.
+//   - EstimateMonthlyCostUSD: in-binary live /v2/sizes fetcher (cost.go).
+//
+// DIGITALOCEAN_TOKEN is consumed directly by the CAPDO controller pod
+// from its env/secret and is NOT substituted into the manifest — same
+// pattern as HCLOUD_TOKEN on Hetzner.
 package digitalocean
 
 import (
@@ -26,4 +32,136 @@ func (p *Provider) InfraProviderName() string { return "digitalocean" }
 
 func (p *Provider) ClusterctlInitArgs(cfg *config.Config) []string {
 	return []string{"--infrastructure", "digitalocean"}
+}
+
+// k3sTemplate is the DigitalOcean-flavored K3s manifest.
+// CRD API group: infrastructure.cluster.x-k8s.io/v1beta1 (CAPDO v0.x).
+// Placeholders: DO_REGION, DO_CP_SIZE, DO_WORKER_SIZE, DO_VPC_UUID,
+// WORKLOAD_CLUSTER_NAME (universal) — no token placeholder; the
+// CAPDO controller reads DIGITALOCEAN_TOKEN from its own Secret/env.
+//
+// DO_VPC_UUID may be empty when the user hasn't set DIGITALOCEAN_VPC_UUID;
+// CAPDO falls back to the region default VPC in that case. The field is
+// included in the template for clusters where it IS set.
+const k3sTemplate = `apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    services:
+      cidrBlocks: ["10.96.0.0/12"]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: KThreesControlPlane
+    name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DOCluster
+    name: ${WORKLOAD_CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DOCluster
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  region: ${DO_REGION}
+  network:
+    vpc:
+      uuid: ${DO_VPC_UUID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KThreesControlPlane
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}+k3s1
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DOMachineTemplate
+      name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  kthreesConfigSpec:
+    serverConfig:
+      disableComponents: [servicelb, traefik]
+    agentConfig:
+      airGapped: false
+      kubeletArgs:
+        - "--cloud-provider=external"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DOMachineTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      size: ${DO_CP_SIZE}
+      region: ${DO_REGION}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${WORKLOAD_CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: {}
+  template:
+    spec:
+      clusterName: ${WORKLOAD_CLUSTER_NAME}
+      version: ${KUBERNETES_VERSION}+k3s1
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KThreesConfigTemplate
+          name: ${WORKLOAD_CLUSTER_NAME}-md-0
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DOMachineTemplate
+        name: ${WORKLOAD_CLUSTER_NAME}-md-0
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KThreesConfigTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      agentConfig:
+        airGapped: false
+        kubeletArgs:
+          - "--cloud-provider=external"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DOMachineTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      size: ${DO_WORKER_SIZE}
+      region: ${DO_REGION}
+`
+
+// K3sTemplate returns the DigitalOcean K3s manifest template.
+func (p *Provider) K3sTemplate(cfg *config.Config, mgmt bool) (string, error) {
+	return k3sTemplate, nil
+}
+
+// PatchManifest is a no-op for DigitalOcean today. Sizing is driven
+// entirely by DO_CP_SIZE / DO_WORKER_SIZE in TemplateVars.
+func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt bool) error {
+	return nil
 }

--- a/internal/provider/digitalocean/state.go
+++ b/internal/provider/digitalocean/state.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package digitalocean
+
+// State-handoff hooks for DigitalOcean Cloud (CAPDO).
+//
+// See docs/abstraction-plan.md §11 + §14.D.
+// DIGITALOCEAN_TOKEN deliberately stays in env — it's operator state,
+// not yage state (same precedent as HCLOUD_TOKEN / AWS_ACCESS_KEY_ID).
+
+import (
+	"github.com/lpasquali/yage/internal/config"
+)
+
+// KindSyncFields persists the DigitalOcean-specific configuration the
+// next yage run needs to reconstruct the active cluster. The DO API
+// token stays in env and is NOT round-tripped here.
+func (p *Provider) KindSyncFields(cfg *config.Config) map[string]string {
+	out := map[string]string{}
+	add := func(k, v string) {
+		if v != "" {
+			out[k] = v
+		}
+	}
+	add("region", cfg.Providers.DigitalOcean.Region)
+	add("control_plane_size", cfg.Providers.DigitalOcean.ControlPlaneSize)
+	add("node_size", cfg.Providers.DigitalOcean.NodeSize)
+	add("vpc_uuid", cfg.Providers.DigitalOcean.VPCUUID)
+	add("overhead_tier", cfg.Providers.DigitalOcean.OverheadTier)
+	return out
+}
+
+// TemplateVars returns the DigitalOcean-specific clusterctl manifest
+// substitution map. The DIGITALOCEAN_TOKEN env var is consumed directly
+// by the CAPDO controller pod — not substituted into the manifest.
+func (p *Provider) TemplateVars(cfg *config.Config) map[string]string {
+	return map[string]string{
+		"DO_REGION":      orDefault(cfg.Providers.DigitalOcean.Region, "nyc3"),
+		"DO_CP_SIZE":     orDefault(cfg.Providers.DigitalOcean.ControlPlaneSize, "s-2vcpu-4gb"),
+		"DO_WORKER_SIZE": orDefault(cfg.Providers.DigitalOcean.NodeSize, "s-2vcpu-4gb"),
+		"DO_VPC_UUID":    cfg.Providers.DigitalOcean.VPCUUID,
+	}
+}
+
+// AbsorbConfigYAML is the reverse of KindSyncFields: reads the
+// lowercase bare-key map the yage-system/bootstrap-config Secret
+// schema writes (orchestrator strips the "digitalocean." prefix before
+// dispatching) and fills empty cfg fields with non-empty values.
+func (p *Provider) AbsorbConfigYAML(cfg *config.Config, kv map[string]string) bool {
+	assigned := false
+	assign := func(cur *string, v string) {
+		if *cur == "" && v != "" {
+			*cur = v
+			assigned = true
+		}
+	}
+	for k, v := range kv {
+		switch k {
+		case "region":
+			assign(&cfg.Providers.DigitalOcean.Region, v)
+		case "control_plane_size":
+			assign(&cfg.Providers.DigitalOcean.ControlPlaneSize, v)
+		case "node_size":
+			assign(&cfg.Providers.DigitalOcean.NodeSize, v)
+		case "vpc_uuid":
+			assign(&cfg.Providers.DigitalOcean.VPCUUID, v)
+		case "overhead_tier":
+			assign(&cfg.Providers.DigitalOcean.OverheadTier, v)
+		}
+	}
+	return assigned
+}

--- a/internal/provider/linode/linode.go
+++ b/internal/provider/linode/linode.go
@@ -5,8 +5,15 @@
 // the Cluster API Linode/Akamai infrastructure provider (CAPL —
 // linode/cluster-api-provider-linode).
 //
-// Status: cost-only stub (live pricing fetcher + clusterctl init).
-// Catalog calls are auth-free; provisioning needs LINODE_TOKEN.
+// What's wired:
+//
+//   - K3sTemplate: LinodeCluster + LinodeMachineTemplate with ${LINODE_*} placeholders.
+//   - KindSyncFields / AbsorbConfigYAML / TemplateVars: state.go.
+//   - EstimateMonthlyCostUSD: live Linode catalog fetcher (cost.go).
+//
+// LINODE_TOKEN is consumed directly by the CAPL controller pod
+// from its env/Secret and is NOT substituted into the manifest — same
+// pattern as HCLOUD_TOKEN on Hetzner.
 package linode
 
 import (
@@ -25,4 +32,129 @@ func (p *Provider) InfraProviderName() string { return "linode" }
 
 func (p *Provider) ClusterctlInitArgs(cfg *config.Config) []string {
 	return []string{"--infrastructure", "linode"}
+}
+
+// k3sTemplate is the Linode/Akamai-flavored K3s manifest.
+// CRD API group: infrastructure.cluster.x-k8s.io/v1alpha2 (CAPL).
+// Placeholders: LINODE_REGION, LINODE_CP_TYPE, LINODE_WORKER_TYPE,
+// WORKLOAD_CLUSTER_NAME (universal) — no token placeholder; the CAPL
+// controller reads LINODE_TOKEN from its own Secret/env.
+const k3sTemplate = `apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    services:
+      cidrBlocks: ["10.96.0.0/12"]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: KThreesControlPlane
+    name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: LinodeCluster
+    name: ${WORKLOAD_CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeCluster
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  region: ${LINODE_REGION}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KThreesControlPlane
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}+k3s1
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeMachineTemplate
+      name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  kthreesConfigSpec:
+    serverConfig:
+      disableComponents: [servicelb, traefik]
+    agentConfig:
+      airGapped: false
+      kubeletArgs:
+        - "--cloud-provider=external"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachineTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      type: ${LINODE_CP_TYPE}
+      region: ${LINODE_REGION}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${WORKLOAD_CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: {}
+  template:
+    spec:
+      clusterName: ${WORKLOAD_CLUSTER_NAME}
+      version: ${KUBERNETES_VERSION}+k3s1
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KThreesConfigTemplate
+          name: ${WORKLOAD_CLUSTER_NAME}-md-0
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: LinodeMachineTemplate
+        name: ${WORKLOAD_CLUSTER_NAME}-md-0
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KThreesConfigTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      agentConfig:
+        airGapped: false
+        kubeletArgs:
+          - "--cloud-provider=external"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachineTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      type: ${LINODE_WORKER_TYPE}
+      region: ${LINODE_REGION}
+`
+
+// K3sTemplate returns the Linode K3s manifest template.
+func (p *Provider) K3sTemplate(cfg *config.Config, mgmt bool) (string, error) {
+	return k3sTemplate, nil
+}
+
+// PatchManifest is a no-op for Linode today. Sizing is driven
+// entirely by LINODE_CP_TYPE / LINODE_WORKER_TYPE in TemplateVars.
+func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt bool) error {
+	return nil
 }

--- a/internal/provider/linode/state.go
+++ b/internal/provider/linode/state.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package linode
+
+// State-handoff hooks for Linode/Akamai Cloud (CAPL).
+//
+// See docs/abstraction-plan.md §11 + §14.D.
+// LINODE_TOKEN deliberately stays in env — it's operator state, not yage
+// state (same precedent as HCLOUD_TOKEN / DIGITALOCEAN_TOKEN).
+
+import (
+	"github.com/lpasquali/yage/internal/config"
+)
+
+// KindSyncFields persists the Linode-specific configuration the
+// next yage run needs to reconstruct the active cluster. The Linode
+// API token stays in env and is NOT round-tripped here.
+func (p *Provider) KindSyncFields(cfg *config.Config) map[string]string {
+	out := map[string]string{}
+	add := func(k, v string) {
+		if v != "" {
+			out[k] = v
+		}
+	}
+	add("region", cfg.Providers.Linode.Region)
+	add("control_plane_type", cfg.Providers.Linode.ControlPlaneType)
+	add("node_type", cfg.Providers.Linode.NodeType)
+	add("overhead_tier", cfg.Providers.Linode.OverheadTier)
+	return out
+}
+
+// TemplateVars returns the Linode-specific clusterctl manifest
+// substitution map. LINODE_TOKEN is consumed directly by the CAPL
+// controller pod from its env/Secret — not substituted into the manifest.
+func (p *Provider) TemplateVars(cfg *config.Config) map[string]string {
+	return map[string]string{
+		"LINODE_REGION":      orDefault(cfg.Providers.Linode.Region, "us-east"),
+		"LINODE_CP_TYPE":     orDefault(cfg.Providers.Linode.ControlPlaneType, "g6-standard-2"),
+		"LINODE_WORKER_TYPE": orDefault(cfg.Providers.Linode.NodeType, "g6-standard-2"),
+	}
+}
+
+// AbsorbConfigYAML is the reverse of KindSyncFields: reads the
+// lowercase bare-key map the yage-system/bootstrap-config Secret
+// schema writes (orchestrator strips the "linode." prefix before
+// dispatching) and fills empty cfg fields with non-empty values.
+func (p *Provider) AbsorbConfigYAML(cfg *config.Config, kv map[string]string) bool {
+	assigned := false
+	assign := func(cur *string, v string) {
+		if *cur == "" && v != "" {
+			*cur = v
+			assigned = true
+		}
+	}
+	for k, v := range kv {
+		switch k {
+		case "region":
+			assign(&cfg.Providers.Linode.Region, v)
+		case "control_plane_type":
+			assign(&cfg.Providers.Linode.ControlPlaneType, v)
+		case "node_type":
+			assign(&cfg.Providers.Linode.NodeType, v)
+		case "overhead_tier":
+			assign(&cfg.Providers.Linode.OverheadTier, v)
+		}
+	}
+	return assigned
+}

--- a/internal/provider/oci/oci.go
+++ b/internal/provider/oci/oci.go
@@ -5,8 +5,15 @@
 // Cluster API Oracle Cloud Infrastructure provider (CAPOCI —
 // oracle/cluster-api-provider-oci).
 //
-// Status: cost-only stub. OCI publishes an auth-free public price
-// list JSON; provisioning needs an OCI API key + tenancy/user OCID.
+// What's wired:
+//
+//   - K3sTemplate: OCICluster + OCIMachineTemplate with ${OCI_*} placeholders.
+//   - KindSyncFields / AbsorbConfigYAML / TemplateVars: state.go.
+//   - EstimateMonthlyCostUSD: live OCI public price-list fetcher (cost.go).
+//
+// OCI authentication uses a private key file. The CAPOCI controller
+// reads the key via a Kubernetes Secret it is bootstrapped with;
+// yage only stores the on-disk path reference (never the key itself).
 package oci
 
 import (
@@ -25,4 +32,134 @@ func (p *Provider) InfraProviderName() string { return "oci" }
 
 func (p *Provider) ClusterctlInitArgs(cfg *config.Config) []string {
 	return []string{"--infrastructure", "oci"}
+}
+
+// k3sTemplate is the OCI-flavored K3s manifest.
+// CRD API group: infrastructure.cluster.x-k8s.io/v1beta2 (CAPOCI).
+// Placeholders: OCI_REGION, OCI_CP_SHAPE, OCI_WORKER_SHAPE,
+// OCI_TENANCY_OCID, OCI_USER_OCID, OCI_COMPARTMENT_OCID, OCI_IMAGE_ID,
+// WORKLOAD_CLUSTER_NAME (universal).
+// OCI private key is supplied out-of-band via a Secret bootstrapped
+// into the CAPOCI controller namespace — not substituted here.
+const k3sTemplate = `apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    services:
+      cidrBlocks: ["10.96.0.0/12"]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: KThreesControlPlane
+    name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: OCICluster
+    name: ${WORKLOAD_CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCICluster
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  compartmentId: ${OCI_COMPARTMENT_OCID}
+  region: ${OCI_REGION}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KThreesControlPlane
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}+k3s1
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: OCIMachineTemplate
+      name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  kthreesConfigSpec:
+    serverConfig:
+      disableComponents: [servicelb, traefik]
+    agentConfig:
+      airGapped: false
+      kubeletArgs:
+        - "--cloud-provider=external"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCIMachineTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-control-plane
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      compartmentId: ${OCI_COMPARTMENT_OCID}
+      imageId: ${OCI_IMAGE_ID}
+      shape: ${OCI_CP_SHAPE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${WORKLOAD_CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: {}
+  template:
+    spec:
+      clusterName: ${WORKLOAD_CLUSTER_NAME}
+      version: ${KUBERNETES_VERSION}+k3s1
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KThreesConfigTemplate
+          name: ${WORKLOAD_CLUSTER_NAME}-md-0
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: OCIMachineTemplate
+        name: ${WORKLOAD_CLUSTER_NAME}-md-0
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KThreesConfigTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      agentConfig:
+        airGapped: false
+        kubeletArgs:
+          - "--cloud-provider=external"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: OCIMachineTemplate
+metadata:
+  name: ${WORKLOAD_CLUSTER_NAME}-md-0
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      compartmentId: ${OCI_COMPARTMENT_OCID}
+      imageId: ${OCI_IMAGE_ID}
+      shape: ${OCI_WORKER_SHAPE}
+`
+
+// K3sTemplate returns the OCI K3s manifest template.
+func (p *Provider) K3sTemplate(cfg *config.Config, mgmt bool) (string, error) {
+	return k3sTemplate, nil
+}
+
+// PatchManifest is a no-op for OCI today. Sizing is driven entirely
+// by OCI_CP_SHAPE / OCI_WORKER_SHAPE in TemplateVars.
+func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt bool) error {
+	return nil
 }

--- a/internal/provider/oci/state.go
+++ b/internal/provider/oci/state.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package oci
+
+// State-handoff hooks for Oracle Cloud Infrastructure (CAPOCI).
+//
+// See docs/abstraction-plan.md §11 + §14.D.
+// OCI authentication uses a private key file on disk — only the path
+// is tracked here (never the key material). The CAPOCI controller
+// reads the key from the path/Secret it is configured with at deploy
+// time. TenancyOCID and UserOCID are non-secret identity pointers and
+// are safe to round-trip through the kind Secret.
+
+import (
+	"github.com/lpasquali/yage/internal/config"
+)
+
+// KindSyncFields persists the OCI-specific configuration the next
+// yage run needs to reconstruct the active cluster. No private key
+// material is included — only the path reference and non-secret OCIDs.
+func (p *Provider) KindSyncFields(cfg *config.Config) map[string]string {
+	out := map[string]string{}
+	add := func(k, v string) {
+		if v != "" {
+			out[k] = v
+		}
+	}
+	add("region", cfg.Providers.OCI.Region)
+	add("control_plane_shape", cfg.Providers.OCI.ControlPlaneShape)
+	add("node_shape", cfg.Providers.OCI.NodeShape)
+	add("tenancy_ocid", cfg.Providers.OCI.TenancyOCID)
+	add("user_ocid", cfg.Providers.OCI.UserOCID)
+	add("fingerprint", cfg.Providers.OCI.Fingerprint)
+	add("compartment_ocid", cfg.Providers.OCI.CompartmentOCID)
+	add("image_id", cfg.Providers.OCI.ImageID)
+	add("private_key_path", cfg.Providers.OCI.PrivateKeyPath)
+	add("overhead_tier", cfg.Providers.OCI.OverheadTier)
+	return out
+}
+
+// TemplateVars returns the OCI-specific clusterctl manifest
+// substitution map.
+func (p *Provider) TemplateVars(cfg *config.Config) map[string]string {
+	return map[string]string{
+		"OCI_REGION":           orDefault(cfg.Providers.OCI.Region, "us-ashburn-1"),
+		"OCI_CP_SHAPE":         orDefault(cfg.Providers.OCI.ControlPlaneShape, "VM.Standard.E4.Flex"),
+		"OCI_WORKER_SHAPE":     orDefault(cfg.Providers.OCI.NodeShape, "VM.Standard.E4.Flex"),
+		"OCI_TENANCY_OCID":     cfg.Providers.OCI.TenancyOCID,
+		"OCI_USER_OCID":        cfg.Providers.OCI.UserOCID,
+		"OCI_COMPARTMENT_OCID": cfg.Providers.OCI.CompartmentOCID,
+		"OCI_IMAGE_ID":         cfg.Providers.OCI.ImageID,
+	}
+}
+
+// AbsorbConfigYAML is the reverse of KindSyncFields: reads the
+// lowercase bare-key map the yage-system/bootstrap-config Secret
+// schema writes (orchestrator strips the "oci." prefix before
+// dispatching) and fills empty cfg fields with non-empty values.
+func (p *Provider) AbsorbConfigYAML(cfg *config.Config, kv map[string]string) bool {
+	assigned := false
+	assign := func(cur *string, v string) {
+		if *cur == "" && v != "" {
+			*cur = v
+			assigned = true
+		}
+	}
+	for k, v := range kv {
+		switch k {
+		case "region":
+			assign(&cfg.Providers.OCI.Region, v)
+		case "control_plane_shape":
+			assign(&cfg.Providers.OCI.ControlPlaneShape, v)
+		case "node_shape":
+			assign(&cfg.Providers.OCI.NodeShape, v)
+		case "tenancy_ocid":
+			assign(&cfg.Providers.OCI.TenancyOCID, v)
+		case "user_ocid":
+			assign(&cfg.Providers.OCI.UserOCID, v)
+		case "fingerprint":
+			assign(&cfg.Providers.OCI.Fingerprint, v)
+		case "compartment_ocid":
+			assign(&cfg.Providers.OCI.CompartmentOCID, v)
+		case "image_id":
+			assign(&cfg.Providers.OCI.ImageID, v)
+		case "private_key_path":
+			assign(&cfg.Providers.OCI.PrivateKeyPath, v)
+		case "overhead_tier":
+			assign(&cfg.Providers.OCI.OverheadTier, v)
+		}
+	}
+	return assigned
+}


### PR DESCRIPTION
## Summary
Brings DigitalOcean, Linode, and OCI providers from cost-only stubs to bootable-ready:

**Per provider:**
- `state.go`: `KindSyncFields`, `AbsorbConfigYAML`, `TemplateVars`
- K3sTemplate in the main provider file: full CAPI cluster manifest (Cluster + InfraCluster + KThreesControlPlane + MachineDeployment + templates)
- `PatchManifest`: no-op (future optimization)

**Config additions:**
- `DigitalOceanConfig`: +VPCUUID, +OverheadTier
- `LinodeConfig`: +OverheadTier; `Cost.Credentials.LinodeToken` field wired
- `OCIConfig`: +TenancyOCID, +UserOCID, +Fingerprint, +CompartmentOCID, +ImageID, +PrivateKeyPath, +OverheadTier

**CRD API versions used:**
- CAPDO: `infrastructure.cluster.x-k8s.io/v1beta1`
- CAPL: `infrastructure.cluster.x-k8s.io/v1alpha2`
- CAPOCI: `infrastructure.cluster.x-k8s.io/v1beta2`

API tokens are not stored in KindSyncFields — operators supply them via env, same convention as Hetzner's HCLOUD_TOKEN.

Part of #18

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `provider.For(cfg).K3sTemplate(cfg, false)` returns non-empty YAML for each provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)