### PR TITLE
feat(xapiri): overcommit toggle in dashboard + capacity prompt (#11)

### DIFF
--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -88,10 +88,11 @@ const (
 // ─── toggle (bool) slot indices ──────────────────────────────────────────────
 
 const (
-	toiQueue    = 0
-	toiObjStore = 1
-	toiCache    = 2
-	toiCount    = 3
+	toiQueue      = 0
+	toiObjStore   = 1
+	toiCache      = 2
+	toiOvercommit = 3 // on-prem only: allow resource overcommit
+	toiCount      = 4
 )
 
 // ─── logical focus IDs (tab order) ───────────────────────────────────────────
@@ -117,10 +118,11 @@ const (
 	focCacheCPU           // 17
 	focCacheMem           // 18
 	focBootstrap          // 19
-	focDCLoc              // 20
-	focBudget             // 21
-	focHeadroom           // 22
-	focCount              // 23 — must be last
+	focOvercommit         // 20 — on-prem only: allow resource overcommit
+	focDCLoc              // 21
+	focBudget             // 22
+	focHeadroom           // 23
+	focCount              // 24 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -168,6 +170,7 @@ var dashFields = []fieldMeta{
 	{fkText, tiCacheMem, "  cache mem (Mi)", "", true},
 	// ── Bootstrap (on-prem only) ──────────────────────────────────────
 	{fkSelect, siBootstrap, "bootstrap mode", "Bootstrap", false},
+	{fkToggle, toiOvercommit, "allow overcommit", "", false},
 	// ── Geo + Budget (cloud only) ─────────────────────────────────────
 	{fkText, tiDCLoc, "data-center loc", "Geo", false},
 	{fkText, tiBudget, "budget USD/mo", "Budget", false},
@@ -312,6 +315,7 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.toggles[toiQueue] = s.workload.HasQueue
 	m.toggles[toiObjStore] = s.workload.HasObjStore
 	m.toggles[toiCache] = s.workload.HasCache
+	m.toggles[toiOvercommit] = cfg.Capacity.AllowOvercommit
 
 	// Focus the first visible input.
 	cmd := m.textInputs[tiKindName].Focus()
@@ -340,7 +344,7 @@ func (m *dashModel) isHidden(fid int) bool {
 		focHasQueue, focHasObjStore, focHasCache,
 		focDCLoc, focBudget, focHeadroom:
 		return !isCloud
-	case focBootstrap:
+	case focBootstrap, focOvercommit:
 		return isCloud // only visible on on-prem
 	case focQueueCPU, focQueueMem, focQueueVol:
 		return !isCloud || !m.toggles[toiQueue]
@@ -592,6 +596,7 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 	wl.HasQueue = m.toggles[toiQueue]
 	wl.HasObjStore = m.toggles[toiObjStore]
 	wl.HasCache = m.toggles[toiCache]
+	snap.Capacity.AllowOvercommit = m.toggles[toiOvercommit]
 
 	if apps := parseAppBuckets(m.textInputs[tiApps].Value()); len(apps) > 0 {
 		wl.Apps = apps

--- a/internal/ui/xapiri/onprem.go
+++ b/internal/ui/xapiri/onprem.go
@@ -119,9 +119,15 @@ func (s *state) step5_onprem_capacity() error {
 		s.r.info("✓ comfortable on the configured host pool.")
 		return nil
 	case FeasibilityTight:
-		s.r.info("⚠ tight on the configured host pool — proceeding anyway.")
+		s.r.info("⚠ tight on the configured host pool.")
 		if err != nil {
 			s.r.info("  detail: %v", err)
+		}
+		s.r.info("  Resource overcommit lets VMs exceed the soft capacity budget;")
+		s.r.info("  the hard ceiling (memory/disk) still applies.")
+		if s.r.promptYesNo("allow resource overcommit?", s.cfg.Capacity.AllowOvercommit) {
+			s.cfg.Capacity.AllowOvercommit = true
+			s.r.info("  ✓ overcommit enabled (equivalent to --allow-resource-overcommit)")
 		}
 		return nil
 	case FeasibilityInfeasible:


### PR DESCRIPTION
## Summary

- Adds `toiOvercommit` toggle slot and `focOvercommit` focus ID to the bubbletea dashboard; `isHidden()` gates it to on-prem mode only
- Wires toggle initialization from `cfg.Capacity.AllowOvercommit` in `newDashModel` and read-back in `dashSnapshot`
- In `step5_onprem_capacity`: when the host pool is `FeasibilityTight`, prompt "allow resource overcommit?" with a brief explanation (overcommit vs. hard ceiling), then set `cfg.Capacity.AllowOvercommit`

Closes #11

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [ ] Manual: run `--xapiri` on-prem fork with a tight pool stub; verify overcommit prompt appears and toggle shows in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)