### PR TITLE
feat(xapiri+kindsync+pricing): per-config bootstrap Secrets, region-ranked costs, installer TUI API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,18 @@ Multi-document YAML (`\n---\n` separated) is the main workload manifest format. 
 
 ### State persistence
 
-State lives in kind Secrets (`proxmox-bootstrap-config/config.yaml` in `yage-system` namespace), not local disk. `internal/cluster/kindsync` owns this round-trip. `config.Snapshot()` serialises fields; `kindsync.MergeProxmoxBootstrapSecretsFromKind()` reads them back (skipping fields marked `*_EXPLICIT`).
+State lives in kind Secrets in the `yage-system` namespace, not local disk. `internal/cluster/kindsync` owns this round-trip. `config.Snapshot()` serialises fields; `kindsync.ApplySnapshotKV()` reads them back (skipping fields marked `*_EXPLICIT`).
+
+Two distinct Secret types coexist:
+
+1. **Provider snapshot** (`cfg.Providers.Proxmox.BootstrapConfigSecretName`, e.g. `proxmox-bootstrap-config`): Proxmox-specific, written by `ApplyBootstrapConfigToManagementCluster` / `SyncBootstrapConfigToKind` throughout the orchestrator run. Contains `config.yaml` with a full env-var snapshot.
+
+2. **Orchestrator-state Secret** (`<cfg.ConfigName>-bootstrap-config`, labeled `app.kubernetes.io/managed-by=yage,app.kubernetes.io/component=bootstrap-config`): generic, written by xapiri at end of walkthrough (`WriteBootstrapConfigSecret`), promoted to `yage.io/config-status=realized` by `PromoteBootstrapConfigToRealized` on orchestrator success. One Secret per `ConfigName` — supporting:
+   - **Case 1**: N workload clusters on one kind mgmt (ConfigName = WorkloadClusterName by default).
+   - **Case 2**: N named profiles for the same workload (`--config-name prod-eu-low-cost`).
+   - **Case 3**: N draft scenarios without a realized workload yet.
+
+`cfg.ConfigName` defaults to `cfg.WorkloadClusterName` so case 1 needs no new flag. Set `--config-name` or `YAGE_CONFIG_NAME` explicitly for cases 2 and 3.
 
 ### Kubernetes clients
 

--- a/cmd/yage-operator/main.go
+++ b/cmd/yage-operator/main.go
@@ -13,9 +13,13 @@
 //
 // Config:
 //
-//	--bootstrap-secret-ref   namespace/name of the bootstrap-config
-//	                         Secret written by the yage CLI post-pivot
-//	                         (default: yage-system/proxmox-bootstrap-config).
+//	--config-name NAME       Bootstrap-config name prefix; the operator reads
+//	                         yage-system/<name>-bootstrap-config (the
+//	                         orchestrator-state Secret written by the yage CLI).
+//	                         When unset, defaults to the CAPI cluster name
+//	                         "capi-quickstart". Use --bootstrap-secret-ref to
+//	                         override the full namespace/name directly.
+//	--bootstrap-secret-ref   namespace/name override (overrides --config-name).
 //	                         When the Secret is unreadable the runner
 //	                         falls back to an empty config (all providers
 //	                         priced at default shape).
@@ -59,10 +63,11 @@ func main() {
 		fmt.Fprintln(os.Stderr, "warning: prctl PR_SET_DUMPABLE failed:", err)
 	}
 	var (
-		metricsAddr    string
-		probeAddr      string
-		pollInterval   time.Duration
-		secretRef      string
+		metricsAddr  string
+		probeAddr    string
+		pollInterval time.Duration
+		configName   string
+		secretRef    string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"Address to expose Prometheus metrics on.")
@@ -70,12 +75,23 @@ func main() {
 		"Address to expose /healthz and /readyz probes on.")
 	flag.DurationVar(&pollInterval, "cost-poll-interval", 24*time.Hour,
 		"How often to poll pricing APIs (e.g. 24h, 6h).")
-	flag.StringVar(&secretRef, "bootstrap-secret-ref", "yage-system/proxmox-bootstrap-config",
-		"namespace/name of the bootstrap-config Secret written by the yage CLI.")
+	flag.StringVar(&configName, "config-name", "",
+		"Bootstrap-config name prefix; Secret is yage-system/<name>-bootstrap-config. "+
+			"Defaults to \"capi-quickstart\" when unset.")
+	flag.StringVar(&secretRef, "bootstrap-secret-ref", "",
+		"namespace/name override for the bootstrap-config Secret. When empty, computed from --config-name.")
 
 	zapOpts := zap.Options{}
 	zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if secretRef == "" {
+		name := configName
+		if name == "" {
+			name = "capi-quickstart"
+		}
+		secretRef = "yage-system/" + name + "-bootstrap-config"
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 	log := ctrl.Log.WithName("yage-operator")

--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -93,24 +93,26 @@ func main() {
 	airgap.RewriteConfigChartURLs(cfg)
 	shell.SetKindNodeImage(cfg.NodeImage)
 
-	// §16 c2: read cfg.Cost.Credentials + per-provider state from
-	// Secret/yage-system/bootstrap-config when the kind cluster is
-	// reachable. Best-effort: if the Secret doesn't exist (first
-	// run) or the kind cluster isn't up yet, the call is a silent
-	// no-op and cfg keeps what config.Load got from env.
+	// §16 c2: read cfg.Cost.Credentials + per-provider state from the
+	// per-config bootstrap-config Secret (<ConfigName>-bootstrap-config
+	// in yage-system). Best-effort: first run and offline modes are
+	// silent no-ops.
 	//
-	// Fill-empty-only semantics: env values that were explicitly
-	// set survive the merge.
-	//
-	// When no cluster name was provided (no env var, no flag), scan
-	// every running kind cluster for a yage-system/bootstrap-config
-	// Secret and use the first match. This lets `yage` start from
-	// saved config regardless of the cluster name chosen at xapiri
-	// time, without requiring the user to pass --kind-cluster-name.
-	if cfg.KindClusterName == "" {
-		kindsync.MergeBootstrapConfigFromFirstKindCluster(cfg)
-	} else {
+	// Three branches correspond to the three supported modes:
+	//   • KindClusterName set + ConfigNameExplicit (--config-name passed)
+	//     → deterministic get: exactly one Secret targeted.
+	//   • KindClusterName set, ConfigName defaulted from WorkloadClusterName
+	//     → huh picker across all Secrets on that kind cluster so the user
+	//       can choose among profiles / drafts for the same workload.
+	//   • Neither set → scan every running kind cluster for labeled Secrets
+	//     and let the user pick across all of them.
+	switch {
+	case cfg.KindClusterName != "" && cfg.ConfigNameExplicit:
 		_ = kindsync.MergeBootstrapConfigFromKind(cfg)
+	case cfg.KindClusterName != "":
+		kindsync.MergeBootstrapConfigFromKindCluster(cfg)
+	default:
+		kindsync.MergeBootstrapConfigFromFirstKindCluster(cfg)
 	}
 
 	// Hand cost-estimation credentials + currency preferences to

--- a/go.mod
+++ b/go.mod
@@ -66,17 +66,21 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
+	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+	github.com/charmbracelet/huh v1.0.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
+	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/diskfs/go-diskfs v1.7.0 // indirect
 	github.com/djherbis/times v1.6.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
@@ -124,6 +128,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
 github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
+github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
+github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -78,12 +80,16 @@ github.com/charmbracelet/bubbletea v1.3.6 h1:VkHIxPJQeDt0aFJIsVxw8BQdh/F/L2KKZGs
 github.com/charmbracelet/bubbletea v1.3.6/go.mod h1:oQD9VCRQFF8KplacJLo28/jofOI2ToOfGYeFgBBxHOc=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
+github.com/charmbracelet/huh v1.0.0 h1:wOnedH8G4qzJbmhftTqrpppyqHakl/zbbNdXIWJyIxw=
+github.com/charmbracelet/huh v1.0.0/go.mod h1:5YVc+SlZ1IhQALxRPpkGwwEKftN/+OlJlnJYlDRFqN4=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.9.3 h1:BXt5DHS/MKF+LjuK4huWrC6NCvHtexww7dMayh6GXd0=
 github.com/charmbracelet/x/ansi v0.9.3/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13 h1:/KBBKHuVRbq1lYx5BzEHBAFBP8VcQzJejZ/IA3iR28k=
 github.com/charmbracelet/x/cellbuf v0.0.13/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 h1:qko3AQ4gK1MTS/de7F5hPGx6/k1u0w4TeYmBFwzYVP4=
+github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
@@ -104,6 +110,8 @@ github.com/diskfs/go-diskfs v1.7.0 h1:vonWmt5CMowXwUc79jWyGrf2DIMeoOjkLlMnQYGVOs
 github.com/diskfs/go-diskfs v1.7.0/go.mod h1:LhQyXqOugWFRahYUSw47NyZJPezFzB9UELwhpszLP/k=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab h1:h1UgjJdAAhj+uPL68n7XASS6bU+07ZX1WJvVS2eyoeY=
 github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -259,6 +267,8 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/cluster/kindsync/bootstrap_config.go
+++ b/internal/cluster/kindsync/bootstrap_config.go
@@ -3,38 +3,45 @@
 
 package kindsync
 
-// The yage-system/bootstrap-config Secret schema (§16 c2):
-// WriteBootstrapConfigSecret emits the canonical state at
-// end-of-run (or after xapiri commits a config);
-// MergeBootstrapConfigFromKind populates cfg.Cost.Credentials +
-// per-provider state from that Secret on subsequent runs.
+// bootstrap_config.go manages per-config orchestrator-state Secrets in
+// the yage-system namespace. Each Secret is named
+// "<cfg.ConfigName>-bootstrap-config" and carries a full env-var
+// snapshot (config.yaml) plus labeled metadata for discovery.
 //
-// The schema is "flat keys with category prefixes":
+// Three coexistence modes (cfg.ConfigName is the discriminator):
 //
-//	provider                = "proxmox" | "aws" | …
-//	cluster_name            = "capi-quickstart"
-//	cluster_id              = "capi-aws-prod"
-//	kubernetes_version      = "v1.32.0"
-//	cost.gcp_api_key        = "<base64 by k8s>"
-//	cost.hetzner_token      = "<base64>"
-//	cost.digitalocean_token = "<base64>"
-//	cost.ibmcloud_api_key   = "<base64>"
-//	cost.display_currency   = "EUR"
-//	cost.eur_usd_override   = "1.07"
-//	<provider>.<key>        = (per-provider state from
-//	                           Provider.KindSyncFields)
+//  1. N workload-cluster states: ConfigName defaults to WorkloadClusterName
+//     (case 1 needs no new flag — naming a workload names its config).
+//  2. N profiles for one workload: same WorkloadClusterName, distinct
+//     ConfigName values (e.g. "prod-eu-low-cost", "prod-aws-failover").
+//  3. N draft scenarios: ConfigName set to a scenario label, no realized
+//     workload yet.
 //
-// The Proxmox bootstrap-config Secret (proxmox-bootstrap-config
-// with config.yaml payload) coexists with this schema; both are
-// recognized.
+// Labels written on every Secret:
+//
+//	app.kubernetes.io/managed-by:  yage
+//	app.kubernetes.io/component:   bootstrap-config
+//	yage.io/config-name:           <cfg.ConfigName>
+//	yage.io/workload-cluster:      <cfg.WorkloadClusterName>
+//	yage.io/config-status:         draft  (promoted to "realized" on success)
+//	yage.io/provider:              <cfg.InfraProvider>           (when set)
+//	yage.io/region:                <provider.Region or "">       (when set)
+//
+// The Proxmox provider-snapshot Secret (proxmox-bootstrap-config, written
+// by applyBootstrapConfigToManagementCluster) is a separate concept and is
+// not affected by this file.
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/charmbracelet/huh"
 
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
@@ -47,9 +54,95 @@ import (
 // for its bootstrap state Secret.
 const BootstrapConfigNamespace = "yage-system"
 
-// BootstrapConfigSecretName is the name of the Secret inside
-// BootstrapConfigNamespace.
-const BootstrapConfigSecretName = "bootstrap-config"
+// BootstrapConfigSecretName returns the name of the bootstrap-config
+// Secret for cfg in BootstrapConfigNamespace. The name is
+// "<cfg.ConfigName>-bootstrap-config"; when ConfigName is empty
+// (should not happen after Load()) falls back to "bootstrap-config".
+func BootstrapConfigSecretName(cfg *config.Config) string {
+	if cfg.ConfigName == "" {
+		return "bootstrap-config"
+	}
+	return cfg.ConfigName + "-bootstrap-config"
+}
+
+// sanitizeLabelValue maps s to a valid Kubernetes label value
+// ([a-z0-9]([-a-z0-9]*[a-z0-9])?, ≤63 chars). Returns "" when
+// the result is empty so callers can skip the label entirely.
+func sanitizeLabelValue(s string) string {
+	s = strings.ToLower(s)
+	result := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			return r
+		}
+		return '-'
+	}, s)
+	result = strings.Trim(result, "-")
+	if len(result) > 63 {
+		result = strings.TrimRight(result[:63], "-")
+	}
+	return result
+}
+
+// bestEffortProviderRegion returns the Region or Location field of the
+// active provider's config sub-struct. Returns "" when not available.
+func bestEffortProviderRegion(cfg *config.Config) string {
+	if cfg.InfraProvider == "" {
+		return ""
+	}
+	structNames := map[string]string{
+		"aws": "AWS", "azure": "Azure", "gcp": "GCP",
+		"hetzner": "Hetzner", "digitalocean": "DigitalOcean",
+		"linode": "Linode", "oci": "OCI", "ibmcloud": "IBMCloud",
+		"proxmox": "Proxmox", "openstack": "OpenStack", "vsphere": "Vsphere",
+	}
+	sn, ok := structNames[strings.ToLower(cfg.InfraProvider)]
+	if !ok {
+		return ""
+	}
+	pv := reflect.ValueOf(cfg.Providers)
+	sub := pv.FieldByName(sn)
+	if !sub.IsValid() {
+		return ""
+	}
+	for _, fname := range []string{"Region", "Location"} {
+		fv := sub.FieldByName(fname)
+		if fv.IsValid() && fv.Kind() == reflect.String && fv.String() != "" {
+			return fv.String()
+		}
+	}
+	return ""
+}
+
+// bootstrapLabels builds the full label set for a bootstrap-config Secret.
+// Labels that sanitize to "" are omitted.
+func bootstrapLabels(cfg *config.Config, status string) map[string]string {
+	lbl := map[string]string{
+		"app.kubernetes.io/managed-by": "yage",
+		"app.kubernetes.io/component":  "bootstrap-config",
+	}
+	if v := sanitizeLabelValue(cfg.ConfigName); v != "" {
+		lbl["yage.io/config-name"] = v
+	}
+	if v := sanitizeLabelValue(cfg.WorkloadClusterName); v != "" {
+		lbl["yage.io/workload-cluster"] = v
+	}
+	if status != "" {
+		lbl["yage.io/config-status"] = status
+	}
+	if v := sanitizeLabelValue(cfg.InfraProvider); v != "" {
+		lbl["yage.io/provider"] = v
+	}
+	if v := sanitizeLabelValue(bestEffortProviderRegion(cfg)); v != "" {
+		lbl["yage.io/region"] = v
+	}
+	return lbl
+}
+
+// isTTY reports whether stdin is an interactive terminal.
+func isTTY() bool {
+	fi, err := os.Stdin.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
 
 // WriteBootstrapConfigSecret emits cfg into Secret/yage-system/
 // bootstrap-config, using the prefix-based schema documented at
@@ -62,7 +155,7 @@ func WriteBootstrapConfigSecret(cfg *config.Config) error {
 	cli, err := k8sclient.ForContext(kctx)
 	if err != nil {
 		// Kind cluster not reachable — best-effort skip.
-		logx.Warn("kindsync: kind context %s not reachable; skipping yage-system/bootstrap-config write (%v)", kctx, err)
+		logx.Warn("kindsync: kind context %s not reachable; skipping %s/%s write (%v)", kctx, BootstrapConfigNamespace, BootstrapConfigSecretName(cfg), err)
 		return nil
 	}
 	bg := context.Background()
@@ -105,10 +198,7 @@ func WriteBootstrapConfigSecret(cfg *config.Config) error {
 		data["config.yaml"] = []byte(yaml)
 	}
 
-	return applySecret(bg, cli, BootstrapConfigNamespace, BootstrapConfigSecretName, data, map[string]string{
-		"app.kubernetes.io/managed-by": "yage",
-		"app.kubernetes.io/component":  "bootstrap-config",
-	})
+	return applySecret(bg, cli, BootstrapConfigNamespace, BootstrapConfigSecretName(cfg), data, bootstrapLabels(cfg, "draft"))
 }
 
 // MergeBootstrapConfigFromKind reads Secret/yage-system/
@@ -132,14 +222,13 @@ func MergeBootstrapConfigFromKind(cfg *config.Config) error {
 	if err != nil {
 		return nil // best-effort; caller continues
 	}
+	if cfg.ConfigName == "" {
+		return nil // no discriminator; caller must populate ConfigName first
+	}
 	bg := context.Background()
-	sec, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Get(bg, BootstrapConfigSecretName, metav1.GetOptions{})
+	sec, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Get(bg, BootstrapConfigSecretName(cfg), metav1.GetOptions{})
 	if err != nil {
-		// back-compat: old name from before Phase D
-		sec, err = cli.Typed.CoreV1().Secrets("proxmox-bootstrap-system").Get(bg, BootstrapConfigSecretName, metav1.GetOptions{})
-		if err != nil {
-			return nil // not present yet → first-run case
-		}
+		return nil // not present yet → first-run case
 	}
 
 	assign := func(cur *string, v string) {
@@ -204,69 +293,247 @@ func MergeBootstrapConfigFromKind(cfg *config.Config) error {
 	return nil
 }
 
+// PromoteBootstrapConfigToRealized patches the yage.io/config-status
+// label on the bootstrap-config Secret to "realized". Idempotent;
+// best-effort (logs on failure, never returns error to caller).
+// Called by the orchestrator success path after workload kubeconfig
+// is verified.
+func PromoteBootstrapConfigToRealized(cfg *config.Config) {
+	if cfg == nil || cfg.KindClusterName == "" || cfg.ConfigName == "" {
+		return
+	}
+	kctx := "kind-" + cfg.KindClusterName
+	cli, err := k8sclient.ForContext(kctx)
+	if err != nil {
+		logx.Warn("kindsync: PromoteBootstrapConfigToRealized: kind context %s not reachable: %v", kctx, err)
+		return
+	}
+	patch := []byte(`{"metadata":{"labels":{"yage.io/config-status":"realized"}}}`)
+	_, err = cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Patch(
+		context.Background(), BootstrapConfigSecretName(cfg),
+		types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		logx.Warn("kindsync: PromoteBootstrapConfigToRealized: patch %s/%s: %v",
+			BootstrapConfigNamespace, BootstrapConfigSecretName(cfg), err)
+	}
+}
+
+// BootstrapCandidate is a row returned by the label-selector scan.
+type BootstrapCandidate struct {
+	KindCluster string
+	ConfigName  string
+	Workload    string
+	Status      string
+	Provider    string
+	Region      string
+}
+
+func (c BootstrapCandidate) Label() string {
+	st := c.Status
+	if st == "" {
+		st = "unknown"
+	}
+	return fmt.Sprintf("%-30s [%-8s]  workload=%-15s  provider=%-10s  region=%s",
+		c.ConfigName, st, c.Workload, c.Provider, c.Region)
+}
+
+// ListBootstrapCandidates returns all bootstrap-config Secrets in
+// yage-system on the given kind cluster identified by kindClusterName.
+func ListBootstrapCandidates(kindClusterName string) []BootstrapCandidate {
+	kctx := "kind-" + kindClusterName
+	cli, err := k8sclient.ForContext(kctx)
+	if err != nil {
+		return nil
+	}
+	list, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).List(
+		context.Background(), metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/managed-by=yage,app.kubernetes.io/component=bootstrap-config",
+		},
+	)
+	if err != nil {
+		return nil
+	}
+	out := make([]BootstrapCandidate, 0, len(list.Items))
+	for _, sec := range list.Items {
+		lbl := sec.Labels
+		out = append(out, BootstrapCandidate{
+			KindCluster: kindClusterName,
+			ConfigName:  lbl["yage.io/config-name"],
+			Workload:    lbl["yage.io/workload-cluster"],
+			Status:      lbl["yage.io/config-status"],
+			Provider:    lbl["yage.io/provider"],
+			Region:      lbl["yage.io/region"],
+		})
+	}
+	return out
+}
+
+// pickBootstrapConfig presents a huh.Select form to pick one candidate.
+// In non-TTY environments the first candidate is auto-picked with a
+// warning to stderr.
+func pickBootstrapConfig(candidates []BootstrapCandidate, title string) *BootstrapCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if !isTTY() {
+		fmt.Fprintf(os.Stderr, "kindsync: non-interactive: using config %q (kind cluster %q)\n",
+			candidates[0].ConfigName, candidates[0].KindCluster)
+		return &candidates[0]
+	}
+	options := make([]huh.Option[int], len(candidates))
+	for i, c := range candidates {
+		options[i] = huh.NewOption(c.Label(), i)
+	}
+	var chosen int
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[int]().
+				Title(title).
+				Options(options...).
+				Value(&chosen),
+		),
+	)
+	if err := form.Run(); err != nil {
+		// User cancelled (Ctrl+C) or non-TTY fallback.
+		fmt.Fprintf(os.Stderr, "kindsync: selection cancelled: %v\n", err)
+		return nil
+	}
+	return &candidates[chosen]
+}
+
+// applyCandidate sets KindClusterName, ConfigName, and (unless explicit)
+// WorkloadClusterName from a picked candidate, then merges its Secret.
+func applyCandidate(cfg *config.Config, c *BootstrapCandidate) {
+	cfg.KindClusterName = c.KindCluster
+	cfg.ConfigName = c.ConfigName
+	if !cfg.WorkloadClusterNameExplicit && c.Workload != "" {
+		cfg.WorkloadClusterName = c.Workload
+	}
+	_ = MergeBootstrapConfigFromKind(cfg)
+}
+
 // MergeBootstrapConfigFromFirstKindCluster is the zero-argument variant of
 // MergeBootstrapConfigFromKind for when cfg.KindClusterName is empty. It
-// scans every running kind cluster for a yage-system/bootstrap-config Secret:
+// scans every running kind cluster for bootstrap-config Secrets (via label
+// selector), then:
 //
 //   - 0 found → no-op (cfg.KindClusterName stays empty)
 //   - 1 found → merge silently
-//   - N found → print a numbered menu to stderr and ask which one to use;
-//     if stdin is not a TTY (CI, pipes) the first entry is used with a warning
+//   - N found → huh.Select picker; non-TTY auto-picks first with a warning
 func MergeBootstrapConfigFromFirstKindCluster(cfg *config.Config) {
 	out, _, _ := shell.Capture("kind", "get", "clusters")
-	var candidates []string
+	var candidates []BootstrapCandidate
 	for _, ln := range strings.Split(strings.ReplaceAll(out, "\r", ""), "\n") {
 		name := strings.TrimSpace(ln)
 		if name == "" {
 			continue
 		}
-		cfg.KindClusterName = name
-		if err := MergeBootstrapConfigFromKind(cfg); err == nil && cfg.InfraProvider != "" {
-			candidates = append(candidates, name)
-			// Reset so the next iteration starts clean.
-			cfg.KindClusterName = ""
-			cfg.InfraProvider = ""
-		} else {
-			cfg.KindClusterName = ""
-		}
+		candidates = append(candidates, ListBootstrapCandidates(name)...)
 	}
-
 	switch len(candidates) {
 	case 0:
 		// No kind cluster has yage data — leave cfg.KindClusterName empty.
 	case 1:
-		cfg.KindClusterName = candidates[0]
-		_ = MergeBootstrapConfigFromKind(cfg)
+		applyCandidate(cfg, &candidates[0])
 	default:
-		chosen := pickKindCluster(candidates)
-		cfg.KindClusterName = chosen
-		_ = MergeBootstrapConfigFromKind(cfg)
+		c := pickBootstrapConfig(candidates, "Select a bootstrap config to load")
+		if c != nil {
+			applyCandidate(cfg, c)
+		}
 	}
 }
 
-// pickKindCluster prints a numbered menu to stderr and returns the chosen
-// cluster name. Falls back to the first entry when stdin is not a TTY.
-func pickKindCluster(names []string) string {
-	fmt.Fprintln(os.Stderr, "  Multiple kind clusters contain yage data. Which one do you want to use?")
-	for i, n := range names {
-		fmt.Fprintf(os.Stderr, "    %d) %s\n", i+1, n)
+// SelectBootstrapConfigForXapiri presents a huh picker so the xapiri
+// walkthrough can choose which bootstrap config to continue editing, or
+// start a new draft. It only sets cfg.ConfigName (and optionally
+// cfg.WorkloadClusterName when not explicit) — the caller still calls
+// MergeBootstrapConfigFromKind to load the data.
+//
+// No-op when cfg.ConfigNameExplicit is set (the user passed --config-name).
+// No-op when no Secrets exist on the kind cluster yet (first-run case).
+// Non-TTY: auto-selects the first existing config with a stderr warning.
+func SelectBootstrapConfigForXapiri(cfg *config.Config) error {
+	if cfg.ConfigNameExplicit {
+		return nil
 	}
-	// Non-interactive fallback.
-	fi, err := os.Stdin.Stat()
-	if err != nil || fi.Mode()&os.ModeCharDevice == 0 {
-		fmt.Fprintf(os.Stderr, "  (non-interactive: using %s)\n", names[0])
-		return names[0]
+	candidates := ListBootstrapCandidates(cfg.KindClusterName)
+	if len(candidates) == 0 {
+		return nil
 	}
-	for {
-		fmt.Fprintf(os.Stderr, "  choice [1-%d]: ", len(names))
-		var line string
-		fmt.Fscan(os.Stdin, &line)
-		line = strings.TrimSpace(line)
-		for i, n := range names {
-			if line == fmt.Sprintf("%d", i+1) || line == n {
-				return n
-			}
+
+	setFromCandidate := func(c *BootstrapCandidate) {
+		cfg.ConfigName = c.ConfigName
+		if !cfg.WorkloadClusterNameExplicit && c.Workload != "" {
+			cfg.WorkloadClusterName = c.Workload
 		}
-		fmt.Fprintf(os.Stderr, "  invalid choice — enter a number between 1 and %d\n", len(names))
+	}
+
+	if !isTTY() {
+		fmt.Fprintf(os.Stderr, "kindsync: non-interactive: using config %q\n", candidates[0].ConfigName)
+		setFromCandidate(&candidates[0])
+		return nil
+	}
+
+	const newDraftSentinel = "__new_draft__"
+	options := make([]huh.Option[string], len(candidates)+1)
+	for i, c := range candidates {
+		options[i] = huh.NewOption(c.Label(), c.ConfigName)
+	}
+	options[len(candidates)] = huh.NewOption("  [ create new draft... ]", newDraftSentinel)
+
+	var chosen string
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title(fmt.Sprintf("Load a saved config on kind cluster %q (or create new draft)", cfg.KindClusterName)).
+			Options(options...).
+			Value(&chosen),
+	)).Run(); err != nil {
+		return err
+	}
+
+	if chosen == newDraftSentinel {
+		var newName string
+		if err := huh.NewForm(huh.NewGroup(
+			huh.NewInput().
+				Title("New config name").
+				Description("Prefix for the bootstrap-config Secret in yage-system (default: workload cluster name).").
+				Value(&newName),
+		)).Run(); err != nil {
+			return err
+		}
+		if n := strings.TrimSpace(newName); n != "" {
+			cfg.ConfigName = n
+		}
+		return nil
+	}
+
+	for i := range candidates {
+		if candidates[i].ConfigName == chosen {
+			setFromCandidate(&candidates[i])
+			return nil
+		}
+	}
+	return nil
+}
+
+// MergeBootstrapConfigFromKindCluster is the single-cluster variant for
+// when cfg.KindClusterName is set but cfg.ConfigNameExplicit is false.
+// It lists all bootstrap-config Secrets on that kind cluster and applies
+// the same 0/1/N huh-picker logic as MergeBootstrapConfigFromFirstKindCluster.
+func MergeBootstrapConfigFromKindCluster(cfg *config.Config) {
+	candidates := ListBootstrapCandidates(cfg.KindClusterName)
+	switch len(candidates) {
+	case 0:
+		// No configs on this cluster yet — leave ConfigName at its default.
+	case 1:
+		applyCandidate(cfg, &candidates[0])
+	default:
+		c := pickBootstrapConfig(candidates,
+			fmt.Sprintf("Select a bootstrap config on kind cluster %q", cfg.KindClusterName))
+		if c != nil {
+			applyCandidate(cfg, c)
+		}
 	}
 }
+

--- a/internal/cluster/kindsync/bootstrap_config_test.go
+++ b/internal/cluster/kindsync/bootstrap_config_test.go
@@ -15,6 +15,7 @@ package kindsync
 // cluster required) by calling the same internal functions directly.
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
@@ -142,6 +143,189 @@ func TestKindSyncExplicitGuardPreservedOnMerge(t *testing.T) {
 	}
 	if dst.KindVersion != "v0.25.0" {
 		t.Errorf("unguarded KindVersion should be applied: got %q", dst.KindVersion)
+	}
+}
+
+// TestBootstrapConfigSecretName verifies the naming function for all three
+// supported modes.
+func TestBootstrapConfigSecretName(t *testing.T) {
+	// Case 1 / 2 / 3: ConfigName is non-empty.
+	cfg := config.Load()
+	cfg.ConfigName = "dev"
+	if got := BootstrapConfigSecretName(cfg); got != "dev-bootstrap-config" {
+		t.Errorf("case 1: got %q, want %q", got, "dev-bootstrap-config")
+	}
+	cfg.ConfigName = "prod-eu-low-cost"
+	if got := BootstrapConfigSecretName(cfg); got != "prod-eu-low-cost-bootstrap-config" {
+		t.Errorf("case 2: got %q, want %q", got, "prod-eu-low-cost-bootstrap-config")
+	}
+	cfg.ConfigName = "scenario-aws-vs-hetzner"
+	if got := BootstrapConfigSecretName(cfg); got != "scenario-aws-vs-hetzner-bootstrap-config" {
+		t.Errorf("case 3: got %q, want %q", got, "scenario-aws-vs-hetzner-bootstrap-config")
+	}
+	// Empty ConfigName falls back to "bootstrap-config".
+	cfg.ConfigName = ""
+	if got := BootstrapConfigSecretName(cfg); got != "bootstrap-config" {
+		t.Errorf("empty fallback: got %q, want %q", got, "bootstrap-config")
+	}
+}
+
+// TestSanitizeLabelValue verifies the K8s label charset sanitization.
+func TestSanitizeLabelValue(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"aws", "aws"},
+		{"us-east-1", "us-east-1"},
+		{"prod-eu-low-cost", "prod-eu-low-cost"},
+		{"PROD", "prod"},
+		{"my cluster", "my-cluster"},
+		{"--leading--", "leading"},
+		{"trailing--", "trailing"},
+		{"a_b", "a-b"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := sanitizeLabelValue(c.in); got != c.want {
+			t.Errorf("sanitizeLabelValue(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	// Values longer than 63 chars are truncated without trailing hyphen.
+	long := "a" + strings.Repeat("-", 62) + "b"
+	if got := sanitizeLabelValue(long); len(got) > 63 {
+		t.Errorf("long label: len=%d > 63", len(got))
+	}
+}
+
+// TestBootstrapLabelsCase1 verifies that two configs with distinct WorkloadClusterNames
+// (ConfigName defaults to WorkloadClusterName) produce distinct Secret names
+// and carry the correct labels.
+func TestBootstrapLabelsCase1(t *testing.T) {
+	for _, wl := range []string{"dev", "staging", "prod"} {
+		cfg := config.Load()
+		cfg.WorkloadClusterName = wl
+		cfg.ConfigName = wl // default rule applied in Load()
+		cfg.InfraProvider = "aws"
+
+		name := BootstrapConfigSecretName(cfg)
+		if name != wl+"-bootstrap-config" {
+			t.Errorf("case1 %s: Secret name %q, want %q", wl, name, wl+"-bootstrap-config")
+		}
+
+		lbl := bootstrapLabels(cfg, "draft")
+		if lbl["yage.io/config-name"] != wl {
+			t.Errorf("case1 %s: config-name label %q", wl, lbl["yage.io/config-name"])
+		}
+		if lbl["yage.io/workload-cluster"] != wl {
+			t.Errorf("case1 %s: workload-cluster label %q", wl, lbl["yage.io/workload-cluster"])
+		}
+		if lbl["yage.io/config-status"] != "draft" {
+			t.Errorf("case1 %s: config-status label %q", wl, lbl["yage.io/config-status"])
+		}
+		if lbl["yage.io/provider"] != "aws" {
+			t.Errorf("case1 %s: provider label %q", wl, lbl["yage.io/provider"])
+		}
+	}
+}
+
+// TestBootstrapLabelsCase2 verifies two configs for the same workload cluster
+// (different ConfigName) both carry workload-cluster=prod but distinct Secret names.
+func TestBootstrapLabelsCase2(t *testing.T) {
+	for _, configName := range []string{"prod", "prod-eu-low-cost"} {
+		cfg := config.Load()
+		cfg.WorkloadClusterName = "prod"
+		cfg.ConfigName = configName
+		cfg.InfraProvider = "azure"
+
+		name := BootstrapConfigSecretName(cfg)
+		if name != configName+"-bootstrap-config" {
+			t.Errorf("case2 %s: Secret name %q", configName, name)
+		}
+		lbl := bootstrapLabels(cfg, "draft")
+		if lbl["yage.io/workload-cluster"] != "prod" {
+			t.Errorf("case2 %s: workload-cluster %q", configName, lbl["yage.io/workload-cluster"])
+		}
+		if lbl["yage.io/config-name"] != configName {
+			t.Errorf("case2 %s: config-name %q", configName, lbl["yage.io/config-name"])
+		}
+	}
+}
+
+// TestBootstrapLabelsCase3 verifies a draft scenario config has status="draft"
+// in its labels.
+func TestBootstrapLabelsCase3(t *testing.T) {
+	cfg := config.Load()
+	cfg.ConfigName = "scenario-aws-vs-hetzner"
+	cfg.WorkloadClusterName = ""
+	cfg.InfraProvider = ""
+
+	lbl := bootstrapLabels(cfg, "draft")
+	if lbl["yage.io/config-status"] != "draft" {
+		t.Errorf("case3: config-status %q", lbl["yage.io/config-status"])
+	}
+	if _, ok := lbl["yage.io/workload-cluster"]; ok {
+		t.Errorf("case3: workload-cluster label should be absent when WorkloadClusterName is empty")
+	}
+	if _, ok := lbl["yage.io/provider"]; ok {
+		t.Errorf("case3: provider label should be absent when InfraProvider is empty")
+	}
+}
+
+// TestBootstrapLabelsPromoted verifies the realized status string.
+func TestBootstrapLabelsPromoted(t *testing.T) {
+	cfg := config.Load()
+	cfg.ConfigName = "dev"
+	lbl := bootstrapLabels(cfg, "realized")
+	if lbl["yage.io/config-status"] != "realized" {
+		t.Errorf("realized label: got %q", lbl["yage.io/config-status"])
+	}
+}
+
+// TestConfigNameRoundTripSnapshot verifies YAGE_CONFIG_NAME round-trips
+// through SnapshotYAML → ApplySnapshotKV correctly, and that the explicit
+// guard prevents overwrite.
+func TestConfigNameRoundTripSnapshot(t *testing.T) {
+	src := config.Load()
+	src.ConfigName = "prod-eu-low-cost"
+	src.ConfigNameExplicit = false // not explicit, so snapshot can restore it
+
+	yaml := src.SnapshotYAML()
+	kv := parseFlatYAMLOrJSON(yaml)
+
+	dst := config.Load()
+	dst.ApplySnapshotKV(kv)
+
+	if dst.ConfigName != "prod-eu-low-cost" {
+		t.Errorf("ConfigName round-trip: got %q, want %q", dst.ConfigName, "prod-eu-low-cost")
+	}
+
+	// With explicit guard set, the CLI-provided value wins.
+	dst2 := config.Load()
+	dst2.ConfigName = "my-override"
+	dst2.ConfigNameExplicit = true
+	dst2.ApplySnapshotKV(kv)
+	if dst2.ConfigName != "my-override" {
+		t.Errorf("ConfigName explicit guard: got %q, want %q", dst2.ConfigName, "my-override")
+	}
+}
+
+// TestPickBootstrapConfigNonTTY verifies that pickBootstrapConfig auto-picks
+// the first candidate when stdin is not a TTY (the expected state in CI/tests).
+func TestPickBootstrapConfigNonTTY(t *testing.T) {
+	candidates := []BootstrapCandidate{
+		{KindCluster: "k1", ConfigName: "prod", Workload: "prod", Status: "realized", Provider: "aws"},
+		{KindCluster: "k1", ConfigName: "prod-eu-low-cost", Workload: "prod", Status: "draft", Provider: "azure"},
+		{KindCluster: "k2", ConfigName: "dev", Workload: "dev", Status: "draft", Provider: "gcp"},
+	}
+	// In test environments stdin is not a TTY, so pickBootstrapConfig should
+	// return the first candidate without prompting.
+	if isTTY() {
+		t.Skip("skipping non-TTY test when stdin is a TTY (interactive terminal)")
+	}
+	c := pickBootstrapConfig(candidates, "test picker")
+	if c == nil {
+		t.Fatal("pickBootstrapConfig returned nil")
+	}
+	if c.ConfigName != "prod" {
+		t.Errorf("non-TTY auto-pick: got %q, want %q", c.ConfigName, "prod")
 	}
 }
 

--- a/internal/cluster/kindsync/handoff.go
+++ b/internal/cluster/kindsync/handoff.go
@@ -202,6 +202,64 @@ func HandOffBootstrapSecretsToManagement(cfg *config.Config, kindCtx, mgmtKubeco
 			tgt.Namespace, tgt.Name, tgt.Description, kindCtx)
 	}
 
+	// Also hand off all per-config bootstrap-config Secrets in yage-system
+	// (labeled app.kubernetes.io/component=bootstrap-config). These are the
+	// orchestrator-state Secrets written by xapiri and promoted by the
+	// success path — one per ConfigName.
+	if bcList, listErr := srcCli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).List(
+		bg, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/managed-by=yage,app.kubernetes.io/component=bootstrap-config",
+		},
+	); listErr == nil {
+		if !ensuredNS[BootstrapConfigNamespace] {
+			if nsErr := dstCli.EnsureNamespace(bg, BootstrapConfigNamespace); nsErr != nil {
+				logx.Warn("Hand-off: failed to ensure namespace %s on management: %v", BootstrapConfigNamespace, nsErr)
+				if firstErr == nil {
+					firstErr = nsErr
+				}
+			} else {
+				ensuredNS[BootstrapConfigNamespace] = true
+			}
+		}
+		if ensuredNS[BootstrapConfigNamespace] {
+			for _, src := range bcList.Items {
+				clean := corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: src.Name, Namespace: src.Namespace, Labels: src.Labels, Annotations: stripServerAnnotations(src.Annotations)},
+					Type:       src.Type,
+					Data:       src.Data,
+					StringData: src.StringData,
+					Immutable:  src.Immutable,
+				}
+				if clean.Type == "" {
+					clean.Type = corev1.SecretTypeOpaque
+				}
+				body, merr := json.Marshal(clean)
+				if merr != nil {
+					logx.Warn("Hand-off: failed to marshal %s/%s: %v", src.Namespace, src.Name, merr)
+					if firstErr == nil {
+						firstErr = merr
+					}
+					continue
+				}
+				_, perr := dstCli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Patch(
+					bg, src.Name, types.ApplyPatchType, body,
+					metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: boolTrue()},
+				)
+				if perr != nil {
+					logx.Warn("Hand-off: failed to apply %s/%s on management: %v", src.Namespace, src.Name, perr)
+					if firstErr == nil {
+						firstErr = perr
+					}
+					continue
+				}
+				copied++
+				logx.Log("Hand-off: copied %s/%s (bootstrap config %s) from %s to management cluster.",
+					src.Namespace, src.Name, src.Labels["yage.io/config-name"], kindCtx)
+			}
+		}
+	}
+
 	logx.Log("Hand-off summary: %d Secret(s) copied from kind context %s to management cluster.", copied, kindCtx)
 	return copied, firstErr
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -844,6 +844,12 @@ type Config struct {
 	// See docs/abstraction-plan.md §17.
 	Airgapped bool
 
+	// GeoIPEnabled, when true, fetches the operator's outbound IP via
+	// GeoJS to determine nearest cloud regions for cost estimation.
+	// Off by default; DataCenterLocation provides location hints without
+	// any outbound lookup. CLI flag: --geoip.
+	GeoIPEnabled bool
+
 	// ImageRegistryMirror, when non-empty, prefixes every CAPI
 	// provider image reference passed to `clusterctl init` so the
 	// images come from an internal mirror instead of the public
@@ -1083,8 +1089,15 @@ type Config struct {
 	WorkloadClusterName             string
 	WorkloadCiliumClusterID         string
 	WorkloadClusterNamespace        string
-	WorkloadClusterNameExplicit     bool
+	WorkloadClusterNameExplicit      bool
 	WorkloadClusterNamespaceExplicit bool
+	// ConfigName is the per-config discriminator used to name the
+	// yage-system bootstrap-config Secret (<ConfigName>-bootstrap-config).
+	// Defaults to WorkloadClusterName so case-1 (N workload clusters on one
+	// mgmt) needs no extra flag. Set --config-name explicitly to create
+	// named profiles (case 2) or draft scenarios (case 3).
+	ConfigName         string
+	ConfigNameExplicit bool
 	WorkloadKubernetesVersion         string
 	WorkloadKubernetesVersionExplicit bool
 	ControlPlaneMachineCount          string
@@ -1642,6 +1655,11 @@ func Load() *Config {
 	c.WorkloadClusterNamespace = getenv("WORKLOAD_CLUSTER_NAMESPACE", "default")
 	c.WorkloadClusterNameExplicit = envBoolLoose("WORKLOAD_CLUSTER_NAME_EXPLICIT", false) || os.Getenv("WORKLOAD_CLUSTER_NAME") != ""
 	c.WorkloadClusterNamespaceExplicit = envBoolLoose("WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT", false) || os.Getenv("WORKLOAD_CLUSTER_NAMESPACE") != ""
+	c.ConfigName = getenv("YAGE_CONFIG_NAME", "")
+	c.ConfigNameExplicit = envBoolLoose("YAGE_CONFIG_NAME_EXPLICIT", false) || os.Getenv("YAGE_CONFIG_NAME") != ""
+	if c.ConfigName == "" {
+		c.ConfigName = c.WorkloadClusterName
+	}
 	c.WorkloadKubernetesVersion = getenv("WORKLOAD_KUBERNETES_VERSION", "v1.35.0")
 	c.WorkloadKubernetesVersionExplicit = os.Getenv("WORKLOAD_KUBERNETES_VERSION") != ""
 	c.ControlPlaneMachineCount = getenv("CONTROL_PLANE_MACHINE_COUNT", "1")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,11 @@ type ProxmoxMgmtConfig struct {
 	ControlPlaneBootVolumeDevice string
 	ControlPlaneBootVolumeSize   string
 	ControlPlaneTemplateID       string
+	WorkerNumSockets             string // "1"
+	WorkerNumCores               string // "2"
+	WorkerMemoryMiB              string // "2048"
+	WorkerBootVolumeDevice       string
+	WorkerBootVolumeSize         string // "30"
 	WorkerTemplateID             string
 	// Pool is the Proxmox VE pool name the management cluster's VMs are
 	// tagged with. See ProxmoxConfig.Pool for the workload counterpart.
@@ -1695,6 +1700,11 @@ func Load() *Config {
 	c.Providers.Proxmox.Mgmt.ControlPlaneMemoryMiB = getenv("MGMT_CONTROL_PLANE_MEMORY_MIB", "2048")
 	c.Providers.Proxmox.Mgmt.ControlPlaneBootVolumeDevice = getenv("MGMT_CONTROL_PLANE_BOOT_VOLUME_DEVICE", c.Providers.Proxmox.ControlPlaneBootVolumeDevice)
 	c.Providers.Proxmox.Mgmt.ControlPlaneBootVolumeSize = getenv("MGMT_CONTROL_PLANE_BOOT_VOLUME_SIZE", "30")
+	c.Providers.Proxmox.Mgmt.WorkerNumSockets = getenv("MGMT_WORKER_NUM_SOCKETS", "1")
+	c.Providers.Proxmox.Mgmt.WorkerNumCores = getenv("MGMT_WORKER_NUM_CORES", "2")
+	c.Providers.Proxmox.Mgmt.WorkerMemoryMiB = getenv("MGMT_WORKER_MEMORY_MIB", "2048")
+	c.Providers.Proxmox.Mgmt.WorkerBootVolumeDevice = getenv("MGMT_WORKER_BOOT_VOLUME_DEVICE", c.Providers.Proxmox.WorkerBootVolumeDevice)
+	c.Providers.Proxmox.Mgmt.WorkerBootVolumeSize = getenv("MGMT_WORKER_BOOT_VOLUME_SIZE", "30")
 	// Proxmox CSI on the management cluster: off by default (stateless).
 	c.Providers.Proxmox.Mgmt.CSIEnabled = envBool("MGMT_PROXMOX_CSI_ENABLED", false)
 

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -161,6 +161,7 @@ func (c *Config) Snapshot() []SnapshotField {
 		sp("WORKER_NUM_CORES", &c.Providers.Proxmox.WorkerNumCores),
 		sp("WORKER_MEMORY_MIB", &c.Providers.Proxmox.WorkerMemoryMiB),
 		// --- Workload cluster (EXPLICIT-guarded for NAME/NAMESPACE) ---
+		spEx("YAGE_CONFIG_NAME", "YAGE_CONFIG_NAME_EXPLICIT", &c.ConfigName),
 		spEx("WORKLOAD_CLUSTER_NAME", "WORKLOAD_CLUSTER_NAME_EXPLICIT", &c.WorkloadClusterName),
 		spEx("WORKLOAD_CLUSTER_NAMESPACE", "WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT", &c.WorkloadClusterNamespace),
 		sp("WORKLOAD_CILIUM_CLUSTER_ID", &c.WorkloadCiliumClusterID),
@@ -391,6 +392,7 @@ func (c *Config) explicitSet() map[string]bool {
 		"IP_PREFIX_EXPLICIT":                  c.IPPrefixExplicit,
 		"DNS_SERVERS_EXPLICIT":                c.DNSServersExplicit,
 		"ALLOWED_NODES_EXPLICIT":              c.AllowedNodesExplicit,
+		"YAGE_CONFIG_NAME_EXPLICIT":            c.ConfigNameExplicit,
 		"WORKLOAD_CLUSTER_NAME_EXPLICIT":       c.WorkloadClusterNameExplicit,
 		"WORKLOAD_CLUSTER_NAMESPACE_EXPLICIT":  c.WorkloadClusterNamespaceExplicit,
 		"WORKLOAD_KUBERNETES_VERSION_EXPLICIT": c.WorkloadKubernetesVersionExplicit,

--- a/internal/cost/compare.go
+++ b/internal/cost/compare.go
@@ -114,6 +114,7 @@ func blockStorageTierName(provName string) string {
 // CloudCost is one row in the multi-cloud comparison table.
 type CloudCost struct {
 	ProviderName         string
+	Region               string  // region estimated; empty for on-prem or single-region flows
 	Estimate             provider.CostEstimate
 	Err                  error
 	StorageUSDPerGBMonth float64 // 0 when not fetchable
@@ -211,6 +212,95 @@ func StreamWithFilter(cfg *config.Config, scope Scope, progress io.Writer, ch ch
 				fmt.Fprintf(progress, "    ✓ %s\n", name)
 			}
 		}()
+	}
+	go func() { wg.Wait(); close(ch) }()
+}
+
+// withProviderRegion returns a shallow copy of cfg with the named
+// provider's region / location field set to region. Used by
+// StreamWithRegions to price each (provider, region) pair with a
+// region-specific config copy — all other fields (machine types,
+// credentials, overhead tier) remain identical to the source.
+func withProviderRegion(cfg *config.Config, provName, region string) config.Config {
+	c := *cfg
+	switch provName {
+	case "aws":
+		c.Providers.AWS.Region = region
+	case "azure":
+		c.Providers.Azure.Location = region
+	case "gcp":
+		c.Providers.GCP.Region = region
+	case "hetzner":
+		c.Providers.Hetzner.Location = region
+	case "digitalocean":
+		c.Providers.DigitalOcean.Region = region
+	case "linode":
+		c.Providers.Linode.Region = region
+	case "oci":
+		c.Providers.OCI.Region = region
+	case "ibmcloud":
+		c.Providers.IBMCloud.Region = region
+	}
+	return c
+}
+
+// StreamWithRegions fans out cost estimates per (provider, region) pair
+// and sends each CloudCost to ch as it completes, then closes ch.
+// regionsByProvider maps provider name to the ordered list of regions to
+// estimate for that provider. If a provider has no entry (or an empty
+// list) the provider's current region from cfg is used (single estimate).
+// CloudCost.Region is set for every result. Provider / scope filtering is
+// identical to StreamWithFilter.
+func StreamWithRegions(cfg *config.Config, scope Scope, regionsByProvider map[string][]string, progress io.Writer, ch chan<- CloudCost) {
+	names := provider.AirgapFilter(provider.Registered(), cfg.Airgapped)
+	names = filterEphemeralTestProviders(names)
+	switch scope {
+	case ScopeCloudOnly:
+		names = filterCloudOnly(names)
+	case ScopeOnPremOnly:
+		names = filterOnPremOnly(names)
+	}
+	if cfg.InfraProvider != "" && !cfg.InfraProviderDefaulted {
+		names = filterByInclusion(names, map[string]struct{}{cfg.InfraProvider: {}})
+	}
+	skipped := parseProviderList(cfg.SkipProviders)
+	if len(skipped) > 0 {
+		names = filterByExclusion(names, skipped)
+	}
+	var wg sync.WaitGroup
+	for _, name := range names {
+		name := name
+		regions := regionsByProvider[name]
+		if len(regions) == 0 {
+			regions = []string{""} // sentinel: use region already in cfg
+		}
+		for _, region := range regions {
+			region := region
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				p, err := provider.Get(name)
+				if err != nil {
+					return
+				}
+				var cfgCopy config.Config
+				if region != "" {
+					cfgCopy = withProviderRegion(cfg, name, region)
+				} else {
+					cfgCopy = *cfg
+				}
+				est, estErr := p.EstimateMonthlyCostUSD(&cfgCopy)
+				storagePrice, storageErr := liveBlockStorageUSDPerGBMonth(name, &cfgCopy)
+				ch <- CloudCost{
+					ProviderName:         name,
+					Region:               region,
+					Estimate:             est,
+					Err:                  estErr,
+					StorageUSDPerGBMonth: storagePrice,
+					StorageErr:           storageErr,
+				}
+			}()
+		}
 	}
 	go func() { wg.Wait(); close(ch) }()
 }

--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -998,6 +998,9 @@ func Run(ctx context.Context, cfg *config.Config) int {
 		}
 	}
 
+	// Promote the bootstrap-config Secret from draft → realized now that
+	// the full bootstrap (CAPI + Argo CD) has completed successfully.
+	kindsync.PromoteBootstrapConfigToRealized(cfg)
 	logx.Log("Done. CAPI: 'kubectl get clusters -A' and 'clusterctl describe cluster <name>'. For workload apps, rely on Argo CD sync (this script does not wait for all add-ons to be Healthy).")
 	return 0
 }

--- a/internal/platform/installer/installer.go
+++ b/internal/platform/installer/installer.go
@@ -159,6 +159,13 @@ func Clusterctl(cfg *config.Config) error {
 // CiliumCLI ensures cilium CLI matches cfg.CiliumCLIVersion,
 // installing the upstream tarball when missing or out of date.
 func CiliumCLI(cfg *config.Config) error {
+	if err := ciliumCLI(cfg); err != nil {
+		logx.Die("Failed to install cilium CLI (curl or tar: check CILIUM_CLI_VERSION=%s and network).", cfg.CiliumCLIVersion)
+	}
+	return nil
+}
+
+func ciliumCLI(cfg *config.Config) error {
 	if shell.CommandExists("cilium") {
 		have := firstVersionOn("cilium", "version", "2>&1")
 		if versionx.Match(have, cfg.CiliumCLIVersion) {
@@ -171,7 +178,7 @@ func CiliumCLI(cfg *config.Config) error {
 	tarball := fmt.Sprintf("cilium-%s-%s.tar.gz", sysinfo.OS(), sysinfo.Arch())
 	url := fmt.Sprintf("https://github.com/cilium/cilium-cli/releases/download/%s/%s", cfg.CiliumCLIVersion, tarball)
 	if err := installTarballMember(url, "cilium", 0); err != nil {
-		logx.Die("Failed to install cilium CLI (curl or tar: check CILIUM_CLI_VERSION=%s and network).", cfg.CiliumCLIVersion)
+		return fmt.Errorf("install cilium CLI: %w", err)
 	}
 	return nil
 }
@@ -180,8 +187,15 @@ func CiliumCLI(cfg *config.Config) error {
 // installing the upstream release binary when missing or out of date.
 // Linux-only.
 func ArgoCDCLI(cfg *config.Config) error {
+	if err := argoCDCLI(cfg); err != nil {
+		logx.Die("%v", err)
+	}
+	return nil
+}
+
+func argoCDCLI(cfg *config.Config) error {
 	if runtime.GOOS != "linux" {
-		logx.Die("argocd CLI install is supported on Linux only (amd64/arm64), not %s.", runtime.GOOS)
+		return fmt.Errorf("argocd CLI install is supported on Linux only (amd64/arm64), not %s", runtime.GOOS)
 	}
 	if shell.CommandExists("argocd") {
 		have := firstVersionOn("argocd", "version", "--client", "2>&1")
@@ -196,7 +210,7 @@ func ArgoCDCLI(cfg *config.Config) error {
 	switch arch {
 	case "amd64", "arm64":
 	default:
-		logx.Die("Unsupported architecture for argocd CLI on Linux: %s (need amd64 or arm64).", arch)
+		return fmt.Errorf("unsupported architecture for argocd CLI on Linux: %s (need amd64 or arm64)", arch)
 	}
 	url := fmt.Sprintf("https://github.com/argoproj/argo-cd/releases/download/%s/argocd-linux-%s", cfg.ArgoCD.Version, arch)
 	return installBinary("argocd", url)
@@ -205,8 +219,15 @@ func ArgoCDCLI(cfg *config.Config) error {
 // KyvernoCLI ensures the kyverno CLI matches cfg.KyvernoCLIVersion.
 // Linux-only; amd64 uses x86_64 in the asset name.
 func KyvernoCLI(cfg *config.Config) error {
+	if err := kyvernoCLI(cfg); err != nil {
+		logx.Die("%v", err)
+	}
+	return nil
+}
+
+func kyvernoCLI(cfg *config.Config) error {
 	if runtime.GOOS != "linux" {
-		logx.Die("kyverno CLI install is supported on Linux only (amd64/arm64), not %s.", runtime.GOOS)
+		return fmt.Errorf("kyverno CLI install is supported on Linux only (amd64/arm64), not %s", runtime.GOOS)
 	}
 	if shell.CommandExists("kyverno") {
 		have := firstVersionOn("kyverno", "version", "2>&1")
@@ -224,12 +245,12 @@ func KyvernoCLI(cfg *config.Config) error {
 	case "arm64":
 		kyArch = "arm64"
 	default:
-		logx.Die("Unsupported architecture for kyverno CLI on Linux: %s (need amd64 or arm64).", sysinfo.Arch())
+		return fmt.Errorf("unsupported architecture for kyverno CLI on Linux: %s (need amd64 or arm64)", sysinfo.Arch())
 	}
 	tarball := fmt.Sprintf("kyverno-cli_%s_linux_%s.tar.gz", cfg.KyvernoCLIVersion, kyArch)
 	url := fmt.Sprintf("https://github.com/kyverno/kyverno/releases/download/%s/%s", cfg.KyvernoCLIVersion, tarball)
 	if err := installTarballMember(url, "kyverno", 0); err != nil {
-		logx.Die("Failed to install kyverno CLI (check KYVERNO_CLI_VERSION=%s and network).", cfg.KyvernoCLIVersion)
+		return fmt.Errorf("install kyverno CLI: %w", err)
 	}
 	return nil
 }
@@ -237,8 +258,15 @@ func KyvernoCLI(cfg *config.Config) error {
 // Cmctl ensures the cmctl (cert-manager) CLI matches
 // cfg.CmctlVersion. Linux-only.
 func Cmctl(cfg *config.Config) error {
+	if err := cmctlInner(cfg); err != nil {
+		logx.Die("%v", err)
+	}
+	return nil
+}
+
+func cmctlInner(cfg *config.Config) error {
 	if runtime.GOOS != "linux" {
-		logx.Die("cmctl install is supported on Linux only (amd64/arm64), not %s.", runtime.GOOS)
+		return fmt.Errorf("cmctl install is supported on Linux only (amd64/arm64), not %s", runtime.GOOS)
 	}
 	if shell.CommandExists("cmctl") {
 		have := firstVersionOn("cmctl", "version", "2>&1")
@@ -251,12 +279,12 @@ func Cmctl(cfg *config.Config) error {
 	}
 	arch := sysinfo.Arch()
 	if arch != "amd64" && arch != "arm64" {
-		logx.Die("Unsupported architecture for cmctl on Linux: %s (need amd64 or arm64).", arch)
+		return fmt.Errorf("unsupported architecture for cmctl on Linux: %s (need amd64 or arm64)", arch)
 	}
 	tarball := fmt.Sprintf("cmctl_linux_%s.tar.gz", arch)
 	url := fmt.Sprintf("https://github.com/cert-manager/cmctl/releases/download/%s/%s", cfg.CmctlVersion, tarball)
 	if err := installTarballMember(url, "cmctl", 0); err != nil {
-		logx.Die("Failed to install cmctl (check CMCTL_VERSION=%s and network).", cfg.CmctlVersion)
+		return fmt.Errorf("install cmctl: %w", err)
 	}
 	return nil
 }
@@ -436,6 +464,13 @@ func BuildIfNoArm64(cfg *config.Config, image, repo, tag, dir, cluster string) e
 // `tofu version -json` emits the same schema Terraform did, including the
 // `terraform_version` key — we reuse the existing parser for that reason.
 func OpenTofu(cfg *config.Config) error {
+	if err := openTofuInner(cfg); err != nil {
+		logx.Die("Failed to install OpenTofu (check OPENTOFU_VERSION=%s and network): %v", cfg.OpenTofuVersion, err)
+	}
+	return nil
+}
+
+func openTofuInner(cfg *config.Config) error {
 	if shell.CommandExists("tofu") {
 		have := tofuJSONVersion()
 		if versionx.Match(have, cfg.OpenTofuVersion) {
@@ -451,7 +486,7 @@ func OpenTofu(cfg *config.Config) error {
 		cfg.OpenTofuVersion, cfg.OpenTofuVersion, osName, arch)
 	zipPath := filepath.Join(os.TempDir(), fmt.Sprintf("tofu_%s_%s_%s.zip", cfg.OpenTofuVersion, osName, arch))
 	if err := downloadTo(url, zipPath); err != nil {
-		logx.Die("Failed to download OpenTofu from %s (check OPENTOFU_VERSION=%s and network).", url, cfg.OpenTofuVersion)
+		return fmt.Errorf("download OpenTofu from %s: %w", url, err)
 	}
 	defer os.Remove(zipPath)
 	bin := filepath.Join(os.TempDir(), "tofu.bin")
@@ -594,4 +629,138 @@ func extractZipMember(zipPath, name, dest string) error {
 	// supplies archive/zip, this is trivial; adding import here keeps the
 	// function self-contained for readability.
 	return extractZipMemberImpl(zipPath, name, dest)
+}
+
+// ─── deps check / upgrade ─────────────────────────────────────────────────────
+
+// DepCheck records the current state of one CLI dependency.
+type DepCheck struct {
+	Name string
+	Want string // pinned version or "any"
+	Have string // detected version or "not found"
+	OK   bool
+	Skip bool // built-in (no check needed)
+}
+
+// ImageCheck records arm64 availability for one container image.
+type ImageCheck struct {
+	Name  string // human-friendly label
+	Image string // full image:tag reference
+	Arm64 bool   // has arm64 in manifest list
+	Err   bool   // docker absent or network failure
+}
+
+// CheckDeps returns the installed-vs-required status for every CLI tool yage
+// needs, without installing anything. Safe to call from the TUI.
+func CheckDeps(cfg *config.Config) []DepCheck {
+	check := func(name, want, have string) DepCheck {
+		ok := versionx.Match(have, want)
+		if have == "" {
+			have = "not found"
+		}
+		return DepCheck{Name: name, Want: want, Have: have, OK: ok}
+	}
+	var out []DepCheck
+	out = append(out, DepCheck{Name: "kind", Want: "embedded", Have: "embedded", OK: true, Skip: true})
+	out = append(out, check("kubectl", cfg.KubectlVersion, kubectlClientGitVersion()))
+	out = append(out, check("clusterctl", cfg.ClusterctlVersion, clusterctlGitVersion()))
+	out = append(out, check("tofu", cfg.OpenTofuVersion, tofuJSONVersion()))
+	if cfg.CiliumCLIVersion != "" {
+		out = append(out, check("cilium", cfg.CiliumCLIVersion, firstVersionOn("cilium", "version", "2>&1")))
+	}
+	if cfg.ArgoCD.Enabled {
+		out = append(out, check("argocd", cfg.ArgoCD.Version, firstVersionOn("argocd", "version", "--client", "2>&1")))
+	}
+	if cfg.KyvernoEnabled {
+		out = append(out, check("kyverno", cfg.KyvernoCLIVersion, firstVersionOn("kyverno", "version", "2>&1")))
+	}
+	if cfg.CertManagerEnabled {
+		out = append(out, check("cmctl", cfg.CmctlVersion, firstVersionOn("cmctl", "version", "2>&1")))
+	}
+	helmHave := firstVersionOn("helm", "version")
+	out = append(out, DepCheck{Name: "helm", Want: "any", Have: orHelmMissing(helmHave), OK: helmHave != ""})
+	dockerHave := firstVersionOn("docker", "--version")
+	out = append(out, DepCheck{Name: "docker", Want: "any", Have: orHelmMissing(dockerHave), OK: dockerHave != ""})
+	return out
+}
+
+func orHelmMissing(v string) string {
+	if v == "" {
+		return "not found"
+	}
+	return v
+}
+
+// CheckProviderImages checks whether the container images required by the
+// active provider have arm64 support in their registry manifest lists.
+// Returns an empty slice when docker is absent. Safe to call from the TUI.
+func CheckProviderImages(cfg *config.Config) []ImageCheck {
+	if !shell.CommandExists("docker") {
+		return nil
+	}
+	var images []struct{ name, ref string }
+	if cfg.CAPICoreImage != "" {
+		images = append(images, struct{ name, ref string }{"CAPI core", cfg.CAPICoreImage})
+	}
+	if cfg.CAPIBootstrapImage != "" {
+		images = append(images, struct{ name, ref string }{"CAPI bootstrap", cfg.CAPIBootstrapImage})
+	}
+	if cfg.CAPIControlplaneImage != "" {
+		images = append(images, struct{ name, ref string }{"CAPI controlplane", cfg.CAPIControlplaneImage})
+	}
+	if cfg.IPAMImage != "" {
+		images = append(images, struct{ name, ref string }{"IPAM", cfg.IPAMImage})
+	}
+	if cfg.CAPMOXImageRepo != "" {
+		tag := cfg.CAPMOXVersion
+		if tag == "" {
+			tag = "latest"
+		}
+		images = append(images, struct{ name, ref string }{"CAPMOX", cfg.CAPMOXImageRepo + ":" + tag})
+	}
+	var out []ImageCheck
+	for _, img := range images {
+		arm64 := HasArm64Image(img.ref)
+		out = append(out, ImageCheck{Name: img.name, Image: img.ref, Arm64: arm64})
+	}
+	return out
+}
+
+// UpgradeDeps installs or upgrades every CLI tool to its pinned version.
+// Unlike the individual exported functions, this returns the first error
+// rather than calling logx.Die, making it safe to call from the TUI.
+func UpgradeDeps(cfg *config.Config) error {
+	if err := Kubectl(cfg); err != nil {
+		return fmt.Errorf("kubectl: %w", err)
+	}
+	if err := Clusterctl(cfg); err != nil {
+		return fmt.Errorf("clusterctl: %w", err)
+	}
+	if err := openTofuInner(cfg); err != nil {
+		return fmt.Errorf("tofu: %w", err)
+	}
+	if cfg.CiliumCLIVersion != "" {
+		if err := ciliumCLI(cfg); err != nil {
+			return fmt.Errorf("cilium: %w", err)
+		}
+	}
+	if cfg.ArgoCD.Enabled {
+		if err := argoCDCLI(cfg); err != nil {
+			return fmt.Errorf("argocd: %w", err)
+		}
+	}
+	if cfg.KyvernoEnabled {
+		if err := kyvernoCLI(cfg); err != nil {
+			return fmt.Errorf("kyverno: %w", err)
+		}
+	}
+	if cfg.CertManagerEnabled {
+		if err := cmctlInner(cfg); err != nil {
+			return fmt.Errorf("cmctl: %w", err)
+		}
+	}
+	if err := Helm(); err != nil {
+		return fmt.Errorf("helm: %w", err)
+	}
+	return nil
 }

--- a/internal/platform/sysinfo/proc_linux.go
+++ b/internal/platform/sysinfo/proc_linux.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+//go:build linux
+
+package sysinfo
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Stats is a point-in-time sample of the yage process + network.
+type Stats struct {
+	CPUPercent  float64       // process CPU %age (0-100 per logical core)
+	MemRSSBytes uint64        // process resident-set size in bytes
+	NetRxDelta  uint64        // total received bytes since previous Sample()
+	NetTxDelta  uint64        // total transmitted bytes since previous Sample()
+	DeltaDur    time.Duration // elapsed time between the last two samples
+}
+
+// Sampler accumulates the previous tick's counters so deltas can be computed.
+type Sampler struct {
+	lastProcTicks  uint64
+	lastTotalTicks uint64
+	lastRxBytes    uint64
+	lastTxBytes    uint64
+	lastTime       time.Time
+}
+
+// NewSampler returns a ready-to-use Sampler.
+func NewSampler() *Sampler { return &Sampler{} }
+
+// Sample reads the current /proc values and returns deltas vs the previous call.
+// The very first call always returns zero deltas (no prior reference point).
+func (s *Sampler) Sample() Stats {
+	now := time.Now()
+	procTicks := readProcCPUTicks()
+	totalTicks := readTotalCPUTicks()
+	rss := readProcRSS()
+	rx, tx := readNetBytes()
+
+	var cpu float64
+	var rxDelta, txDelta uint64
+	dur := now.Sub(s.lastTime)
+
+	if !s.lastTime.IsZero() {
+		dProc := float64(procTicks - s.lastProcTicks)
+		dTotal := float64(totalTicks - s.lastTotalTicks)
+		if dTotal > 0 {
+			cpu = (dProc / dTotal) * 100.0
+		}
+		if rx >= s.lastRxBytes {
+			rxDelta = rx - s.lastRxBytes
+		}
+		if tx >= s.lastTxBytes {
+			txDelta = tx - s.lastTxBytes
+		}
+	}
+
+	s.lastProcTicks = procTicks
+	s.lastTotalTicks = totalTicks
+	s.lastRxBytes = rx
+	s.lastTxBytes = tx
+	s.lastTime = now
+
+	return Stats{
+		CPUPercent:  cpu,
+		MemRSSBytes: rss,
+		NetRxDelta:  rxDelta,
+		NetTxDelta:  txDelta,
+		DeltaDur:    dur,
+	}
+}
+
+// readProcCPUTicks returns utime+stime for this process from /proc/self/stat.
+func readProcCPUTicks() uint64 {
+	raw, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		return 0
+	}
+	// Format: pid (comm) state ppid ... utime stime ... (fields 14 and 15, 1-indexed)
+	// comm can contain spaces and parentheses; skip past the closing ')'.
+	s := string(raw)
+	close := strings.LastIndex(s, ")")
+	if close < 0 {
+		return 0
+	}
+	fields := strings.Fields(s[close+1:])
+	// After ')': state(0) ppid(1) pgrp(2) session(3) tty(4) tpgid(5)
+	// flags(6) minflt(7) cminflt(8) majflt(9) cmajflt(10)
+	// utime(11) stime(12)
+	if len(fields) < 13 {
+		return 0
+	}
+	u, _ := strconv.ParseUint(fields[11], 10, 64)
+	sv, _ := strconv.ParseUint(fields[12], 10, 64)
+	return u + sv
+}
+
+// readTotalCPUTicks returns the sum of all CPU-time fields from /proc/stat line 0.
+func readTotalCPUTicks() uint64 {
+	f, err := os.Open("/proc/stat")
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "cpu ") {
+			continue
+		}
+		var total uint64
+		for _, tok := range strings.Fields(line)[1:] {
+			v, _ := strconv.ParseUint(tok, 10, 64)
+			total += v
+		}
+		return total
+	}
+	return 0
+}
+
+// readProcRSS returns VmRSS (bytes) from /proc/self/status.
+func readProcRSS() uint64 {
+	f, err := os.Open("/proc/self/status")
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "VmRSS:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, _ := strconv.ParseUint(fields[1], 10, 64)
+		return kb * 1024
+	}
+	return 0
+}
+
+// readNetBytes sums rx_bytes and tx_bytes across all non-loopback interfaces
+// from /proc/net/dev. On a non-namespaced process this equals /proc/self/net/dev.
+func readNetBytes() (rx, tx uint64) {
+	f, err := os.Open("/proc/net/dev")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	// Skip 2 header lines.
+	for i := 0; i < 2; i++ {
+		sc.Scan()
+	}
+	for sc.Scan() {
+		line := sc.Text()
+		// "  eth0:  12345 ... 67890 ..."  — colon separates iface from stats.
+		colon := strings.Index(line, ":")
+		if colon < 0 {
+			continue
+		}
+		iface := strings.TrimSpace(line[:colon])
+		if iface == "lo" {
+			continue
+		}
+		fields := strings.Fields(line[colon+1:])
+		if len(fields) < 9 {
+			continue
+		}
+		r, _ := strconv.ParseUint(fields[0], 10, 64)
+		t, _ := strconv.ParseUint(fields[8], 10, 64)
+		rx += r
+		tx += t
+	}
+	return
+}

--- a/internal/platform/sysinfo/proc_other.go
+++ b/internal/platform/sysinfo/proc_other.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+//go:build !linux
+
+package sysinfo
+
+import "time"
+
+// Stats is a point-in-time sample of the yage process + network.
+type Stats struct {
+	CPUPercent  float64
+	MemRSSBytes uint64
+	NetRxDelta  uint64
+	NetTxDelta  uint64
+	DeltaDur    time.Duration
+}
+
+// Sampler is a no-op stub on non-Linux platforms.
+type Sampler struct{}
+
+func NewSampler() *Sampler { return &Sampler{} }
+
+func (s *Sampler) Sample() Stats { return Stats{} }

--- a/internal/pricing/aws.go
+++ b/internal/pricing/aws.go
@@ -43,6 +43,14 @@ const (
 	awsBulkCacheTTL = 7 * 24 * time.Hour
 )
 
+// awsBulkMemCache is a process-lifetime in-memory cache so repeated calls
+// for the same service/region (e.g. AmazonEC2 for both NAT and egress
+// pricing) only incur one disk read per process.
+var (
+	awsBulkMemMu    sync.RWMutex
+	awsBulkMemCache = map[string]*awsBulkPayload{}
+)
+
 type awsFetcher struct {
 	mu sync.Mutex
 }
@@ -115,7 +123,11 @@ type awsPriceListItem struct {
 func awsBulkCachePath(service, region string) string {
 	d := cacheDir()
 	_ = os.MkdirAll(d, 0o755)
-	return filepath.Join(d, fmt.Sprintf("aws-bulk-%s-%s.json", service, region))
+	tag := region
+	if tag == "" {
+		tag = "global"
+	}
+	return filepath.Join(d, fmt.Sprintf("aws-svc-%s-%s.json", service, tag))
 }
 
 // newAWSPricingClient creates a Pricing API client.
@@ -220,16 +232,29 @@ func (a *awsFetcher) loadBulk(service, region string) (*awsBulkPayload, error) {
 	return awsLoadOrFetch(service, region, nil)
 }
 
-// awsLoadOrFetch checks the disk cache, returning cached data if
-// fresh (< 7 days old). On a cache miss it calls the AWS Pricing SDK
-// to fetch and cache the payload.
+// awsLoadOrFetch checks the in-memory cache, then the disk cache, returning
+// cached data if fresh (< 7 days old). On a miss it calls the AWS Pricing SDK
+// to fetch and cache the payload. The in-memory cache prevents repeated 440MB
+// disk reads when multiple overhead pricing functions request the same service
+// (e.g. AmazonEC2 for both NAT gateway and egress pricing).
 func awsLoadOrFetch(service, region string, extraFilters []awspricingtypes.Filter) (*awsBulkPayload, error) {
+	memKey := service + ":" + region
+	awsBulkMemMu.RLock()
+	if cached, ok := awsBulkMemCache[memKey]; ok {
+		awsBulkMemMu.RUnlock()
+		return cached, nil
+	}
+	awsBulkMemMu.RUnlock()
+
 	cache := awsBulkCachePath(service, region)
 	if st, err := os.Stat(cache); err == nil && time.Since(st.ModTime()) < awsBulkCacheTTL {
 		raw, err := os.ReadFile(cache)
 		if err == nil {
 			var pl awsBulkPayload
 			if err := json.Unmarshal(raw, &pl); err == nil {
+				awsBulkMemMu.Lock()
+				awsBulkMemCache[memKey] = &pl
+				awsBulkMemMu.Unlock()
 				return &pl, nil
 			}
 		}
@@ -240,7 +265,14 @@ func awsLoadOrFetch(service, region string, extraFilters []awspricingtypes.Filte
 	if err != nil {
 		return nil, err
 	}
-	return awsFetchAndBuildPayload(ctx, client, service, region, extraFilters)
+	pl, err := awsFetchAndBuildPayload(ctx, client, service, region, extraFilters)
+	if err != nil {
+		return nil, err
+	}
+	awsBulkMemMu.Lock()
+	awsBulkMemCache[memKey] = pl
+	awsBulkMemMu.Unlock()
+	return pl, nil
 }
 
 // Fetch routes by SKU shape:

--- a/internal/pricing/aws.go
+++ b/internal/pricing/aws.go
@@ -118,27 +118,33 @@ func awsBulkCachePath(service, region string) string {
 	return filepath.Join(d, fmt.Sprintf("aws-bulk-%s-%s.json", service, region))
 }
 
-// newAWSPricingClient creates a Pricing API client using the explicit
-// key+secret stored in the package-level creds global (set via
-// pricing.SetCredentials). Returns ErrUnavailable when either field is
-// empty — the default AWS credential chain is intentionally NOT used to
-// avoid ambient-credential conflicts with the operator's shell profile.
-//
-// The AWS Pricing API endpoint is always in us-east-1 regardless of
-// the priced workload region.
+// newAWSPricingClient creates a Pricing API client.
+// If explicit key+secret have been set via pricing.SetCredentials those are
+// used as a static credential provider. Otherwise the SDK's default
+// credential chain is tried (AWS_ACCESS_KEY_ID env vars, ~/.aws/credentials,
+// IAM instance profile, etc.). The AWS Pricing API returns the same public
+// catalog regardless of which account authenticates, so ambient credentials
+// are safe to use here — there is no "wrong account" risk for a read-only
+// price query.
+// The Pricing API endpoint is always us-east-1.
 func newAWSPricingClient(ctx context.Context) (*awspricingsdk.Client, error) {
 	keyID := creds.AWSAccessKeyID
 	secret := creds.AWSSecretAccessKey
-	if keyID == "" || secret == "" {
-		return nil, fmt.Errorf("%w: aws credentials not configured — pass --cost-compare-config to set them", ErrUnavailable)
-	}
-	cfg, err := config.LoadDefaultConfig(ctx,
+	opts := []func(*config.LoadOptions) error{
 		config.WithRegion("us-east-1"),
 		config.WithHTTPClient(&http.Client{}),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(keyID, secret, "")),
-	)
+	}
+	if keyID != "" && secret != "" {
+		opts = append(opts, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(keyID, secret, ""),
+		))
+	}
+	// If no explicit credentials, LoadDefaultConfig uses the standard chain
+	// (env → shared-credentials-file → IAM role). If that chain has nothing,
+	// the first real API call will fail and we surface the error then.
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("aws config: %w", err)
+		return nil, fmt.Errorf("%w: aws config: %v", ErrUnavailable, err)
 	}
 	return awspricingsdk.NewFromConfig(cfg), nil
 }

--- a/internal/pricing/aws_services.go
+++ b/internal/pricing/aws_services.go
@@ -5,7 +5,6 @@ package pricing
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -51,16 +50,6 @@ type awsServiceFetcher struct {
 }
 
 var awsSvc = &awsServiceFetcher{}
-
-func awsBulkServiceCachePath(service, region string) string {
-	d := cacheDir()
-	_ = os.MkdirAll(d, 0o755)
-	tag := region
-	if tag == "" {
-		tag = "global"
-	}
-	return fmt.Sprintf("%s/aws-svc-%s-%s.json", d, service, tag)
-}
 
 func (a *awsServiceFetcher) loadServiceBulk(service, region string) (*awsBulkPayload, error) {
 	a.mu.Lock()

--- a/internal/pricing/gcp.go
+++ b/internal/pricing/gcp.go
@@ -143,13 +143,13 @@ func (g *gcpFetcher) findCoreRam(family, region, key string, wantCore bool) (flo
 		if !inSlice(s.ServiceRegions, region) {
 			continue
 		}
-		if s.Category == nil || s.Category.ResourceFamily != "Compute" {
+		if s.ResourceFamily != "Compute" {
 			continue
 		}
-		if !strings.Contains(s.Category.ResourceGroup, wantGroup) {
+		if !strings.Contains(s.ResourceGroup, wantGroup) {
 			continue
 		}
-		if s.Category.UsageType != "OnDemand" {
+		if s.UsageType != "OnDemand" {
 			continue
 		}
 		desc := strings.ToUpper(s.Description)
@@ -165,12 +165,8 @@ func (g *gcpFetcher) findCoreRam(family, region, key string, wantCore bool) (flo
 		if strings.Contains(desc, "SOLE TENANT") || strings.Contains(desc, "CUSTOM") {
 			continue
 		}
-		if len(s.PricingInfo) == 0 {
-			continue
-		}
-		price := gcpUsdFromTier(s.PricingInfo[0])
-		if price > 0 {
-			return price, nil
+		if s.PriceUSD > 0 {
+			return s.PriceUSD, nil
 		}
 	}
 	return 0, fmt.Errorf("gcp: no %s sku for family %s in %s", wantGroup, family, region)
@@ -199,17 +195,13 @@ func (g *gcpFetcher) fetchPD(kind, region, key string) (Item, error) {
 		if !strings.Contains(s.Description, wantDesc) {
 			continue
 		}
-		if s.Category == nil || s.Category.UsageType != "OnDemand" {
+		if s.UsageType != "OnDemand" {
 			continue
 		}
-		if len(s.PricingInfo) == 0 {
-			continue
-		}
-		price := gcpUsdFromTier(s.PricingInfo[0])
-		if price > 0 {
+		if s.PriceUSD > 0 {
 			return Item{
 				USDPerHour:  0,
-				USDPerMonth: price,
+				USDPerMonth: s.PriceUSD,
 				FetchedAt:   time.Now(),
 			}, nil
 		}

--- a/internal/pricing/gcp_services.go
+++ b/internal/pricing/gcp_services.go
@@ -4,11 +4,12 @@
 package pricing
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
-
-	"cloud.google.com/go/billing/apiv1/billingpb"
+	"time"
 )
 
 // GCP service-specific helpers — read from the same Cloud Billing
@@ -40,20 +41,44 @@ const (
 	gcpCloudSQLService    = "9662-B51E-5089" // Cloud SQL (PostgreSQL / MySQL / SQLServer)
 )
 
-// gcpServiceSKUCache memoizes the full SKU list per service ID for
-// the process lifetime. The Cloud Billing Catalog is stable enough
-// that one fetch per `yage` run is plenty, and re-walking the
-// paginated catalog on every gcpFindSku call (NAT, LB, egress, …)
-// dominates the cost-compare wall-clock when GCP is in the mix.
+// gcpSkuRecord is the compact, disk-cacheable representation of a GCP SKU.
+// Only the fields needed by gcpFindSku and findCoreRam are stored.
+type gcpSkuRecord struct {
+	Description    string   `json:"d"`
+	ServiceRegions []string `json:"r"`
+	UsageType      string   `json:"u"` // Category.UsageType
+	ResourceFamily string   `json:"f"` // Category.ResourceFamily
+	ResourceGroup  string   `json:"g"` // Category.ResourceGroup
+	PriceUSD       float64  `json:"p"` // first non-zero on-demand price
+}
+
+type gcpServiceDiskCache struct {
+	FetchedAt time.Time      `json:"fetchedAt"`
+	SKUs      []gcpSkuRecord `json:"skus"`
+}
+
+// gcpServiceSKUCache memoizes the compact SKU list per service ID for the
+// process lifetime with 24-hour disk persistence — so the slow first-ever
+// GCP Billing Catalog fetch is only paid once across restarts.
 var (
 	gcpServiceSKUMu    sync.Mutex
-	gcpServiceSKUCache = map[string][]*billingpb.Sku{}
+	gcpServiceSKUCache = map[string][]gcpSkuRecord{}
 )
 
-// gcpListAllSkus returns every SKU the catalog exposes for a service,
-// fetching once per process and caching the result. Callers do their
-// own filtering by region / description / category in-memory.
-func gcpListAllSkus(serviceID, key string) ([]*billingpb.Sku, error) {
+// gcpSkuDiskPath returns the cache file path for a GCP service SKU list.
+func gcpSkuDiskPath(serviceID string) string {
+	d := cacheDir()
+	_ = os.MkdirAll(d, 0o755)
+	return fmt.Sprintf("%s/gcp-svc-%s.json", d, serviceID)
+}
+
+// gcpListAllSkus returns every SKU the catalog exposes for a service in
+// compact form, with two caching layers:
+//  1. Per-process in-memory cache (zero cost after first call per service).
+//  2. 24-hour disk cache (avoids slow API pagination on process restart).
+//
+// Callers filter the returned slice by region / description / category.
+func gcpListAllSkus(serviceID, key string) ([]gcpSkuRecord, error) {
 	gcpServiceSKUMu.Lock()
 	if cached, ok := gcpServiceSKUCache[serviceID]; ok {
 		gcpServiceSKUMu.Unlock()
@@ -61,23 +86,67 @@ func gcpListAllSkus(serviceID, key string) ([]*billingpb.Sku, error) {
 	}
 	gcpServiceSKUMu.Unlock()
 
-	skus, err := gcpFetchAllSkus(serviceID, key)
+	// Check disk cache.
+	if path := gcpSkuDiskPath(serviceID); true {
+		if raw, err := os.ReadFile(path); err == nil {
+			var dc gcpServiceDiskCache
+			if err := json.Unmarshal(raw, &dc); err == nil && time.Since(dc.FetchedAt) < DefaultTTL {
+				gcpServiceSKUMu.Lock()
+				gcpServiceSKUCache[serviceID] = dc.SKUs
+				gcpServiceSKUMu.Unlock()
+				return dc.SKUs, nil
+			}
+		}
+	}
+
+	// Full API fetch — slow on first call; result written to disk + memory.
+	protos, err := gcpFetchAllSkus(serviceID, key)
 	if err != nil {
 		return nil, err
 	}
+	records := make([]gcpSkuRecord, 0, len(protos))
+	for _, s := range protos {
+		price := 0.0
+		if len(s.PricingInfo) > 0 {
+			price = gcpUsdFromTier(s.PricingInfo[0])
+		}
+		cat := s.Category
+		rec := gcpSkuRecord{
+			Description:    s.Description,
+			ServiceRegions: s.ServiceRegions,
+			PriceUSD:       price,
+		}
+		if cat != nil {
+			rec.UsageType = cat.UsageType
+			rec.ResourceFamily = cat.ResourceFamily
+			rec.ResourceGroup = cat.ResourceGroup
+		}
+		if rec.PriceUSD == 0 {
+			continue // skip un-priced SKUs — they won't match any lookup
+		}
+		records = append(records, rec)
+	}
 
 	gcpServiceSKUMu.Lock()
-	gcpServiceSKUCache[serviceID] = skus
+	gcpServiceSKUCache[serviceID] = records
 	gcpServiceSKUMu.Unlock()
-	return skus, nil
+
+	if path := gcpSkuDiskPath(serviceID); path != "" {
+		dc := gcpServiceDiskCache{FetchedAt: time.Now(), SKUs: records}
+		if raw, err := json.Marshal(dc); err == nil {
+			tmp := path + ".tmp"
+			if err := os.WriteFile(tmp, raw, 0o644); err == nil {
+				_ = os.Rename(tmp, path)
+			}
+		}
+	}
+	return records, nil
 }
 
-// gcpFindSku scans the cached SKU list for a service+region and
-// returns the first non-zero on-demand price whose description
-// contains all of descContains (and none of mustNotContain). Pure
-// in-memory after the first fetch — repeated calls across
-// gcpFindSku / overhead helpers cost a slice walk, not an HTTP
-// request.
+// gcpFindSku scans the cached SKU list for a service+region and returns the
+// first non-zero on-demand price whose description contains all of
+// descContains (and none of mustNotContain). Pure in-memory after the first
+// fetch — repeated calls cost a slice walk, not an HTTP request.
 func gcpFindSku(serviceID, region, key string, descContains []string, mustNotContain []string) (float64, error) {
 	skus, err := gcpListAllSkus(serviceID, key)
 	if err != nil {
@@ -87,7 +156,7 @@ func gcpFindSku(serviceID, region, key string, descContains []string, mustNotCon
 		if region != "" && !inSlice(s.ServiceRegions, region) {
 			continue
 		}
-		if s.Category == nil || s.Category.UsageType != "OnDemand" {
+		if s.UsageType != "OnDemand" {
 			continue
 		}
 		desc := strings.ToLower(s.Description)
@@ -111,12 +180,8 @@ func gcpFindSku(serviceID, region, key string, descContains []string, mustNotCon
 		if skip {
 			continue
 		}
-		if len(s.PricingInfo) == 0 {
-			continue
-		}
-		price := gcpUsdFromTier(s.PricingInfo[0])
-		if price > 0 {
-			return price, nil
+		if s.PriceUSD > 0 {
+			return s.PriceUSD, nil
 		}
 	}
 	return 0, fmt.Errorf("gcp: no sku for %v in %s", descContains, region)

--- a/internal/pricing/georegion.go
+++ b/internal/pricing/georegion.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package pricing
+
+import (
+	"math"
+	"sort"
+)
+
+// georegion.go — nearest-region ranking for each registered cloud
+// provider. Pairs with country_geo.go (country centroids) to resolve
+// --data-center-location <CC> into the closest provider region slug.
+//
+// Used by:
+//   - xapiri dashboard: rank 4 nearest regions for cost-compare display
+//   - cost.WarmCaches: pre-heat pricing caches for nearby regions
+//   - xapiri step-6 prompts: geo-bracket defaults
+//
+// Centroid coordinates are the lat/lon of the data-center location
+// for each provider region slug. They do not need to be exact —
+// great-circle distance at this scale only needs city-level accuracy.
+
+type regionPoint struct {
+	id       string
+	lat, lon float64
+}
+
+func regionCentroids(prov string) []regionPoint {
+	switch prov {
+	case "aws":
+		return []regionPoint{
+			{"us-east-1", 39.04, -77.49},
+			{"us-east-2", 39.96, -83.00},
+			{"us-west-1", 37.35, -121.96},
+			{"us-west-2", 45.51, -122.68},
+			{"ca-central-1", 45.50, -73.57},
+			{"eu-west-1", 53.35, -6.26},
+			{"eu-west-2", 51.51, -0.13},
+			{"eu-west-3", 48.86, 2.35},
+			{"eu-central-1", 50.11, 8.68},
+			{"eu-north-1", 59.33, 18.07},
+			{"ap-southeast-1", 1.35, 103.82},
+			{"ap-southeast-2", -33.87, 151.21},
+			{"ap-northeast-1", 35.68, 139.65},
+			{"ap-northeast-2", 37.57, 126.98},
+			{"ap-south-1", 19.08, 72.88},
+			{"sa-east-1", -23.55, -46.63},
+			{"me-south-1", 26.07, 50.56},
+			{"af-south-1", -33.92, 18.42},
+		}
+	case "azure":
+		return []regionPoint{
+			{"eastus", 37.37, -79.82},
+			{"eastus2", 36.67, -78.80},
+			{"westus2", 47.23, -119.85},
+			{"westus3", 33.45, -112.07},
+			{"centralus", 41.88, -87.63},
+			{"northeurope", 53.35, -6.26},
+			{"westeurope", 52.37, 4.89},
+			{"uksouth", 51.51, -0.13},
+			{"francecentral", 48.86, 2.35},
+			{"germanywestcentral", 50.11, 8.68},
+			{"switzerlandnorth", 47.38, 8.54},
+			{"norwayeast", 59.91, 10.75},
+			{"swedencentral", 59.33, 18.07},
+			{"polandcentral", 52.23, 21.01},
+			{"italynorth", 45.46, 9.19},
+			{"australiaeast", -33.87, 151.21},
+			{"southeastasia", 1.35, 103.82},
+			{"japaneast", 35.68, 139.65},
+			{"japanwest", 34.69, 135.50},
+			{"koreacentral", 37.57, 126.98},
+			{"brazilsouth", -23.55, -46.63},
+			{"southafricanorth", -25.75, 28.23},
+		}
+	case "gcp":
+		return []regionPoint{
+			{"us-central1", 41.26, -95.86},
+			{"us-east1", 33.84, -81.16},
+			{"us-east4", 39.04, -77.49},
+			{"us-west1", 45.51, -122.68},
+			{"us-west2", 34.05, -118.24},
+			{"europe-west1", 50.45, 3.98},
+			{"europe-west2", 51.51, -0.13},
+			{"europe-west3", 50.11, 8.68},
+			{"europe-west4", 53.44, 6.84},
+			{"europe-west6", 47.38, 8.54},
+			{"europe-west8", 41.90, 12.50},
+			{"europe-west9", 48.86, 2.35},
+			{"europe-north1", 60.17, 24.94},
+			{"asia-east1", 25.03, 121.57},
+			{"asia-northeast1", 35.68, 139.65},
+			{"asia-southeast1", 1.35, 103.82},
+			{"asia-south1", 19.08, 72.88},
+			{"australia-southeast1", -37.81, 144.96},
+		}
+	case "hetzner":
+		return []regionPoint{
+			{"fsn1", 50.48, 12.36},
+			{"nbg1", 49.45, 11.08},
+			{"hel1", 60.17, 24.94},
+			{"ash", 39.04, -77.49},
+			{"hil", 45.52, -122.99},
+			{"sin", 1.35, 103.82},
+		}
+	case "digitalocean":
+		return []regionPoint{
+			{"nyc3", 40.71, -74.01},
+			{"nyc1", 40.71, -74.01},
+			{"sfo3", 37.77, -122.42},
+			{"ams3", 52.37, 4.90},
+			{"fra1", 50.11, 8.68},
+			{"lon1", 51.51, -0.13},
+			{"sgp1", 1.35, 103.82},
+			{"tor1", 43.65, -79.38},
+			{"blr1", 12.97, 77.59},
+			{"syd1", -33.87, 151.21},
+		}
+	case "linode":
+		return []regionPoint{
+			{"us-east", 40.74, -74.17},
+			{"us-central", 32.78, -96.80},
+			{"us-west", 37.55, -121.99},
+			{"us-southeast", 33.75, -84.39},
+			{"us-iowa", 43.15, -93.20},
+			{"ca-central", 43.65, -79.38},
+			{"eu-west", 51.51, -0.13},
+			{"eu-central", 50.11, 8.68},
+			{"ap-west", 1.35, 103.82},
+			{"ap-south", 19.08, 72.88},
+			{"ap-northeast", 35.68, 139.65},
+			{"ap-southeast", -33.87, 151.21},
+		}
+	case "oci":
+		return []regionPoint{
+			{"us-ashburn-1", 39.04, -77.49},
+			{"us-phoenix-1", 33.45, -112.07},
+			{"eu-frankfurt-1", 50.11, 8.68},
+			{"uk-london-1", 51.51, -0.13},
+			{"eu-amsterdam-1", 52.37, 4.90},
+			{"ap-sydney-1", -33.87, 151.21},
+			{"ap-mumbai-1", 19.08, 72.88},
+			{"ap-osaka-1", 34.69, 135.50},
+			{"ca-toronto-1", 43.65, -79.38},
+			{"sa-saopaulo-1", -23.55, -46.63},
+		}
+	case "ibmcloud":
+		return []regionPoint{
+			{"us-south", 32.78, -96.80},
+			{"eu-gb", 51.51, -0.13},
+			{"eu-de", 50.11, 8.68},
+			{"jp-tok", 35.68, 139.65},
+			{"au-syd", -33.87, 151.21},
+			{"ca-tor", 45.50, -73.57},
+		}
+	}
+	return nil
+}
+
+func haversineKm(lat1, lon1, lat2, lon2 float64) float64 {
+	const rEarth = 6371.0
+	p1 := lat1 * math.Pi / 180
+	p2 := lat2 * math.Pi / 180
+	dlat := (lat2 - lat1) * math.Pi / 180
+	dlon := (lon2 - lon1) * math.Pi / 180
+	a := math.Sin(dlat/2)*math.Sin(dlat/2) + math.Cos(p1)*math.Cos(p2)*math.Sin(dlon/2)*math.Sin(dlon/2)
+	return rEarth * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+}
+
+// GeoRankedRegions returns the nearest region slugs for the named provider,
+// sorted by great-circle distance from (lat, lon), capped at limit.
+// Returns nil when provider has no centroid table.
+func GeoRankedRegions(prov string, lat, lon float64, limit int) []string {
+	pts := regionCentroids(prov)
+	if len(pts) == 0 || limit <= 0 {
+		return nil
+	}
+	type scored struct {
+		id string
+		km float64
+	}
+	xs := make([]scored, 0, len(pts))
+	for _, p := range pts {
+		xs = append(xs, scored{id: p.id, km: haversineKm(lat, lon, p.lat, p.lon)})
+	}
+	sort.Slice(xs, func(i, j int) bool { return xs[i].km < xs[j].km })
+	seen := map[string]struct{}{}
+	out := make([]string, 0, limit)
+	for _, x := range xs {
+		if _, ok := seen[x.id]; ok {
+			continue
+		}
+		seen[x.id] = struct{}{}
+		out = append(out, x.id)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+// GeoNearestRegion returns the single closest region slug for provider.
+// Returns "" when the provider has no centroid table.
+func GeoNearestRegion(prov string, lat, lon float64) string {
+	r := GeoRankedRegions(prov, lat, lon, 1)
+	if len(r) == 0 {
+		return ""
+	}
+	return r[0]
+}
+
+// GeoHasCentroids reports whether provider has a centroid table for
+// geo-based region selection.
+func GeoHasCentroids(prov string) bool {
+	return len(regionCentroids(prov)) > 0
+}

--- a/internal/ui/cli/completion.go
+++ b/internal/ui/cli/completion.go
@@ -73,6 +73,7 @@ var topLevelFlags = []string{
 	"--cilium-wait-duration",
 	"--cloudinit-storage",
 	"--cluster-set-id",
+	"--config-name",
 	"--cluster-topology",
 	"--cnpg-version",
 	"--completion",

--- a/internal/ui/cli/help/all.txt
+++ b/internal/ui/cli/help/all.txt
@@ -261,6 +261,8 @@ OPTIONS
         --worker-memory-mib N                  (default: 4096 — kubelet + Cilium + a small pod budget)
 
   Workload cluster
+        --config-name NAME                    Bootstrap-config discriminator (default: workload-cluster-name).
+                                              Use to keep N profiles or draft scenarios side-by-side in yage-system.
         --workload-cluster-name NAME          CAPI Cluster name (default: capi-quickstart)
         --workload-cluster-namespace NS       Cluster namespace (default: default)
         --workload-cilium-cluster-id ID       Cilium cluster.id (default: derived from CLUSTER_SET_ID)

--- a/internal/ui/cli/help/proxmox.txt
+++ b/internal/ui/cli/help/proxmox.txt
@@ -52,6 +52,7 @@ proxmox — Proxmox VE / CAPMOX flags (most-mature path)
     --recreate-proxmox-identities to force a clean re-bootstrap.
 
 See also:
+    --config-name    bootstrap-config discriminator (see general --help)
     --help kind      kind cluster name, config, backup/restore
     --help pivot     move CAPI to a Proxmox-hosted mgmt cluster
     --help cost      on-prem TCO (--hardware-cost-usd, --hardware-watts, ...)

--- a/internal/ui/cli/parse.go
+++ b/internal/ui/cli/parse.go
@@ -297,6 +297,9 @@ func Parse(c *config.Config, argv []string) {
 			c.Providers.Proxmox.WorkerNumCores = shiftVal(a)
 		case "--worker-memory-mib":
 			c.Providers.Proxmox.WorkerMemoryMiB = shiftVal(a)
+		case "--config-name":
+			c.ConfigName = shiftVal(a)
+			c.ConfigNameExplicit = true
 		case "--workload-cluster-name":
 			c.WorkloadClusterName = shiftVal(a)
 			c.WorkloadClusterNameExplicit = true
@@ -425,6 +428,10 @@ func Parse(c *config.Config, argv []string) {
 			// Launch the interactive configuration TUI and exit.
 			// See package internal/xapiri for the cultural note.
 			c.Xapiri = true
+		case "--geoip":
+			// Fetch the operator's outbound IP via GeoJS and use it to
+			// rank nearest cloud regions for cost estimation.
+			c.GeoIPEnabled = true
 		case "--airgapped":
 			// Disable every internet-requiring path (cloud providers,
 			// pricing fetchers, geo + FX). On-prem only. See §17.

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -38,6 +38,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/creack/pty"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -2565,7 +2566,12 @@ func (m dashModel) renderBottomStrip() string {
 			suffix += stMuted.Render("  [term:bg]")
 		}
 	}
-	return line + "  " + strings.Join(parts, stMuted.Render("  ")) + suffix
+	content := "  " + strings.Join(parts, stMuted.Render("  ")) + suffix
+	// Hard-cap to terminal width so the bar never wraps onto a second line.
+	if m.width > 0 && lipgloss.Width(content) > m.width {
+		content = ansi.Truncate(content, m.width-1, "…")
+	}
+	return line + content
 }
 
 func (m dashModel) renderFooter() string {

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -93,12 +93,24 @@ const (
 	tiDNSServers
 	tiMgmtCPEndpointIP   // mgmt control-plane VIP (on-prem)
 	tiMgmtNodeIPRanges   // mgmt node IP ranges (on-prem)
-	tiProxmoxDefaultTmpl // Proxmox default VM template ID
-	tiProxmoxWLCPTmpl    // Proxmox workload control-plane template ID
-	tiProxmoxWLWorkerTmpl // Proxmox workload worker template ID
-	tiProxmoxMgmtCPTmpl  // Proxmox mgmt control-plane template ID
-	tiProxmoxMgmtWorkerTmpl // Proxmox mgmt worker template ID
-	tiArgoURL            // AppOfApps git URL
+	tiProxmoxDefaultTmpl    // Proxmox default VM template ID
+	tiProxmoxWLCPTmpl       // Proxmox workload control-plane template ID
+	tiProxmoxWLCPCores      // Proxmox workload CP CPU cores
+	tiProxmoxWLCPMemMiB     // Proxmox workload CP memory MiB
+	tiProxmoxWLCPDiskGB     // Proxmox workload CP boot disk GB
+	tiProxmoxWLWorkerTmpl   // Proxmox workload worker template ID
+	tiProxmoxWLWorkerCores  // Proxmox workload worker CPU cores
+	tiProxmoxWLWorkerMemMiB // Proxmox workload worker memory MiB
+	tiProxmoxWLWorkerDiskGB // Proxmox workload worker boot disk GB
+	tiProxmoxMgmtCPTmpl     // Proxmox mgmt control-plane template ID
+	tiProxmoxMgmtCPCores    // Proxmox mgmt CP CPU cores
+	tiProxmoxMgmtCPMemMiB   // Proxmox mgmt CP memory MiB
+	tiProxmoxMgmtCPDiskGB   // Proxmox mgmt CP boot disk GB
+	tiProxmoxMgmtWorkerTmpl    // Proxmox mgmt worker template ID
+	tiProxmoxMgmtWorkerCores   // Proxmox mgmt worker CPU cores
+	tiProxmoxMgmtWorkerMemMiB  // Proxmox mgmt worker memory MiB
+	tiProxmoxMgmtWorkerDiskGB  // Proxmox mgmt worker boot disk GB
+	tiArgoURL               // AppOfApps git URL
 	tiArgoPath      // AppOfApps git path
 	tiArgoRef       // AppOfApps git ref
 	tiImgMirror     // image registry mirror
@@ -175,42 +187,54 @@ const (
 	focOvercommit             // 22
 	focProxmoxDefaultTmpl    // 23 — Proxmox default VM template ID
 	focProxmoxWLCPTmpl       // 24 — Proxmox workload CP template ID
-	focProxmoxWLWorkerTmpl   // 25 — Proxmox workload worker template ID
-	focProxmoxMgmtCPTmpl     // 26 — Proxmox mgmt CP template ID
-	focProxmoxMgmtWorkerTmpl // 27 — Proxmox mgmt worker template ID
-	focCPEndpointIP          // 28
-	focNodeIPRanges           // 29
-	focGateway                // 30
-	focIPPrefix               // 31
-	focDNSServers             // 32
-	focMgmtCPEndpointIP      // 33 — on-prem mgmt cluster VIP
-	focMgmtNodeIPRanges      // 34 — on-prem mgmt node IP ranges
-	focArgoURL                // 35
-	focArgoPath               // 36
-	focArgoRef                // 37
-	focAirgapped              // 38
-	focImgMirror              // 39
-	focCABundle               // 40
-	focHelmMirror             // 41
-	focKyverno                // 42
-	focCertMgr                // 43
-	focCNPG                   // 44
-	focCrossplane             // 45
-	focExtSecrets             // 46
-	focOTEL                   // 47
-	focGrafana                // 48
-	focVictoria               // 49
-	focMetrics                // 50
-	focSPIRE                  // 51
-	focDCLoc                  // 52
-	focBudget                 // 53
-	focHeadroom               // 54
-	focTCO                    // 55 — TCO toggle (on-prem only)
-	focHWCost                 // 56
-	focHWWatts                // 57
-	focHWKWH                  // 58
-	focHWSupport              // 59
-	focCount                  // 60 — must be last
+	focProxmoxWLCPCores      // 25
+	focProxmoxWLCPMemMiB     // 26
+	focProxmoxWLCPDiskGB     // 27
+	focProxmoxWLWorkerTmpl   // 28 — Proxmox workload worker template ID
+	focProxmoxWLWorkerCores  // 29
+	focProxmoxWLWorkerMemMiB // 30
+	focProxmoxWLWorkerDiskGB // 31
+	focProxmoxMgmtCPTmpl     // 32 — Proxmox mgmt CP template ID
+	focProxmoxMgmtCPCores    // 33
+	focProxmoxMgmtCPMemMiB   // 34
+	focProxmoxMgmtCPDiskGB   // 35
+	focProxmoxMgmtWorkerTmpl    // 36 — Proxmox mgmt worker template ID
+	focProxmoxMgmtWorkerCores   // 37
+	focProxmoxMgmtWorkerMemMiB  // 38
+	focProxmoxMgmtWorkerDiskGB  // 39
+	focCPEndpointIP             // 40
+	focNodeIPRanges             // 41
+	focGateway                  // 42
+	focIPPrefix                 // 43
+	focDNSServers               // 44
+	focMgmtCPEndpointIP         // 45 — on-prem mgmt cluster VIP
+	focMgmtNodeIPRanges         // 46 — on-prem mgmt node IP ranges
+	focArgoURL                  // 47
+	focArgoPath                 // 48
+	focArgoRef                  // 49
+	focAirgapped                // 50
+	focImgMirror                // 51
+	focCABundle                 // 52
+	focHelmMirror               // 53
+	focKyverno                  // 54
+	focCertMgr                  // 55
+	focCNPG                     // 56
+	focCrossplane               // 57
+	focExtSecrets               // 58
+	focOTEL                     // 59
+	focGrafana                  // 60
+	focVictoria                 // 61
+	focMetrics                  // 62
+	focSPIRE                    // 63
+	focDCLoc                    // 64
+	focBudget                   // 65
+	focHeadroom                 // 66
+	focTCO                      // 67 — TCO toggle (on-prem only)
+	focHWCost                   // 68
+	focHWWatts                  // 69
+	focHWKWH                    // 70
+	focHWSupport                // 71
+	focCount                    // 72 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -262,13 +286,25 @@ var dashFields = []fieldMeta{
 	// ── Bootstrap (on-prem only) ─────────────────────────────────────────── fid 21-22
 	{fkSelect, siBootstrap, "bootstrap mode", "Bootstrap", false},
 	{fkToggle, toiOvercommit, "allow overcommit", "", false},
-	// ── Proxmox Templates (proxmox only) ─────────────────────────────────── fid 23-27
-	{fkText, tiProxmoxDefaultTmpl, "default tmpl ID", "Proxmox Templates", false},
-	{fkText, tiProxmoxWLCPTmpl, "  wl CP tmpl ID", "", false},
-	{fkText, tiProxmoxWLWorkerTmpl, "  wl worker tmpl ID", "", false},
-	{fkText, tiProxmoxMgmtCPTmpl, "  mgmt CP tmpl ID", "", false},
-	{fkText, tiProxmoxMgmtWorkerTmpl, "  mgmt worker tmpl ID", "", false},
-	// ── Workload Network (on-prem only) ──────────────────────────────────── fid 28-32
+	// ── Proxmox Config (proxmox only) ────────────────────────────────────── fid 23-39
+	{fkText, tiProxmoxDefaultTmpl, "default tmpl ID", "Proxmox Config", false},
+	{fkText, tiProxmoxWLCPTmpl, "wl CP tmpl ID", "", false},
+	{fkText, tiProxmoxWLCPCores, "  cores", "", false},
+	{fkText, tiProxmoxWLCPMemMiB, "  mem MiB", "", false},
+	{fkText, tiProxmoxWLCPDiskGB, "  disk GB", "", false},
+	{fkText, tiProxmoxWLWorkerTmpl, "wl worker tmpl ID", "", false},
+	{fkText, tiProxmoxWLWorkerCores, "  cores", "", false},
+	{fkText, tiProxmoxWLWorkerMemMiB, "  mem MiB", "", false},
+	{fkText, tiProxmoxWLWorkerDiskGB, "  disk GB", "", false},
+	{fkText, tiProxmoxMgmtCPTmpl, "mgmt CP tmpl ID", "", false},
+	{fkText, tiProxmoxMgmtCPCores, "  cores", "", false},
+	{fkText, tiProxmoxMgmtCPMemMiB, "  mem MiB", "", false},
+	{fkText, tiProxmoxMgmtCPDiskGB, "  disk GB", "", false},
+	{fkText, tiProxmoxMgmtWorkerTmpl, "mgmt worker tmpl ID", "", false},
+	{fkText, tiProxmoxMgmtWorkerCores, "  cores", "", false},
+	{fkText, tiProxmoxMgmtWorkerMemMiB, "  mem MiB", "", false},
+	{fkText, tiProxmoxMgmtWorkerDiskGB, "  disk GB", "", false},
+	// ── Workload Network (on-prem only) ──────────────────────────────────── fid 40-44
 	{fkText, tiCPEndpointIP, "CP endpoint IP", "Workload Network", false},
 	{fkText, tiNodeIPRanges, "node IP ranges", "", false},
 	{fkText, tiGateway, "gateway", "", false},
@@ -569,9 +605,21 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.textInputs[tiMgmtNodeIPRanges].SetValue(cfg.Mgmt.NodeIPRanges)
 	m.textInputs[tiProxmoxDefaultTmpl].SetValue(cfg.Providers.Proxmox.TemplateID)
 	m.textInputs[tiProxmoxWLCPTmpl].SetValue(cfg.WorkloadControlPlaneTemplateID)
+	m.textInputs[tiProxmoxWLCPCores].SetValue(cfg.Providers.Proxmox.ControlPlaneNumCores)
+	m.textInputs[tiProxmoxWLCPMemMiB].SetValue(cfg.Providers.Proxmox.ControlPlaneMemoryMiB)
+	m.textInputs[tiProxmoxWLCPDiskGB].SetValue(cfg.Providers.Proxmox.ControlPlaneBootVolumeSize)
 	m.textInputs[tiProxmoxWLWorkerTmpl].SetValue(cfg.WorkloadWorkerTemplateID)
+	m.textInputs[tiProxmoxWLWorkerCores].SetValue(cfg.Providers.Proxmox.WorkerNumCores)
+	m.textInputs[tiProxmoxWLWorkerMemMiB].SetValue(cfg.Providers.Proxmox.WorkerMemoryMiB)
+	m.textInputs[tiProxmoxWLWorkerDiskGB].SetValue(cfg.Providers.Proxmox.WorkerBootVolumeSize)
 	m.textInputs[tiProxmoxMgmtCPTmpl].SetValue(cfg.Providers.Proxmox.Mgmt.ControlPlaneTemplateID)
+	m.textInputs[tiProxmoxMgmtCPCores].SetValue(cfg.Providers.Proxmox.Mgmt.ControlPlaneNumCores)
+	m.textInputs[tiProxmoxMgmtCPMemMiB].SetValue(cfg.Providers.Proxmox.Mgmt.ControlPlaneMemoryMiB)
+	m.textInputs[tiProxmoxMgmtCPDiskGB].SetValue(cfg.Providers.Proxmox.Mgmt.ControlPlaneBootVolumeSize)
 	m.textInputs[tiProxmoxMgmtWorkerTmpl].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerTemplateID)
+	m.textInputs[tiProxmoxMgmtWorkerCores].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerNumCores)
+	m.textInputs[tiProxmoxMgmtWorkerMemMiB].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerMemoryMiB)
+	m.textInputs[tiProxmoxMgmtWorkerDiskGB].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerBootVolumeSize)
 	m.textInputs[tiArgoURL].SetValue(cfg.ArgoCD.AppOfAppsGitURL)
 	m.textInputs[tiArgoPath].SetValue(cfg.ArgoCD.AppOfAppsGitPath)
 	m.textInputs[tiArgoRef].SetValue(cfg.ArgoCD.AppOfAppsGitRef)
@@ -800,8 +848,11 @@ func (m *dashModel) isHidden(fid int) bool {
 	case focBootstrap, focOvercommit:
 		return isCloud
 	// Proxmox-specific: only when provider=proxmox.
-	case focProxmoxDefaultTmpl, focProxmoxWLCPTmpl, focProxmoxWLWorkerTmpl,
-		focProxmoxMgmtCPTmpl, focProxmoxMgmtWorkerTmpl:
+	case focProxmoxDefaultTmpl,
+		focProxmoxWLCPTmpl, focProxmoxWLCPCores, focProxmoxWLCPMemMiB, focProxmoxWLCPDiskGB,
+		focProxmoxWLWorkerTmpl, focProxmoxWLWorkerCores, focProxmoxWLWorkerMemMiB, focProxmoxWLWorkerDiskGB,
+		focProxmoxMgmtCPTmpl, focProxmoxMgmtCPCores, focProxmoxMgmtCPMemMiB, focProxmoxMgmtCPDiskGB,
+		focProxmoxMgmtWorkerTmpl, focProxmoxMgmtWorkerCores, focProxmoxMgmtWorkerMemMiB, focProxmoxMgmtWorkerDiskGB:
 		return m.selects[siProvider].value() != "proxmox"
 	// Workload network: on-prem only (cloud VPCs are fully managed).
 	case focCPEndpointIP, focNodeIPRanges, focGateway, focIPPrefix, focDNSServers:
@@ -2233,9 +2284,45 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 		snap.Providers.Proxmox.TemplateID = t
 	}
 	snap.WorkloadControlPlaneTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxWLCPTmpl].Value())
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWLCPCores].Value()); v != "" {
+		snap.Providers.Proxmox.ControlPlaneNumCores = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWLCPMemMiB].Value()); v != "" {
+		snap.Providers.Proxmox.ControlPlaneMemoryMiB = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWLCPDiskGB].Value()); v != "" {
+		snap.Providers.Proxmox.ControlPlaneBootVolumeSize = v
+	}
 	snap.WorkloadWorkerTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxWLWorkerTmpl].Value())
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWLWorkerCores].Value()); v != "" {
+		snap.Providers.Proxmox.WorkerNumCores = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWLWorkerMemMiB].Value()); v != "" {
+		snap.Providers.Proxmox.WorkerMemoryMiB = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWLWorkerDiskGB].Value()); v != "" {
+		snap.Providers.Proxmox.WorkerBootVolumeSize = v
+	}
 	snap.Providers.Proxmox.Mgmt.ControlPlaneTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxMgmtCPTmpl].Value())
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtCPCores].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.ControlPlaneNumCores = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtCPMemMiB].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.ControlPlaneMemoryMiB = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtCPDiskGB].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.ControlPlaneBootVolumeSize = v
+	}
 	snap.Providers.Proxmox.Mgmt.WorkerTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerTmpl].Value())
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerCores].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.WorkerNumCores = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerMemMiB].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.WorkerMemoryMiB = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerDiskGB].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.WorkerBootVolumeSize = v
+	}
 
 	// ArgoCD git coordinates.
 	if u := strings.TrimSpace(m.textInputs[tiArgoURL].Value()); u != "" {
@@ -2432,9 +2519,21 @@ func (m *dashModel) flushToCfg() {
 	m.cfg.Mgmt.NodeIPRanges = snap.Mgmt.NodeIPRanges
 	m.cfg.Providers.Proxmox.TemplateID = snap.Providers.Proxmox.TemplateID
 	m.cfg.WorkloadControlPlaneTemplateID = snap.WorkloadControlPlaneTemplateID
+	m.cfg.Providers.Proxmox.ControlPlaneNumCores = snap.Providers.Proxmox.ControlPlaneNumCores
+	m.cfg.Providers.Proxmox.ControlPlaneMemoryMiB = snap.Providers.Proxmox.ControlPlaneMemoryMiB
+	m.cfg.Providers.Proxmox.ControlPlaneBootVolumeSize = snap.Providers.Proxmox.ControlPlaneBootVolumeSize
 	m.cfg.WorkloadWorkerTemplateID = snap.WorkloadWorkerTemplateID
+	m.cfg.Providers.Proxmox.WorkerNumCores = snap.Providers.Proxmox.WorkerNumCores
+	m.cfg.Providers.Proxmox.WorkerMemoryMiB = snap.Providers.Proxmox.WorkerMemoryMiB
+	m.cfg.Providers.Proxmox.WorkerBootVolumeSize = snap.Providers.Proxmox.WorkerBootVolumeSize
 	m.cfg.Providers.Proxmox.Mgmt.ControlPlaneTemplateID = snap.Providers.Proxmox.Mgmt.ControlPlaneTemplateID
+	m.cfg.Providers.Proxmox.Mgmt.ControlPlaneNumCores = snap.Providers.Proxmox.Mgmt.ControlPlaneNumCores
+	m.cfg.Providers.Proxmox.Mgmt.ControlPlaneMemoryMiB = snap.Providers.Proxmox.Mgmt.ControlPlaneMemoryMiB
+	m.cfg.Providers.Proxmox.Mgmt.ControlPlaneBootVolumeSize = snap.Providers.Proxmox.Mgmt.ControlPlaneBootVolumeSize
 	m.cfg.Providers.Proxmox.Mgmt.WorkerTemplateID = snap.Providers.Proxmox.Mgmt.WorkerTemplateID
+	m.cfg.Providers.Proxmox.Mgmt.WorkerNumCores = snap.Providers.Proxmox.Mgmt.WorkerNumCores
+	m.cfg.Providers.Proxmox.Mgmt.WorkerMemoryMiB = snap.Providers.Proxmox.Mgmt.WorkerMemoryMiB
+	m.cfg.Providers.Proxmox.Mgmt.WorkerBootVolumeSize = snap.Providers.Proxmox.Mgmt.WorkerBootVolumeSize
 	m.cfg.Airgapped = snap.Airgapped
 	m.cfg.ImageRegistryMirror = snap.ImageRegistryMirror
 	m.cfg.InternalCABundle = snap.InternalCABundle

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -86,12 +86,14 @@ const (
 	tiObjVol
 	tiCacheCPU
 	tiCacheMem
-	tiCPEndpointIP // control-plane VIP
-	tiNodeIPRanges // node IP range
+	tiCPEndpointIP     // workload control-plane VIP
+	tiNodeIPRanges     // workload node IP range
 	tiGateway
 	tiIPPrefix
 	tiDNSServers
-	tiArgoURL       // AppOfApps git URL
+	tiMgmtCPEndpointIP // mgmt control-plane VIP (on-prem)
+	tiMgmtNodeIPRanges // mgmt node IP ranges (on-prem)
+	tiArgoURL          // AppOfApps git URL
 	tiArgoPath      // AppOfApps git path
 	tiArgoRef       // AppOfApps git ref
 	tiImgMirror     // image registry mirror
@@ -170,31 +172,33 @@ const (
 	focGateway             // 25
 	focIPPrefix            // 26
 	focDNSServers          // 27
-	focArgoURL             // 28
-	focArgoPath            // 29
-	focArgoRef             // 30
-	focAirgapped           // 31
-	focImgMirror           // 32
-	focCABundle            // 33
-	focHelmMirror          // 34
-	focKyverno             // 35
-	focCertMgr             // 36
-	focCNPG                // 37
-	focCrossplane          // 38
-	focExtSecrets          // 39
-	focOTEL                // 40
-	focGrafana             // 41
-	focVictoria            // 42
-	focMetrics             // 43
-	focSPIRE               // 44
-	focDCLoc               // 45
-	focBudget              // 46
-	focHeadroom            // 47
-	focHWCost              // 48
-	focHWWatts             // 49
-	focHWKWH               // 50
-	focHWSupport           // 51
-	focCount               // 52 — must be last
+	focMgmtCPEndpointIP   // 28 — on-prem mgmt cluster VIP
+	focMgmtNodeIPRanges   // 29 — on-prem mgmt node IP ranges
+	focArgoURL             // 30
+	focArgoPath            // 31
+	focArgoRef             // 32
+	focAirgapped           // 33
+	focImgMirror           // 34
+	focCABundle            // 35
+	focHelmMirror          // 36
+	focKyverno             // 37
+	focCertMgr             // 38
+	focCNPG                // 39
+	focCrossplane          // 40
+	focExtSecrets          // 41
+	focOTEL                // 42
+	focGrafana             // 43
+	focVictoria            // 44
+	focMetrics             // 45
+	focSPIRE               // 46
+	focDCLoc               // 47
+	focBudget              // 48
+	focHeadroom            // 49
+	focHWCost              // 50
+	focHWWatts             // 51
+	focHWKWH               // 52
+	focHWSupport           // 53
+	focCount               // 54 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -245,13 +249,16 @@ var dashFields = []fieldMeta{
 	// ── Bootstrap (on-prem only) ─────────────────────────────────────────── fid 21-22
 	{fkSelect, siBootstrap, "bootstrap mode", "Bootstrap", false},
 	{fkToggle, toiOvercommit, "allow overcommit", "", false},
-	// ── Network ──────────────────────────────────────────────────────────── fid 23-27
-	{fkText, tiCPEndpointIP, "CP endpoint IP", "Network", false},
+	// ── Workload Network (on-prem only) ──────────────────────────────────── fid 23-27
+	{fkText, tiCPEndpointIP, "CP endpoint IP", "Workload Network", false},
 	{fkText, tiNodeIPRanges, "node IP ranges", "", false},
 	{fkText, tiGateway, "gateway", "", false},
 	{fkText, tiIPPrefix, "IP prefix", "", false},
 	{fkText, tiDNSServers, "DNS servers", "", false},
-	// ── ArgoCD ───────────────────────────────────────────────────────────── fid 28-30
+	// ── Mgmt Network (on-prem only) ───────────────────────────────────────── fid 28-29
+	{fkText, tiMgmtCPEndpointIP, "CP endpoint IP", "Mgmt Network", false},
+	{fkText, tiMgmtNodeIPRanges, "node IP ranges", "", false},
+	// ── ArgoCD ───────────────────────────────────────────────────────────── fid 30-32
 	{fkText, tiArgoURL, "app-of-apps URL", "ArgoCD", false},
 	{fkText, tiArgoPath, "app-of-apps path", "", false},
 	{fkText, tiArgoRef, "app-of-apps ref", "", false},
@@ -538,6 +545,8 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.textInputs[tiGateway].SetValue(cfg.Gateway)
 	m.textInputs[tiIPPrefix].SetValue(cfg.IPPrefix)
 	m.textInputs[tiDNSServers].SetValue(cfg.DNSServers)
+	m.textInputs[tiMgmtCPEndpointIP].SetValue(cfg.Mgmt.ControlPlaneEndpointIP)
+	m.textInputs[tiMgmtNodeIPRanges].SetValue(cfg.Mgmt.NodeIPRanges)
 	m.textInputs[tiArgoURL].SetValue(cfg.ArgoCD.AppOfAppsGitURL)
 	m.textInputs[tiArgoPath].SetValue(cfg.ArgoCD.AppOfAppsGitPath)
 	m.textInputs[tiArgoRef].SetValue(cfg.ArgoCD.AppOfAppsGitRef)
@@ -601,7 +610,12 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 		m.selects[siBootstrap].cur = 1
 	}
 
-	provOptions := append([]string{"auto"}, provider.Registered()...)
+	// Build the initial provider list filtered to the resolved mode.
+	initialMode := "cloud"
+	if s.fork == forkOnPrem {
+		initialMode = "on-prem"
+	}
+	provOptions := providerListForMode(initialMode)
 	provCur := 0
 	for i, p := range provOptions {
 		if p == cfg.InfraProvider {
@@ -698,6 +712,48 @@ func (m dashModel) watchLogsCmd() tea.Cmd {
 
 func (m *dashModel) isCloud() bool { return m.selects[siMode].value() == "cloud" }
 
+// onPremProviders is the set of provider IDs that only make sense for bare-metal / VM deployments.
+var onPremProviders = map[string]bool{
+	"proxmox":   true,
+	"vsphere":   true,
+	"openstack": true,
+	"docker":    true,
+}
+
+// providerListForMode returns ["auto", ...] filtered to the providers that
+// match mode ("cloud" or "on-prem"). "auto" is always first.
+func providerListForMode(mode string) []string {
+	all := provider.Registered()
+	out := make([]string, 1, len(all)+1)
+	out[0] = "auto"
+	onPrem := mode == "on-prem"
+	for _, p := range all {
+		if onPremProviders[p] == onPrem {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// rebuildProviderList refreshes m.selects[siProvider].options for the current
+// mode. If the previously selected provider is still valid it is preserved;
+// otherwise the select resets to "auto". Also clears stale cost rows since the
+// affordable provider set may have changed.
+func (m dashModel) rebuildProviderList() dashModel {
+	newOpts := providerListForMode(m.selects[siMode].value())
+	cur := m.selects[siProvider].value()
+	newCur := 0
+	for i, p := range newOpts {
+		if p == cur {
+			newCur = i
+			break
+		}
+	}
+	m.selects[siProvider] = selectState{options: newOpts, cur: newCur}
+	m.costRows = nil // stale rows belong to the old mode
+	return m
+}
+
 func (m *dashModel) isHidden(fid int) bool {
 	isCloud := m.isCloud()
 	switch fid {
@@ -717,9 +773,12 @@ func (m *dashModel) isHidden(fid int) bool {
 	// On-prem only.
 	case focBootstrap, focOvercommit:
 		return isCloud
-	// Network: always visible.
+	// Workload network: on-prem only (cloud VPCs are fully managed).
 	case focCPEndpointIP, focNodeIPRanges, focGateway, focIPPrefix, focDNSServers:
-		return false
+		return isCloud
+	// Mgmt cluster network: on-prem only.
+	case focMgmtCPEndpointIP, focMgmtNodeIPRanges:
+		return isCloud
 	// ArgoCD: hidden when env=dev (ArgoCD is not installed in dev tier).
 	case focArgoURL, focArgoPath, focArgoRef:
 		return m.selects[siEnv].value() == "dev"
@@ -1308,11 +1367,17 @@ func (m dashModel) updateConfigTab(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch {
 		case key == tea.KeyRight || key == tea.KeyEnter || keyStr == "l":
 			m.selects[meta.subIdx].next()
+			if meta.subIdx == siMode {
+				m = m.rebuildProviderList()
+			}
 			if meta.costKey {
 				return m, m.markDirty()
 			}
 		case key == tea.KeyLeft || keyStr == "h":
 			m.selects[meta.subIdx].prev()
+			if meta.subIdx == siMode {
+				m = m.rebuildProviderList()
+			}
 			if meta.costKey {
 				return m, m.markDirty()
 			}
@@ -2118,12 +2183,14 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 		snap.InfraProviderDefaulted = false
 	}
 
-	// Network.
+	// Network (on-prem only; cloud fields are managed by the cloud provider).
 	snap.ControlPlaneEndpointIP = strings.TrimSpace(m.textInputs[tiCPEndpointIP].Value())
 	snap.NodeIPRanges = strings.TrimSpace(m.textInputs[tiNodeIPRanges].Value())
 	snap.Gateway = strings.TrimSpace(m.textInputs[tiGateway].Value())
 	snap.IPPrefix = strings.TrimSpace(m.textInputs[tiIPPrefix].Value())
 	snap.DNSServers = strings.TrimSpace(m.textInputs[tiDNSServers].Value())
+	snap.Mgmt.ControlPlaneEndpointIP = strings.TrimSpace(m.textInputs[tiMgmtCPEndpointIP].Value())
+	snap.Mgmt.NodeIPRanges = strings.TrimSpace(m.textInputs[tiMgmtNodeIPRanges].Value())
 
 	// ArgoCD git coordinates.
 	if u := strings.TrimSpace(m.textInputs[tiArgoURL].Value()); u != "" {
@@ -2316,6 +2383,8 @@ func (m *dashModel) flushToCfg() {
 	m.cfg.Gateway = snap.Gateway
 	m.cfg.IPPrefix = snap.IPPrefix
 	m.cfg.DNSServers = snap.DNSServers
+	m.cfg.Mgmt.ControlPlaneEndpointIP = snap.Mgmt.ControlPlaneEndpointIP
+	m.cfg.Mgmt.NodeIPRanges = snap.Mgmt.NodeIPRanges
 	m.cfg.Airgapped = snap.Airgapped
 	m.cfg.ImageRegistryMirror = snap.ImageRegistryMirror
 	m.cfg.InternalCABundle = snap.InternalCABundle

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -46,6 +46,7 @@ import (
 	"github.com/lpasquali/yage/internal/cost"
 	"github.com/lpasquali/yage/internal/obs"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/platform/sysinfo"
 	"github.com/lpasquali/yage/internal/pricing"
 	"github.com/lpasquali/yage/internal/provider"
 )
@@ -453,6 +454,9 @@ type ptyExitMsg struct{ err error }
 // saveKindMsg is returned when the background Save-to-Kind goroutine completes.
 type saveKindMsg struct{ err error }
 
+// sysStatsMsg carries a fresh sysinfo sample.
+type sysStatsMsg struct{ s sysinfo.Stats }
+
 // ─── select state ────────────────────────────────────────────────────────────
 
 type selectState struct {
@@ -526,6 +530,10 @@ type dashModel struct {
 	termH       int    // total pane height (border+title+content); ctrl+alt+↑/↓ to resize
 	termRaw     []byte // raw PTY output ring buffer (last 64 KB)
 
+	// system stats widget (top-right corner of tab bar)
+	sysSampler *sysinfo.Sampler
+	sysStats   sysinfo.Stats
+
 	width, height int
 	errMsg        string
 	done          bool // ctrl+s pressed
@@ -534,12 +542,15 @@ type dashModel struct {
 // ─── init ─────────────────────────────────────────────────────────────────────
 
 func newDashModel(cfg *config.Config, s *state) dashModel {
+	sampler := sysinfo.NewSampler()
+	sampler.Sample() // prime the counters; first real delta will be on the second call
 	m := dashModel{
 		cfg:         cfg,
 		s:           s,
 		focus:       focKindName,
 		costLoading: cfg.CostCompareEnabled, // show "fetching…" from the first frame
 		termH:       termPaneHDefault,
+		sysSampler:  sampler,
 	}
 
 	// Build text inputs.
@@ -766,7 +777,16 @@ func (m dashModel) Init() tea.Cmd {
 		m.textInputs[tiKindName].Focus(),
 		m.kickRefreshCmd(),
 		m.watchLogsCmd(),
+		m.sysStatsTickCmd(),
 	)
+}
+
+// sysStatsTickCmd samples process stats after 2 s and delivers a sysStatsMsg.
+func (m dashModel) sysStatsTickCmd() tea.Cmd {
+	sampler := m.sysSampler
+	return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {
+		return sysStatsMsg{s: sampler.Sample()}
+	})
 }
 
 // watchLogsCmd returns a command that waits for a log-ring notification and
@@ -1079,6 +1099,10 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.costLoading = true
 		m.costRows = nil // clear so each provider appears as it lands
 		return m, m.kickRefreshCmd()
+
+	case sysStatsMsg:
+		m.sysStats = msg.s
+		return m, m.sysStatsTickCmd()
 
 	case logUpdateMsg:
 		m.logLines = globalLogRing.Lines()
@@ -2620,7 +2644,7 @@ func (m dashModel) View() string {
 	return lipgloss.JoinVertical(lipgloss.Left, tabBar, content, termPane, bottomStrip, footer)
 }
 
-// renderTabBar renders the tab strip at the top.
+// renderTabBar renders the tab strip at the top with a right-aligned sysinfo widget.
 func (m dashModel) renderTabBar() string {
 	var parts []string
 	for i := dashTab(0); i < tabCount; i++ {
@@ -2632,17 +2656,108 @@ func (m dashModel) renderTabBar() string {
 		}
 	}
 	bar := strings.Join(parts, "  ")
-	title := stBold.Render("yage xapiri") + "  "
-	line := title + bar
+	title := stBold.Render("yage") + "  "
+	left := title + bar
+
+	// Right-align the sysinfo widget; pad between left and widget.
+	widget := m.renderSysWidget()
+	// Strip ANSI for width math (widget uses lipgloss styles).
+	wPlain := lipgloss.Width(widget)
+	lPlain := lipgloss.Width(left)
+	pad := m.width - lPlain - wPlain
+	if pad < 1 {
+		pad = 1
+	}
+	line := left + strings.Repeat(" ", pad) + widget
 	return lipgloss.NewStyle().Width(m.width).Render(line) + "\n" +
 		stMuted.Render(strings.Repeat("─", m.width))
 }
 
+// renderSysWidget returns a compact right-corner widget:
+//
+//	cpu 3%  128M  ↓1.2M ↑400B
+func (m dashModel) renderSysWidget() string {
+	s := m.sysStats
+	if s.MemRSSBytes == 0 {
+		return stMuted.Render("cpu –  – M  ↓–  ↑–")
+	}
+
+	// CPU colour: green < 20%, yellow < 60%, red ≥ 60%.
+	cpuStr := fmt.Sprintf("%.0f%%", s.CPUPercent)
+	var cpuStyle lipgloss.Style
+	switch {
+	case s.CPUPercent < 20:
+		cpuStyle = stOK
+	case s.CPUPercent < 60:
+		cpuStyle = stWarn
+	default:
+		cpuStyle = stBad
+	}
+
+	// Memory: colour by absolute size.
+	memStr := fmtBytes(s.MemRSSBytes)
+	var memStyle lipgloss.Style
+	switch {
+	case s.MemRSSBytes < 256<<20: // < 256 MB
+		memStyle = stOK
+	case s.MemRSSBytes < 512<<20: // < 512 MB
+		memStyle = stWarn
+	default:
+		memStyle = stBad
+	}
+
+	// Network: per-second rate; muted when idle, accent when data flowing.
+	var rxRate, txRate uint64
+	if s.DeltaDur > 0 {
+		secs := s.DeltaDur.Seconds()
+		rxRate = uint64(float64(s.NetRxDelta) / secs)
+		txRate = uint64(float64(s.NetTxDelta) / secs)
+	}
+	netStyle := stMuted
+	if rxRate > 1024 || txRate > 1024 {
+		netStyle = stAccent
+	}
+
+	return stMuted.Render("cpu ") + cpuStyle.Render(cpuStr) +
+		stMuted.Render("  ") + memStyle.Render(memStr) +
+		stMuted.Render("  ↓") + netStyle.Render(fmtRate(rxRate)) +
+		stMuted.Render(" ↑") + netStyle.Render(fmtRate(txRate))
+}
+
+// fmtBytes formats a byte count compactly: "128M", "4.2G", "512K", "64B".
+func fmtBytes(b uint64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1fG", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.0fM", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.0fK", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}
+
+// fmtRate formats bytes/s compactly: "1.2M/s", "400K/s", "64B/s", "0".
+func fmtRate(bps uint64) string {
+	if bps == 0 {
+		return "0"
+	}
+	switch {
+	case bps >= 1<<20:
+		return fmt.Sprintf("%.1fM/s", float64(bps)/float64(1<<20))
+	case bps >= 1<<10:
+		return fmt.Sprintf("%.0fK/s", float64(bps)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%dB/s", bps)
+	}
+}
+
 // tabAtX returns the dashTab at visible column x in the tab bar title row (Y==0).
-// The layout is: "yage xapiri  " (13 visible chars) then "[label]  " per tab
+// The layout is: "yage  " (6 visible chars) then "[label]  " per tab
 // separated by "  ". Returns (tab, true) when x falls inside a tab label.
 func tabAtX(x int) (dashTab, bool) {
-	col := len("yage xapiri  ") // 13 visible chars prefix
+	col := len("yage  ") // 6 visible chars prefix
 	for i := dashTab(0); i < tabCount; i++ {
 		w := len(tabLabels[i]) + 2 // "[" + label + "]"
 		if x >= col && x < col+w {

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -38,7 +38,6 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/ansi"
 	"github.com/creack/pty"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -139,17 +138,18 @@ const (
 	toiVictoria   = 12
 	toiMetrics    = 13
 	toiSPIRE      = 14
-	toiCount      = 15
+	toiTCO        = 15 // on-prem TCO fields enabled
+	toiCount      = 16
 )
 
 // ─── logical focus IDs (tab order) ───────────────────────────────────────────
 
 const (
-	focKindName     = iota // 0
-	focK8sVer              // 1
-	focWorkloadName        // 2
-	focProvider            // 3
-	focMode                // 4
+	focMode                = iota // 0
+	focProvider                   // 1
+	focKindName            // 2
+	focK8sVer              // 3
+	focWorkloadName        // 4
 	focEnv                 // 5
 	focResil               // 6
 	focApps                // 7
@@ -195,11 +195,12 @@ const (
 	focDCLoc               // 47
 	focBudget              // 48
 	focHeadroom            // 49
-	focHWCost              // 50
-	focHWWatts             // 51
-	focHWKWH               // 52
-	focHWSupport           // 53
-	focCount               // 54 — must be last
+	focTCO                 // 50 — TCO toggle (on-prem only)
+	focHWCost              // 51
+	focHWWatts             // 52
+	focHWKWH               // 53
+	focHWSupport           // 54
+	focCount               // 55 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -221,13 +222,14 @@ type fieldMeta struct {
 }
 
 var dashFields = []fieldMeta{
-	// ── Cluster ──────────────────────────────────────────────────────────── fid 0-3
+	// ── Mode ─────────────────────────────────────────────────────────────── fid 0
+	{fkSelect, siMode, "mode", "Mode", false},
+	// ── Provider ─────────────────────────────────────────────────────────── fid 1
+	{fkSelect, siProvider, "provider", "Provider", false},
+	// ── Cluster ──────────────────────────────────────────────────────────── fid 2-4
 	{fkText, tiKindName, "kind name", "Cluster", false},
 	{fkText, tiK8sVer, "k8s version", "", false},
 	{fkText, tiWorkloadName, "workload name", "", false},
-	{fkSelect, siProvider, "provider", "", false},
-	// ── Mode ─────────────────────────────────────────────────────────────── fid 4
-	{fkSelect, siMode, "mode", "Mode", false},
 	// ── Tier ─────────────────────────────────────────────────────────────── fid 5-6
 	{fkSelect, siEnv, "environment", "Tier", true},
 	{fkSelect, siResil, "resilience", "", true},
@@ -283,11 +285,12 @@ var dashFields = []fieldMeta{
 	{fkText, tiDCLoc, "data-center loc", "Geo", false},
 	{fkText, tiBudget, "budget USD/mo", "Budget", false},
 	{fkText, tiHeadroom, "headroom %", "", false},
-	// ── TCO (on-prem only) ───────────────────────────────────────────────── fid 48-51
-	{fkText, tiHWCost, "HW cost USD", "TCO", false},
-	{fkText, tiHWWatts, "HW watts", "", false},
-	{fkText, tiHWKWH, "kWh rate USD", "", false},
-	{fkText, tiHWSupport, "support USD/mo", "", false},
+	// ── TCO (on-prem only) ───────────────────────────────────────────────── fid 50-54
+	{fkToggle, toiTCO, "TCO enabled", "TCO", false},
+	{fkText, tiHWCost, "  HW cost USD", "", false},
+	{fkText, tiHWWatts, "  HW watts", "", false},
+	{fkText, tiHWKWH, "  kWh rate USD", "", false},
+	{fkText, tiHWSupport, "  support USD/mo", "", false},
 }
 
 // ─── tab IDs ─────────────────────────────────────────────────────────────────
@@ -642,6 +645,7 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.toggles[toiVictoria] = cfg.VictoriaMetricsEnabled
 	m.toggles[toiMetrics] = cfg.EnableMetricsServer
 	m.toggles[toiSPIRE] = cfg.SPIREEnabled
+	m.toggles[toiTCO] = cfg.HardwareCostUSD != 0 || cfg.HardwareWatts != 0 || cfg.HardwareKWHRateUSD != 0 || cfg.HardwareSupportUSDMonth != 0
 
 	// Cost-tab credential inputs — seeded from saved credentials.
 	credsInit := [ccCount]string{
@@ -759,8 +763,8 @@ func (m *dashModel) isHidden(fid int) bool {
 	isCloud := m.isCloud()
 	switch fid {
 	// Always visible.
-	case focKindName, focK8sVer, focWorkloadName, focProvider,
-		focMode, focEnv, focResil, focApps, focDBGB, focEgressGB:
+	case focMode, focProvider, focKindName, focK8sVer, focWorkloadName,
+		focEnv, focResil, focApps, focDBGB, focEgressGB:
 		return false
 	// Cloud sizing add-ons.
 	case focHasQueue, focHasObjStore, focHasCache:
@@ -795,9 +799,11 @@ func (m *dashModel) isHidden(fid int) bool {
 	// Geo + Budget: cloud only.
 	case focDCLoc, focBudget, focHeadroom:
 		return !isCloud
-	// TCO: on-prem only.
-	case focHWCost, focHWWatts, focHWKWH, focHWSupport:
+	// TCO: on-prem only; detail fields gated by the toggle.
+	case focTCO:
 		return isCloud
+	case focHWCost, focHWWatts, focHWKWH, focHWSupport:
+		return isCloud || !m.toggles[toiTCO]
 	}
 	return false
 }
@@ -2527,49 +2533,99 @@ func (m dashModel) renderBottomStrip() string {
 		return line + suffix
 	}
 	sorted := m.sortedCostRows()
-	var parts []string
-	for _, r := range sorted {
-		if r.Err != nil {
-			parts = append(parts, stMuted.Render(r.ProviderName+" n/a"))
-			continue
+
+	// Find cheapest once.
+	cheapest := 0.0
+	for _, rr := range sorted {
+		if rr.Err == nil && rr.Estimate.TotalUSDMonthly > 0 {
+			cheapest = rr.Estimate.TotalUSDMonthly
+			break
 		}
-		total := r.Estimate.TotalUSDMonthly
-		var style lipgloss.Style
-		cheapest := 0.0
-		for _, rr := range sorted {
-			if rr.Err == nil && rr.Estimate.TotalUSDMonthly > 0 {
-				cheapest = rr.Estimate.TotalUSDMonthly
-				break
-			}
-		}
-		budget := m.cfg.BudgetUSDMonth
-		switch {
-		case budget > 0 && total > budget:
-			style = stBad
-		case cheapest > 0 && total <= cheapest:
-			style = stOK
-		case cheapest > 0 && total > cheapest*1.5:
-			style = stWarn
-		default:
-			style = lipgloss.NewStyle()
-		}
-		parts = append(parts, style.Render(fmt.Sprintf("%s $%.0f", r.ProviderName, total)))
 	}
+	budget := m.cfg.BudgetUSDMonth
+
+	// Build fixed suffix first so we know how much room is left.
 	suffix := ""
 	if m.costLoading {
-		suffix = stMuted.Render("  (fetching…)")
+		suffix = "  (fetching…)"
 	}
 	if m.termRunning {
 		if m.termFocused {
-			suffix += stAccent.Render("  [term:active]")
+			suffix += "  [term:active]"
 		} else {
-			suffix += stMuted.Render("  [term:bg]")
+			suffix += "  [term:bg]"
 		}
 	}
-	content := "  " + strings.Join(parts, stMuted.Render("  ")) + suffix
-	// Hard-cap to terminal width so the bar never wraps onto a second line.
-	if m.width > 0 && lipgloss.Width(content) > m.width {
-		content = ansi.Truncate(content, m.width-1, "…")
+
+	// Greedy-fit: add provider tokens one by one until they no longer fit.
+	// Each token is "  provider $NNN". Width budget = terminal width - 2
+	// (leading indent) - suffix width. When a token doesn't fit we stop and
+	// show "+N more" so the bar is always exactly one line.
+	avail := m.width
+	if avail <= 0 {
+		avail = 120 // safe default before WindowSizeMsg
+	}
+	avail -= 2 // leading "  "
+	avail -= len(suffix)
+
+	var kept []string
+	skipped := 0
+	sep := "  "
+	for _, r := range sorted {
+		var token string
+		if r.Err != nil {
+			token = r.ProviderName + " n/a"
+		} else {
+			token = fmt.Sprintf("%s $%.0f", r.ProviderName, r.Estimate.TotalUSDMonthly)
+		}
+		need := len(token)
+		if len(kept) > 0 {
+			need += len(sep)
+		}
+		if need > avail {
+			skipped++
+			continue
+		}
+		avail -= need
+		kept = append(kept, token)
+	}
+
+	// Render kept tokens with colour.
+	var renderedParts []string
+	for _, tok := range kept {
+		name := strings.Fields(tok)[0]
+		// Find the original row to apply colour.
+		var style lipgloss.Style
+		for _, r := range sorted {
+			if r.ProviderName != name {
+				continue
+			}
+			if r.Err != nil {
+				style = stMuted
+			} else {
+				total := r.Estimate.TotalUSDMonthly
+				switch {
+				case budget > 0 && total > budget:
+					style = stBad
+				case cheapest > 0 && total <= cheapest:
+					style = stOK
+				case cheapest > 0 && total > cheapest*1.5:
+					style = stWarn
+				default:
+					style = lipgloss.NewStyle()
+				}
+			}
+			break
+		}
+		renderedParts = append(renderedParts, style.Render(tok))
+	}
+
+	content := "  " + strings.Join(renderedParts, stMuted.Render(sep))
+	if skipped > 0 {
+		content += stMuted.Render(fmt.Sprintf("  +%d more", skipped))
+	}
+	if suffix != "" {
+		content += stMuted.Render(suffix)
 	}
 	return line + content
 }

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -224,9 +224,9 @@ var dashFields = []fieldMeta{
 	{fkText, tiKindName, "kind name", "Cluster", false},
 	{fkText, tiK8sVer, "k8s version", "", false},
 	{fkText, tiWorkloadName, "workload name", "", false},
-	{fkSelect, siProvider, "provider", "", true},
+	{fkSelect, siProvider, "provider", "", false},
 	// ── Mode ─────────────────────────────────────────────────────────────── fid 4
-	{fkSelect, siMode, "mode", "Mode", true},
+	{fkSelect, siMode, "mode", "Mode", false},
 	// ── Tier ─────────────────────────────────────────────────────────────── fid 5-6
 	{fkSelect, siEnv, "environment", "Tier", true},
 	{fkSelect, siResil, "resilience", "", true},
@@ -2143,6 +2143,12 @@ func (m dashModel) kickRefreshCmd() tea.Cmd {
 		return nil
 	}
 	snap := m.buildSnapshotCfg()
+	// Cost comparison always queries every credentialled provider, regardless
+	// of which provider the user has selected in the config tab. The provider
+	// select is a deployment choice, not a cost-filter. Clear InfraProvider
+	// so StreamWithFilter does not narrow to a single provider.
+	snap.InfraProvider = ""
+	snap.InfraProviderDefaulted = true
 	// Capture credentials at dispatch time: pricing.SetCredentials is a
 	// process-global set before kind is connected, so it may not include
 	// credentials loaded later from the cost-compare-config Secret.

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -45,6 +45,7 @@ import (
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/cost"
 	"github.com/lpasquali/yage/internal/obs"
+	"github.com/lpasquali/yage/internal/platform/installer"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/platform/sysinfo"
 	"github.com/lpasquali/yage/internal/pricing"
@@ -111,6 +112,12 @@ const (
 	tiProxmoxMgmtWorkerCores   // Proxmox mgmt worker CPU cores
 	tiProxmoxMgmtWorkerMemMiB  // Proxmox mgmt worker memory MiB
 	tiProxmoxMgmtWorkerDiskGB  // Proxmox mgmt worker boot disk GB
+	tiProxmoxPool           // Proxmox workload cluster pool
+	tiProxmoxMgmtPool       // Proxmox mgmt cluster pool
+	tiProxmoxCPCount        // workload CP replica count
+	tiProxmoxWorkerCount    // workload worker replica count
+	tiProxmoxMgmtCPCount    // mgmt CP replica count
+	tiProxmoxMgmtWorkerCount // mgmt worker replica count
 	tiArgoURL               // AppOfApps git URL
 	tiArgoPath      // AppOfApps git path
 	tiArgoRef       // AppOfApps git ref
@@ -203,7 +210,13 @@ const (
 	focProxmoxMgmtWorkerCores   // 37
 	focProxmoxMgmtWorkerMemMiB  // 38
 	focProxmoxMgmtWorkerDiskGB  // 39
-	focCPEndpointIP             // 40
+	focProxmoxPool              // 40 — Proxmox workload pool name
+	focProxmoxMgmtPool          // 41 — Proxmox mgmt pool name
+	focProxmoxCPCount           // 42 — workload CP replica count
+	focProxmoxWorkerCount       // 43 — workload worker replica count
+	focProxmoxMgmtCPCount       // 44 — mgmt CP replica count
+	focProxmoxMgmtWorkerCount   // 45 — mgmt worker replica count
+	focCPEndpointIP             // 46
 	focNodeIPRanges             // 41
 	focGateway                  // 42
 	focIPPrefix                 // 43
@@ -305,6 +318,12 @@ var dashFields = []fieldMeta{
 	{fkText, tiProxmoxMgmtWorkerCores, "  cores", "", false},
 	{fkText, tiProxmoxMgmtWorkerMemMiB, "  mem MiB", "", false},
 	{fkText, tiProxmoxMgmtWorkerDiskGB, "  disk GB", "", false},
+	{fkText, tiProxmoxPool, "wl pool name", "", false},
+	{fkText, tiProxmoxMgmtPool, "mgmt pool name", "", false},
+	{fkText, tiProxmoxCPCount, "wl CP replicas", "", false},
+	{fkText, tiProxmoxWorkerCount, "wl worker replicas", "", false},
+	{fkText, tiProxmoxMgmtCPCount, "mgmt CP replicas", "", false},
+	{fkText, tiProxmoxMgmtWorkerCount, "mgmt worker replicas", "", false},
 	// ── Workload Network (on-prem only) ──────────────────────────────────── fid 40-44
 	{fkText, tiCPEndpointIP, "CP endpoint IP", "Workload Network", false},
 	{fkText, tiNodeIPRanges, "node IP ranges", "", false},
@@ -356,12 +375,24 @@ const (
 	tabCosts                 // 2 — full provider comparison table + bar chart
 	tabLogs                  // 3 — scrollable ring buffer
 	tabDeploy                // 4 — save-to-kind + start-deploy actions
-	tabHelp                  // 5 — keyboard shortcuts reference (always second-to-last)
-	tabAbout                 // 6 — version / license / URL (always last)
+	tabDeps                  // 5 — CLI deps check + upgrade; provider image arm64 status
+	tabHelp                  // 6 — keyboard shortcuts reference (always second-to-last)
+	tabAbout                 // 7 — version / license / URL (always last)
 	tabCount                 // must be last
 )
 
-var tabLabels = [tabCount]string{"config", "editor", "costs", "logs", "deploy", "help", "about"}
+var tabLabels = [tabCount]string{"config", "editor", "costs", "logs", "deploy", "deps", "help", "about"}
+
+// ─── config-tab sub-screen state ─────────────────────────────────────────────
+
+// cfgScreenKind is the sub-state of the config tab.
+type cfgScreenKind int
+
+const (
+	cfgScreenList    cfgScreenKind = iota // show list of existing configs
+	cfgScreenNewName                       // enter name for a new config
+	cfgScreenEdit                          // full interactive edit form (all tabs accessible)
+)
 
 // ─── cost-tab credential input slots ─────────────────────────────────────────
 
@@ -454,6 +485,27 @@ type ptyExitMsg struct{ err error }
 // saveKindMsg is returned when the background Save-to-Kind goroutine completes.
 type saveKindMsg struct{ err error }
 
+// depsCheckMsg carries the result of a background dependency check.
+type depsCheckMsg struct {
+	tools  []installer.DepCheck
+	images []installer.ImageCheck
+}
+
+// depsUpgradeMsg carries the result of a background dependency upgrade.
+type depsUpgradeMsg struct{ err error }
+
+// cfgListMsg carries the result of listing bootstrap configs on the kind cluster.
+type cfgListMsg struct {
+	candidates []kindsync.BootstrapCandidate
+	err        error
+}
+
+// cfgEntryLoadMsg carries the fully merged config for a selected bootstrap entry.
+type cfgEntryLoadMsg struct {
+	cfg *config.Config
+	err error
+}
+
 // sysStatsMsg carries a fresh sysinfo sample.
 type sysStatsMsg struct{ s sysinfo.Stats }
 
@@ -471,6 +523,32 @@ func (s *selectState) prev() {
 	s.cur = (s.cur - 1 + len(s.options)) % len(s.options)
 }
 
+// ─── cost time-window presets ─────────────────────────────────────────────────
+
+type costWindowPreset struct {
+	d     time.Duration
+	label string // human-readable full name, shown in the selector
+	short string // compact suffix used in tables and bottom bar
+}
+
+// costWindows is the ordered list of time-window presets. Index 6 (1 month)
+// is the default. The user cycles through them with [ / ] in the costs tab.
+var costWindows = []costWindowPreset{
+	{time.Second, "1 second", "/sec"},
+	{time.Minute, "1 minute", "/min"},
+	{time.Hour, "1 hour", "/hr"},
+	{8 * time.Hour, "8 hours", "/8h"},
+	{24 * time.Hour, "1 day", "/day"},
+	{7 * 24 * time.Hour, "1 week", "/wk"},
+	{30 * 24 * time.Hour, "1 month", "/mo"},   // default (index 6)
+	{365 * 24 * time.Hour, "1 year", "/yr"},
+}
+
+const costDefaultPeriodIdx = 6 // 1 month
+
+// costMonthSecs is the number of seconds in the reference month (30 days).
+const costMonthSecs = 30 * 24 * 3600.0
+
 // ─── dashboard model ─────────────────────────────────────────────────────────
 
 type dashModel struct {
@@ -487,11 +565,12 @@ type dashModel struct {
 	activeTab dashTab
 
 	// cost preview
-	costRows       []cost.CloudCost
-	costLoading    bool
-	costVendor     int // which vendor's detail block is shown (index into costRows)
-	refreshPending bool
-	lastDirty      time.Time
+	costRows        []cost.CloudCost
+	costLoading     bool
+	costVendor      int // which vendor's detail block is shown (index into costRows)
+	costPeriodIdx   int // index into costWindows (default 6 = 1 month)
+	refreshPending  bool
+	lastDirty       time.Time
 
 	// logs tab
 	logLines       []string        // snapshot from globalLogRing
@@ -514,6 +593,21 @@ type dashModel struct {
 	saveKindDone    bool
 	saveKindErr     error
 	deployRequested bool
+
+	// config tab selection state (cfgScreenList / cfgScreenNewName / cfgScreenEdit)
+	cfgScreen     cfgScreenKind
+	cfgCandidates []kindsync.BootstrapCandidate
+	cfgListCursor int
+	cfgLoading    bool
+	cfgLoadErr    string
+	cfgNewInput   textinput.Model
+
+	// deps tab
+	depsTools    []installer.DepCheck
+	depsImages   []installer.ImageCheck
+	depsRunning  bool   // check or upgrade in flight
+	depsFocused  int    // 0=check button, 1=upgrade button
+	depsStatus   string // last result summary
 
 	// editor tab — kind resource browser
 	editorItems    []editorResource // listed Secrets+ConfigMaps in yage-system
@@ -545,12 +639,13 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	sampler := sysinfo.NewSampler()
 	sampler.Sample() // prime the counters; first real delta will be on the second call
 	m := dashModel{
-		cfg:         cfg,
-		s:           s,
-		focus:       focKindName,
-		costLoading: cfg.CostCompareEnabled, // show "fetching…" from the first frame
-		termH:       termPaneHDefault,
-		sysSampler:  sampler,
+		cfg:           cfg,
+		s:             s,
+		focus:         focKindName,
+		costLoading:   cfg.CostCompareEnabled, // show "fetching…" from the first frame
+		termH:         termPaneHDefault,
+		sysSampler:    sampler,
+		costPeriodIdx: costDefaultPeriodIdx,
 	}
 
 	// Build text inputs.
@@ -631,6 +726,12 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.textInputs[tiProxmoxMgmtWorkerCores].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerNumCores)
 	m.textInputs[tiProxmoxMgmtWorkerMemMiB].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerMemoryMiB)
 	m.textInputs[tiProxmoxMgmtWorkerDiskGB].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerBootVolumeSize)
+	m.textInputs[tiProxmoxPool].SetValue(cfg.Providers.Proxmox.Pool)
+	m.textInputs[tiProxmoxMgmtPool].SetValue(cfg.Providers.Proxmox.Mgmt.Pool)
+	m.textInputs[tiProxmoxCPCount].SetValue(cfg.ControlPlaneMachineCount)
+	m.textInputs[tiProxmoxWorkerCount].SetValue(cfg.WorkerMachineCount)
+	m.textInputs[tiProxmoxMgmtCPCount].SetValue(cfg.Mgmt.ControlPlaneMachineCount)
+	m.textInputs[tiProxmoxMgmtWorkerCount].SetValue(cfg.Mgmt.WorkerMachineCount)
 	m.textInputs[tiArgoURL].SetValue(cfg.ArgoCD.AppOfAppsGitURL)
 	m.textInputs[tiArgoPath].SetValue(cfg.ArgoCD.AppOfAppsGitPath)
 	m.textInputs[tiArgoRef].SetValue(cfg.ArgoCD.AppOfAppsGitRef)
@@ -763,6 +864,19 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	fi.Width = 40
 	m.logFilterInput = fi
 
+	// Config selection state: skip the list when --config-name was passed explicitly.
+	if cfg.ConfigNameExplicit {
+		m.cfgScreen = cfgScreenEdit
+	} else {
+		m.cfgScreen = cfgScreenList
+		m.cfgLoading = true
+		ni := textinput.New()
+		ni.Placeholder = "e.g. prod-eu-low-cost"
+		ni.Prompt = "> "
+		ni.Width = 40
+		m.cfgNewInput = ni
+	}
+
 	// Focus the first visible input.
 	cmd := m.textInputs[tiKindName].Focus()
 	_ = cmd // will be returned from Init
@@ -772,13 +886,17 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 
 func (m dashModel) Init() tea.Cmd {
 	m.lastDirty = time.Now()
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		textinput.Blink,
 		m.textInputs[tiKindName].Focus(),
 		m.kickRefreshCmd(),
 		m.watchLogsCmd(),
 		m.sysStatsTickCmd(),
-	)
+	}
+	if m.cfgScreen == cfgScreenList && m.cfgLoading {
+		cmds = append(cmds, m.loadCfgListCmd())
+	}
+	return tea.Batch(cmds...)
 }
 
 // sysStatsTickCmd samples process stats after 2 s and delivers a sysStatsMsg.
@@ -872,7 +990,9 @@ func (m *dashModel) isHidden(fid int) bool {
 		focProxmoxWLCPTmpl, focProxmoxWLCPCores, focProxmoxWLCPMemMiB, focProxmoxWLCPDiskGB,
 		focProxmoxWLWorkerTmpl, focProxmoxWLWorkerCores, focProxmoxWLWorkerMemMiB, focProxmoxWLWorkerDiskGB,
 		focProxmoxMgmtCPTmpl, focProxmoxMgmtCPCores, focProxmoxMgmtCPMemMiB, focProxmoxMgmtCPDiskGB,
-		focProxmoxMgmtWorkerTmpl, focProxmoxMgmtWorkerCores, focProxmoxMgmtWorkerMemMiB, focProxmoxMgmtWorkerDiskGB:
+		focProxmoxMgmtWorkerTmpl, focProxmoxMgmtWorkerCores, focProxmoxMgmtWorkerMemMiB, focProxmoxMgmtWorkerDiskGB,
+		focProxmoxPool, focProxmoxMgmtPool,
+		focProxmoxCPCount, focProxmoxWorkerCount, focProxmoxMgmtCPCount, focProxmoxMgmtWorkerCount:
 		return m.selects[siProvider].value() != "proxmox"
 	// Workload network: on-prem only (cloud VPCs are fully managed).
 	case focCPEndpointIP, focNodeIPRanges, focGateway, focIPPrefix, focDNSServers:
@@ -880,9 +1000,8 @@ func (m *dashModel) isHidden(fid int) bool {
 	// Mgmt cluster network: on-prem only.
 	case focMgmtCPEndpointIP, focMgmtNodeIPRanges:
 		return isCloud
-	// ArgoCD: hidden when env=dev (ArgoCD is not installed in dev tier).
 	case focArgoURL, focArgoPath, focArgoRef:
-		return m.selects[siEnv].value() == "dev"
+		return false
 	// Airgap.
 	case focAirgapped:
 		return false
@@ -1022,7 +1141,7 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Action == tea.MouseActionPress &&
 			msg.Button == tea.MouseButtonLeft &&
 			msg.Y == 0 {
-			if tab, ok := tabAtX(msg.X); ok && tab != tabEditor {
+			if tab, ok := tabAtX(msg.X); ok && tab != tabEditor && m.cfgReady() {
 				m.activeTab = tab
 				return m, nil
 			}
@@ -1201,6 +1320,76 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case depsCheckMsg:
+		m.depsRunning = false
+		m.depsTools = msg.tools
+		m.depsImages = msg.images
+		bad := 0
+		for _, t := range msg.tools {
+			if !t.OK && !t.Skip {
+				bad++
+			}
+		}
+		if bad == 0 {
+			m.depsStatus = "all tools OK"
+		} else {
+			m.depsStatus = fmt.Sprintf("%d tool(s) need upgrade", bad)
+		}
+		return m, nil
+
+	case depsUpgradeMsg:
+		m.depsRunning = false
+		if msg.err != nil {
+			m.depsStatus = "upgrade failed: " + msg.err.Error()
+		} else {
+			m.depsStatus = "upgrade complete"
+		}
+		cfg := m.cfg
+		return m, func() tea.Msg {
+			return depsCheckMsg{
+				tools:  installer.CheckDeps(cfg),
+				images: installer.CheckProviderImages(cfg),
+			}
+		}
+
+	case cfgListMsg:
+		m.cfgLoading = false
+		if msg.err != nil {
+			m.cfgLoadErr = msg.err.Error()
+		} else {
+			m.cfgCandidates = msg.candidates
+			m.cfgListCursor = 0
+			m.cfgLoadErr = ""
+		}
+		return m, nil
+
+	case cfgEntryLoadMsg:
+		m.cfgLoading = false
+		if msg.err != nil {
+			m.cfgLoadErr = msg.err.Error()
+			return m, nil
+		}
+		// Copy loaded fields back into the original cfg pointer so the
+		// caller's reference remains valid after the dashboard exits.
+		*m.cfg = *msg.cfg
+		m.s.initFromConfig(m.cfg)
+		// Rebuild all text inputs / selects / toggles from the loaded cfg.
+		newM := newDashModel(m.cfg, m.s)
+		newM.cfgScreen = cfgScreenEdit
+		newM.activeTab = tabConfig
+		newM.width = m.width
+		newM.height = m.height
+		newM.costRows = m.costRows
+		newM.costLoading = m.costLoading
+		newM.costPeriodIdx = m.costPeriodIdx
+		newM.logLines = m.logLines
+		newM.logSub = m.logSub
+		newM.sysSampler = m.sysSampler
+		newM.sysStats = m.sysStats
+		// Keep the original cfg pointer so callers stay in sync.
+		newM.cfg = m.cfg
+		return newM, tea.Batch(textinput.Blink, newM.kickRefreshCmd(), newM.watchLogsCmd())
+
 	case saveCostCredsMsg:
 		if msg.err != nil {
 			obs.Global().Error("save cost credentials to kind", msg.err)
@@ -1243,45 +1432,54 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
-		// ── Alt+1..7: universal tab switching — works even inside text fields ──
-		switch keyStr {
-		case "alt+1":
-			m.activeTab = tabConfig
-			return m, nil
-		case "alt+2":
-			m.activeTab = tabEditor
-			return m, m.switchToEditorTab()
-		case "alt+3":
-			m.activeTab = tabCosts
-			return m, nil
-		case "alt+4":
-			m.activeTab = tabLogs
-			return m, nil
-		case "alt+5":
-			m.activeTab = tabDeploy
-			return m, nil
-		case "alt+6":
-			m.activeTab = tabHelp
-			return m, nil
-		case "alt+7":
-			m.activeTab = tabAbout
-			return m, nil
+		// ── Ctrl+Alt+1..8: universal tab switching — works even inside text fields ──
+		// Tab switching is locked until a config entry is selected (cfgScreenEdit).
+		if m.cfgReady() {
+			switch keyStr {
+			case "ctrl+alt+1":
+				m.activeTab = tabConfig
+				return m, nil
+			case "ctrl+alt+2":
+				m.activeTab = tabEditor
+				return m, m.switchToEditorTab()
+			case "ctrl+alt+3":
+				m.activeTab = tabCosts
+				return m, nil
+			case "ctrl+alt+4":
+				m.activeTab = tabLogs
+				return m, nil
+			case "ctrl+alt+5":
+				m.activeTab = tabDeploy
+				return m, nil
+			case "ctrl+alt+6":
+				m.activeTab = tabDeps
+				return m, nil
+			case "ctrl+alt+7":
+				m.activeTab = tabHelp
+				return m, nil
+			case "ctrl+alt+8":
+				m.activeTab = tabAbout
+				return m, nil
+			}
 		}
 
 		// ── Ctrl+Left/Right: universal tab cycling — works even inside text fields ──
-		if key == tea.KeyCtrlLeft {
-			m.activeTab = (m.activeTab - 1 + tabCount) % tabCount
-			if m.activeTab == tabEditor {
-				return m, m.switchToEditorTab()
+		// Locked until a config entry is selected.
+		if m.cfgReady() {
+			if key == tea.KeyCtrlLeft {
+				m.activeTab = (m.activeTab - 1 + tabCount) % tabCount
+				if m.activeTab == tabEditor {
+					return m, m.switchToEditorTab()
+				}
+				return m, nil
 			}
-			return m, nil
-		}
-		if key == tea.KeyCtrlRight {
-			m.activeTab = (m.activeTab + 1) % tabCount
-			if m.activeTab == tabEditor {
-				return m, m.switchToEditorTab()
+			if key == tea.KeyCtrlRight {
+				m.activeTab = (m.activeTab + 1) % tabCount
+				if m.activeTab == tabEditor {
+					return m, m.switchToEditorTab()
+				}
+				return m, nil
 			}
-			return m, nil
 		}
 
 		// ── Ctrl+T: start embedded terminal / toggle focus ──
@@ -1370,33 +1568,36 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// ── tab switching: left/right arrows or number keys 1-7 ──
-		// (Only when not in a text input on the config tab.)
-		inTextField := (m.activeTab == tabConfig && dashFields[m.focus].kind == fkText) ||
+		// ── tab switching: left/right arrows or number keys 1-8 ──
+		// (Only when not in a text input on the config tab, and a config is selected.)
+		inTextField := (m.activeTab == tabConfig && m.cfgReady() && dashFields[m.focus].kind == fkText) ||
 			(m.activeTab == tabLogs && m.logFiltering)
 		switch {
-		case !inTextField && keyStr == "1":
+		case !inTextField && keyStr == "1" && m.cfgReady():
 			m.activeTab = tabConfig
 			return m, nil
-		case !inTextField && keyStr == "2":
+		case !inTextField && keyStr == "2" && m.cfgReady():
 			m.activeTab = tabEditor
 			return m, m.switchToEditorTab()
-		case !inTextField && keyStr == "3":
+		case !inTextField && keyStr == "3" && m.cfgReady():
 			m.activeTab = tabCosts
 			return m, nil
-		case !inTextField && keyStr == "4":
+		case !inTextField && keyStr == "4" && m.cfgReady():
 			m.activeTab = tabLogs
 			return m, nil
-		case !inTextField && keyStr == "5":
+		case !inTextField && keyStr == "5" && m.cfgReady():
 			m.activeTab = tabDeploy
 			return m, nil
-		case !inTextField && keyStr == "6":
+		case !inTextField && keyStr == "6" && m.cfgReady():
+			m.activeTab = tabDeps
+			return m, nil
+		case !inTextField && keyStr == "7" && m.cfgReady():
 			m.activeTab = tabHelp
 			return m, nil
-		case !inTextField && keyStr == "7":
+		case !inTextField && keyStr == "8" && m.cfgReady():
 			m.activeTab = tabAbout
 			return m, nil
-		case (key == tea.KeyLeft || key == tea.KeyRight) && !inTextField && m.activeTab != tabConfig:
+		case (key == tea.KeyLeft || key == tea.KeyRight) && !inTextField && m.activeTab != tabConfig && m.cfgReady():
 			// Only cycle tabs with arrows when not on config (config uses arrows for fields).
 			if key == tea.KeyLeft {
 				m.activeTab = (m.activeTab - 1 + tabCount) % tabCount
@@ -1416,24 +1617,116 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateConfigTab(msg)
 
 		case tabEditor:
-			return m.updateEditorTab(msg)
+			if m.cfgReady() {
+				return m.updateEditorTab(msg)
+			}
 
 		case tabLogs:
-			return m.updateLogsTab(msg)
+			if m.cfgReady() {
+				return m.updateLogsTab(msg)
+			}
 
 		case tabCosts:
-			return m.updateCostsTab(msg)
+			if m.cfgReady() {
+				return m.updateCostsTab(msg)
+			}
 
 		case tabDeploy:
-			return m.updateDeployTab(msg)
+			if m.cfgReady() {
+				return m.updateDeployTab(msg)
+			}
+
+		case tabDeps:
+			if m.cfgReady() {
+				return m.updateDepsTab(msg)
+			}
 		}
 	}
 
 	return m, nil
 }
 
-// updateConfigTab handles key events while the config tab is active.
+// updateConfigTab dispatches key events to the active config sub-screen.
 func (m dashModel) updateConfigTab(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.cfgScreen {
+	case cfgScreenList:
+		return m.updateCfgListScreen(msg)
+	case cfgScreenNewName:
+		return m.updateCfgNewNameScreen(msg)
+	default:
+		return m.updateCfgEditScreen(msg)
+	}
+}
+
+// updateCfgListScreen handles keys on the config-list screen.
+func (m dashModel) updateCfgListScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.cfgLoading {
+		return m, nil
+	}
+	key := msg.Type
+	keyStr := msg.String()
+	total := len(m.cfgCandidates) + 1 // +1 for the "[ + New config ]" sentinel
+	switch {
+	case key == tea.KeyUp || keyStr == "k":
+		if m.cfgListCursor > 0 {
+			m.cfgListCursor--
+		}
+	case key == tea.KeyDown || keyStr == "j":
+		if m.cfgListCursor < total-1 {
+			m.cfgListCursor++
+		}
+	case key == tea.KeyEnter:
+		if m.cfgListCursor == len(m.cfgCandidates) {
+			// New config sentinel selected.
+			m.cfgScreen = cfgScreenNewName
+			m.cfgNewInput.SetValue("")
+			cmd := m.cfgNewInput.Focus()
+			return m, cmd
+		}
+		c := m.cfgCandidates[m.cfgListCursor]
+		m.cfgLoading = true
+		m.cfgLoadErr = ""
+		return m, m.loadCfgEntryCmd(c)
+	case keyStr == "n":
+		m.cfgScreen = cfgScreenNewName
+		m.cfgNewInput.SetValue("")
+		cmd := m.cfgNewInput.Focus()
+		return m, cmd
+	case keyStr == "r":
+		m.cfgLoading = true
+		m.cfgLoadErr = ""
+		m.cfgCandidates = nil
+		return m, m.loadCfgListCmd()
+	}
+	return m, nil
+}
+
+// updateCfgNewNameScreen handles keys while entering a new config name.
+func (m dashModel) updateCfgNewNameScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.Type
+	switch {
+	case key == tea.KeyEsc:
+		m.cfgScreen = cfgScreenList
+		m.cfgNewInput.Blur()
+		return m, nil
+	case key == tea.KeyEnter:
+		name := strings.TrimSpace(m.cfgNewInput.Value())
+		m.cfgNewInput.Blur()
+		if name != "" {
+			m.cfg.ConfigName = name
+			m.cfg.ConfigNameExplicit = true
+		}
+		m.cfgScreen = cfgScreenEdit
+		return m, textinput.Blink
+	default:
+		var cmd tea.Cmd
+		m.cfgNewInput, cmd = m.cfgNewInput.Update(msg)
+		return m, cmd
+	}
+}
+
+// updateCfgEditScreen handles key events in the full config edit form.
+func (m dashModel) updateCfgEditScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.Type
 	keyStr := msg.String()
 
@@ -1620,6 +1913,14 @@ func (m dashModel) updateCostsTab(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.costRows) > 0 {
 			m.costVendor = (m.costVendor + 1) % len(m.costRows)
 		}
+	case keyStr == "[":
+		if m.costPeriodIdx > 0 {
+			m.costPeriodIdx--
+		}
+	case keyStr == "]":
+		if m.costPeriodIdx < len(costWindows)-1 {
+			m.costPeriodIdx++
+		}
 	}
 	return m, nil
 }
@@ -1707,6 +2008,36 @@ func (m *dashModel) saveCostCredsCmd() tea.Cmd {
 }
 
 // ─── editor tab ───────────────────────────────────────────────────────────────
+
+// cfgReady reports whether a configuration entry has been selected and the
+// full edit form is active. When false, tab switching is locked.
+func (m dashModel) cfgReady() bool { return m.cfgScreen == cfgScreenEdit }
+
+// loadCfgListCmd fetches all bootstrap-config Secrets from the kind cluster.
+func (m dashModel) loadCfgListCmd() tea.Cmd {
+	kindName := m.cfg.KindClusterName
+	return func() tea.Msg {
+		return cfgListMsg{candidates: kindsync.ListBootstrapCandidates(kindName)}
+	}
+}
+
+// loadCfgEntryCmd merges the selected bootstrap entry into a cfg copy and
+// returns cfgEntryLoadMsg with the fully-populated config.
+func (m dashModel) loadCfgEntryCmd(c kindsync.BootstrapCandidate) tea.Cmd {
+	cfgCopy := *m.cfg
+	return func() tea.Msg {
+		cfgCopy.KindClusterName = c.KindCluster
+		cfgCopy.ConfigName = c.ConfigName
+		if !cfgCopy.WorkloadClusterNameExplicit && c.Workload != "" {
+			cfgCopy.WorkloadClusterName = c.Workload
+		}
+		_ = kindsync.MergeBootstrapConfigFromKind(&cfgCopy)
+		kindsync.MergeBootstrapSecretsFromKind(&cfgCopy)
+		_ = kindsync.ReadCostCompareSecret(&cfgCopy)
+		disableProvidersMissingCredentials(&cfgCopy)
+		return cfgEntryLoadMsg{cfg: &cfgCopy}
+	}
+}
 
 // switchToEditorTab transitions to the editor tab and kicks a resource list load.
 func (m dashModel) switchToEditorTab() tea.Cmd {
@@ -2253,13 +2584,15 @@ func (m dashModel) kickRefreshCmd() tea.Cmd {
 	// Cost comparison always queries every credentialled provider, regardless
 	// of which provider the user has selected in the config tab. The provider
 	// select is a deployment choice, not a cost-filter. Clear InfraProvider
-	// so StreamWithFilter does not narrow to a single provider.
+	// so StreamWithRegions does not narrow to a single provider.
 	snap.InfraProvider = ""
 	snap.InfraProviderDefaulted = true
 	// Capture credentials at dispatch time: pricing.SetCredentials is a
 	// process-global set before kind is connected, so it may not include
 	// credentials loaded later from the cost-compare-config Secret.
 	c := m.cfg.Cost.Credentials
+	s := m.s
+	cfg := m.cfg
 	return func() tea.Msg {
 		pricing.SetCredentials(pricing.Credentials{
 			AWSAccessKeyID:     c.AWSAccessKeyID,
@@ -2269,8 +2602,40 @@ func (m dashModel) kickRefreshCmd() tea.Cmd {
 			DigitalOceanToken:  c.DigitalOceanToken,
 			IBMCloudAPIKey:     c.IBMCloudAPIKey,
 		})
-		ch := make(chan cost.CloudCost, 16)
-		cost.StreamWithFilter(&snap, cost.ScopeCloudOnly, globalLogRing, ch)
+
+		// Determine geo lat/lon for nearest-region ranking.
+		// Source priority: --geoip outbound IP > DataCenterLocation centroid.
+		var geoLat, geoLon float64
+		geoOK := false
+		if cfg.GeoIPEnabled {
+			s.ensureGeoLookup()
+			geoLat, geoLon, geoOK = s.geoLat, s.geoLon, s.geoOK
+		}
+		if !geoOK {
+			dc := strings.ToUpper(strings.TrimSpace(snap.Cost.Currency.DataCenterLocation))
+			if dc != "" {
+				if lat, lon, ok := pricing.CountryCentroid(dc); ok {
+					geoLat, geoLon, geoOK = lat, lon, true
+				}
+			}
+		}
+
+		// Build per-provider region list (up to 4 nearest). When geo is
+		// unavailable, regionsByProvider stays nil and StreamWithRegions
+		// falls back to the region already in snap per provider.
+		var regionsByProvider map[string][]string
+		if geoOK {
+			regionsByProvider = map[string][]string{}
+			for _, name := range []string{"aws", "azure", "gcp", "hetzner", "digitalocean", "linode", "oci", "ibmcloud"} {
+				ranked := geoRankedRegions(name, geoLat, geoLon, 4)
+				if len(ranked) > 0 {
+					regionsByProvider[name] = ranked
+				}
+			}
+		}
+
+		ch := make(chan cost.CloudCost, 64)
+		cost.StreamWithRegions(&snap, cost.ScopeCloudOnly, regionsByProvider, globalLogRing, ch)
 		row, ok := <-ch
 		return costRowMsg{row: row, ch: ch, done: !ok}
 	}
@@ -2347,6 +2712,24 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerDiskGB].Value()); v != "" {
 		snap.Providers.Proxmox.Mgmt.WorkerBootVolumeSize = v
 	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxPool].Value()); v != "" {
+		snap.Providers.Proxmox.Pool = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtPool].Value()); v != "" {
+		snap.Providers.Proxmox.Mgmt.Pool = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxCPCount].Value()); v != "" {
+		snap.ControlPlaneMachineCount = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxWorkerCount].Value()); v != "" {
+		snap.WorkerMachineCount = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtCPCount].Value()); v != "" {
+		snap.Mgmt.ControlPlaneMachineCount = v
+	}
+	if v := strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerCount].Value()); v != "" {
+		snap.Mgmt.WorkerMachineCount = v
+	}
 
 	// ArgoCD git coordinates.
 	if u := strings.TrimSpace(m.textInputs[tiArgoURL].Value()); u != "" {
@@ -2400,18 +2783,8 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 	}
 
 	env := envTier(m.selects[siEnv].value())
-	switch env {
-	case envDev:
-		snap.ArgoCD.Enabled = false
-		snap.ArgoCD.WorkloadEnabled = false
-	case envStaging:
-		snap.ArgoCD.Enabled = true
-		snap.ArgoCD.WorkloadEnabled = false
-	case envProd:
-		snap.ArgoCD.Enabled = true
-		snap.ArgoCD.WorkloadEnabled = true
-		snap.CertManagerEnabled = true
-	}
+	snap.ArgoCD.Enabled = true
+	snap.ArgoCD.WorkloadEnabled = true
 
 	var resil resilienceTier
 	switch m.selects[siResil].value() {
@@ -2558,6 +2931,12 @@ func (m *dashModel) flushToCfg() {
 	m.cfg.Providers.Proxmox.Mgmt.WorkerNumCores = snap.Providers.Proxmox.Mgmt.WorkerNumCores
 	m.cfg.Providers.Proxmox.Mgmt.WorkerMemoryMiB = snap.Providers.Proxmox.Mgmt.WorkerMemoryMiB
 	m.cfg.Providers.Proxmox.Mgmt.WorkerBootVolumeSize = snap.Providers.Proxmox.Mgmt.WorkerBootVolumeSize
+	m.cfg.Providers.Proxmox.Pool = snap.Providers.Proxmox.Pool
+	m.cfg.Providers.Proxmox.Mgmt.Pool = snap.Providers.Proxmox.Mgmt.Pool
+	m.cfg.ControlPlaneMachineCount = snap.ControlPlaneMachineCount
+	m.cfg.WorkerMachineCount = snap.WorkerMachineCount
+	m.cfg.Mgmt.ControlPlaneMachineCount = snap.Mgmt.ControlPlaneMachineCount
+	m.cfg.Mgmt.WorkerMachineCount = snap.Mgmt.WorkerMachineCount
 	m.cfg.Airgapped = snap.Airgapped
 	m.cfg.ImageRegistryMirror = snap.ImageRegistryMirror
 	m.cfg.InternalCABundle = snap.InternalCABundle
@@ -2633,12 +3012,14 @@ func (m dashModel) View() string {
 		content = m.renderCostsTab(m.width, usable)
 	case tabLogs:
 		content = m.renderLogsTab(m.width, usable)
+	case tabDeploy:
+		content = m.renderDeployTab(m.width, usable)
+	case tabDeps:
+		content = m.renderDepsTab(m.width, usable)
 	case tabHelp:
 		content = m.renderHelpTab(m.width, usable)
 	case tabAbout:
 		content = m.renderAboutTab(m.width, usable)
-	case tabDeploy:
-		content = m.renderDeployTab(m.width, usable)
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Left, tabBar, content, termPane, bottomStrip, footer)
@@ -2824,10 +3205,14 @@ func (m dashModel) renderBottomStrip() string {
 	sep := "  "
 	for _, r := range sorted {
 		var token string
+		label := r.ProviderName
+		if r.Region != "" {
+			label = r.ProviderName + "/" + r.Region
+		}
 		if r.Err != nil {
-			token = r.ProviderName + " n/a"
+			token = label + " n/a"
 		} else {
-			token = fmt.Sprintf("%s $%.0f", r.ProviderName, r.Estimate.TotalUSDMonthly)
+			token = label + " " + m.formatCost(r.Estimate.TotalUSDMonthly)
 		}
 		need := len(token)
 		if len(kept) > 0 {
@@ -2855,8 +3240,10 @@ func (m dashModel) renderBottomStrip() string {
 				style = stMuted
 			} else {
 				total := r.Estimate.TotalUSDMonthly
+				scaledTotal := m.costForPeriod(total)
+				scaledBudget := m.costForPeriod(budget)
 				switch {
-				case budget > 0 && total > budget:
+				case scaledBudget > 0 && scaledTotal > scaledBudget:
 					style = stBad
 				case cheapest > 0 && total <= cheapest:
 					style = stOK
@@ -2883,18 +3270,31 @@ func (m dashModel) renderBottomStrip() string {
 
 func (m dashModel) renderFooter() string {
 	shellHint := stMuted.Render("ctrl+t") + " terminal  "
-	tabHint := stMuted.Render("1-7/alt+1-7/ctrl+◄►") + " tabs  "
+	tabHint := stMuted.Render("1-8/ctrl+alt+1-8/ctrl+◄►") + " tabs  "
 	var keys string
 	switch m.activeTab {
 	case tabConfig:
-		keys = stMuted.Render("tab/⇧tab") + " navigate  " +
-			stMuted.Render("space") + " toggle  " +
-			stMuted.Render("◄ ►") + " select  " +
-			shellHint +
-			stMuted.Render("ctrl+l") + " logs  " +
-			tabHint +
-			stAccent.Render("ctrl+s") + " save  " +
-			stMuted.Render("esc/q") + " abort"
+		switch m.cfgScreen {
+		case cfgScreenList:
+			keys = stMuted.Render("↑/↓") + " navigate  " +
+				stMuted.Render("enter") + " select  " +
+				stMuted.Render("n") + " new  " +
+				stMuted.Render("r") + " refresh  " +
+				stMuted.Render("esc/q") + " quit"
+		case cfgScreenNewName:
+			keys = stMuted.Render("enter") + " confirm  " +
+				stMuted.Render("esc") + " back  " +
+				stMuted.Render("esc/q") + " quit"
+		default:
+			keys = stMuted.Render("tab/⇧tab") + " navigate  " +
+				stMuted.Render("space") + " toggle  " +
+				stMuted.Render("◄ ►") + " select  " +
+				shellHint +
+				stMuted.Render("ctrl+l") + " logs  " +
+				tabHint +
+				stAccent.Render("ctrl+s") + " save  " +
+				stMuted.Render("esc/q") + " abort"
+		}
 	case tabLogs:
 		keys = stMuted.Render("j/k") + " scroll  " +
 			stMuted.Render("g/G") + " top/bottom  " +
@@ -2910,6 +3310,7 @@ func (m dashModel) renderFooter() string {
 				stMuted.Render("esc/q") + " abort"
 		} else {
 			keys = stMuted.Render("j/k") + " scroll  " +
+				stMuted.Render("[/]") + " time window  " +
 				stMuted.Render("c") + " edit creds  " +
 				shellHint + tabHint +
 				stAccent.Render("ctrl+s") + " save  " +
@@ -2920,6 +3321,11 @@ func (m dashModel) renderFooter() string {
 			stMuted.Render("enter") + " activate  " +
 			shellHint + tabHint +
 			stAccent.Render("ctrl+s") + " save  " +
+			stMuted.Render("esc/q") + " abort"
+	case tabDeps:
+		keys = stMuted.Render("tab") + " focus  " +
+			stMuted.Render("enter") + " activate  " +
+			shellHint + tabHint +
 			stMuted.Render("esc/q") + " abort"
 	default:
 		keys = shellHint + tabHint +
@@ -2938,10 +3344,95 @@ func (m dashModel) renderFooter() string {
 const labelW = 18
 const inputW = 13
 
-// renderConfigTab renders the full-width interactive config form.
+// renderConfigTab dispatches to the active config sub-screen renderer.
 func (m dashModel) renderConfigTab(w, h int) string {
+	switch m.cfgScreen {
+	case cfgScreenList:
+		return m.renderCfgListScreen(w, h)
+	case cfgScreenNewName:
+		return m.renderCfgNewNameScreen(w, h)
+	default:
+		return m.renderCfgEditScreen(w, h)
+	}
+}
+
+// renderCfgListScreen renders the list of existing bootstrap configs.
+func (m dashModel) renderCfgListScreen(w, h int) string {
+	var lines []string
+	title := fmt.Sprintf(" Configurations on kind cluster %q", m.cfg.KindClusterName)
+	lines = append(lines, stHdr.Render(title))
+	lines = append(lines, stMuted.Render(strings.Repeat("─", w)))
+	lines = append(lines, "")
+
+	if m.cfgLoading {
+		lines = append(lines, stMuted.Render("  loading…"))
+	} else if m.cfgLoadErr != "" {
+		lines = append(lines, stBad.Render("  "+m.cfgLoadErr))
+		lines = append(lines, stMuted.Render("  r = retry"))
+	} else {
+		for i, c := range m.cfgCandidates {
+			cursor := "  "
+			if i == m.cfgListCursor {
+				cursor = stAccent.Render("▸ ")
+			}
+			lines = append(lines, cursor+c.Label())
+		}
+		lines = append(lines, "")
+		// "[ + New config ]" sentinel.
+		sentinelIdx := len(m.cfgCandidates)
+		newLabel := "[ + New config ]"
+		if m.cfgListCursor == sentinelIdx {
+			lines = append(lines, stAccent.Render("▸ ")+stAccent.Render(newLabel))
+		} else {
+			lines = append(lines, "  "+stMuted.Render(newLabel))
+		}
+	}
+
+	lines = append(lines, "")
+	if m.cfgLoading {
+		lines = append(lines, stMuted.Render("  please wait…"))
+	} else {
+		lines = append(lines, stMuted.Render("  ↑/↓  navigate    enter  select    n  new config    r  refresh    esc/q  quit"))
+	}
+	lines = append(lines, "")
+	lines = append(lines, stWarn.Render("  ⚠ Select a configuration to unlock all tabs"))
+
+	for len(lines) < h {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines[:min(len(lines), h)], "\n")
+}
+
+// renderCfgNewNameScreen renders the new config name input.
+func (m dashModel) renderCfgNewNameScreen(w, h int) string {
+	var lines []string
+	lines = append(lines, stHdr.Render(" New configuration name"))
+	lines = append(lines, stMuted.Render(strings.Repeat("─", w)))
+	lines = append(lines, "")
+	lines = append(lines, stMuted.Render("  Enter a name for the new bootstrap config."))
+	lines = append(lines, stMuted.Render("  This becomes the Secret name prefix in yage-system."))
+	lines = append(lines, "  (leave blank to use the workload cluster name as the default)")
+	lines = append(lines, "")
+	lines = append(lines, "  "+m.cfgNewInput.View())
+	lines = append(lines, "")
+	lines = append(lines, stMuted.Render("  enter  confirm    esc  back to list"))
+
+	for len(lines) < h {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines[:min(len(lines), h)], "\n")
+}
+
+// renderCfgEditScreen renders the full interactive config edit form.
+func (m dashModel) renderCfgEditScreen(w, h int) string {
 	var lines []string
 	lastSection := ""
+
+	// Config name badge at the top.
+	if name := m.cfg.ConfigName; name != "" {
+		lines = append(lines, stMuted.Render(fmt.Sprintf("  config: %s", name)))
+		lines = append(lines, "")
+	}
 
 	for fid := 0; fid < focCount; fid++ {
 		if m.isHidden(fid) {
@@ -3066,7 +3557,10 @@ func (m dashModel) renderField(fid int, focused bool, w int) string {
 func (m dashModel) renderCostsTab(w, h int) string {
 	var lines []string
 
-	title := stHdr.Render(" Provider cost comparison ($/mo)")
+	win := m.activeCostWindow()
+	windowSel := stMuted.Render("[") + win.label + stMuted.Render("]") +
+		stMuted.Render("  ◄[ ]►")
+	title := stHdr.Render(" Provider cost comparison") + "  " + windowSel
 	if m.costLoading {
 		title += stMuted.Render("  refreshing…")
 	}
@@ -3113,11 +3607,12 @@ func (m dashModel) renderCostsTab(w, h int) string {
 			m.costVendor = 0
 		}
 
-		// Table header.
-		hdr := fmt.Sprintf("  %-14s %10s  %s", "provider", "$/mo", "bar chart")
+		// Table header. The provider/region column is 22 chars wide to
+		// accommodate "digitalocean nyc3" and similar combined labels.
+		hdr := fmt.Sprintf("  %-22s %10s  %s", "provider/region", m.activeCostWindow().short, "bar chart")
 		lines = append(lines, stHdr.Render(hdr))
 
-		barW := w - 32 // chars available for bar
+		barW := w - 40 // chars available for bar (2+22+1+10+2 = 37 fixed + margin)
 		if barW < 10 {
 			barW = 10
 		}
@@ -3131,7 +3626,11 @@ func (m dashModel) renderCostsTab(w, h int) string {
 		lines = append(lines, "")
 		if m.costVendor < len(sorted) {
 			sel := sorted[m.costVendor]
-			lines = append(lines, stMuted.Render(fmt.Sprintf(" ─ %s detail ─", sel.ProviderName)))
+			detailLabel := sel.ProviderName
+			if sel.Region != "" {
+				detailLabel = sel.ProviderName + " " + sel.Region
+			}
+			lines = append(lines, stMuted.Render(fmt.Sprintf(" ─ %s detail ─", detailLabel)))
 			if sel.Err != nil {
 				lines = append(lines, stBad.Render("  "+sel.Err.Error()))
 			} else {
@@ -3144,17 +3643,23 @@ func (m dashModel) renderCostsTab(w, h int) string {
 					if len(name) > maxNameW {
 						name = name[:maxNameW] + "…"
 					}
-					lineStr := fmt.Sprintf("  %-*s %8.2f", maxNameW, name, it.SubtotalUSD)
+					lineStr := fmt.Sprintf("  %-*s %10s", maxNameW, name, m.formatCost(it.SubtotalUSD))
 					lines = append(lines, lineStr)
 				}
 			}
 			if budget > 0 && sel.Err == nil {
 				lines = append(lines, "")
-				total := sel.Estimate.TotalUSDMonthly
-				if total <= budget {
-					lines = append(lines, stOK.Render(fmt.Sprintf("  ✓ within budget (%.0f / %.0f)", total, budget)))
+				scaledTotal := m.costForPeriod(sel.Estimate.TotalUSDMonthly)
+				scaledBudget := m.costForPeriod(budget)
+				w := m.activeCostWindow()
+				if scaledTotal <= scaledBudget {
+					lines = append(lines, stOK.Render(fmt.Sprintf("  ✓ within budget (%s / %s%s)",
+						m.formatCost(sel.Estimate.TotalUSDMonthly),
+						fmt.Sprintf("$%.0f", scaledBudget), w.short)))
 				} else {
-					lines = append(lines, stBad.Render(fmt.Sprintf("  ✗ over budget (%.0f / %.0f)", total, budget)))
+					lines = append(lines, stBad.Render(fmt.Sprintf("  ✗ over budget (%s / %s%s)",
+						m.formatCost(sel.Estimate.TotalUSDMonthly),
+						fmt.Sprintf("$%.0f", scaledBudget), w.short)))
 				}
 			}
 		}
@@ -3203,24 +3708,37 @@ func (m dashModel) renderCostsCredsForm() []string {
 	return lines
 }
 
-// renderCostRow renders a single provider row with bar chart.
+// renderCostRow renders a single provider+region row with bar chart.
 func (m dashModel) renderCostRow(r cost.CloudCost, selected bool, cheapest, maxTotal, budget float64, barW int) string {
 	prefix := "  "
 	if selected {
 		prefix = stAccent.Render("▌ ")
 	}
 
+	// Combined provider/region label (max 22 chars).
+	label := r.ProviderName
+	if r.Region != "" {
+		label = r.ProviderName + " " + r.Region
+	}
+	if len(label) > 22 {
+		label = label[:21] + "…"
+	}
+
 	if r.Err != nil {
-		row := prefix + stMuted.Render(fmt.Sprintf("%-14s  n/a", r.ProviderName))
+		row := prefix + stMuted.Render(fmt.Sprintf("%-22s  n/a", label))
 		return row
 	}
 
 	total := r.Estimate.TotalUSDMonthly
-	totalStr := fmt.Sprintf("$%8.2f", total)
+	totalStr := fmt.Sprintf("%10s", m.formatCost(total))
 
+	// Budget comparison uses period-scaled values so the budget field
+	// (which is always monthly) is also scaled before the check.
+	scaledBudget := m.costForPeriod(budget)
+	scaledTotal := m.costForPeriod(total)
 	var style lipgloss.Style
 	switch {
-	case budget > 0 && total > budget:
+	case scaledBudget > 0 && scaledTotal > scaledBudget:
 		style = stBad
 	case cheapest > 0 && total <= cheapest:
 		style = stOK
@@ -3241,16 +3759,16 @@ func (m dashModel) renderCostRow(r cost.CloudCost, selected bool, cheapest, maxT
 	bar := strings.Repeat("█", barLen)
 	bar = style.Render(bar)
 
-	name := fmt.Sprintf("%-14s", r.ProviderName)
+	nameStr := fmt.Sprintf("%-22s", label)
 	if selected {
-		name = stAccent.Render(name)
+		nameStr = stAccent.Render(nameStr)
 		totalStr = style.Bold(true).Render(totalStr)
 	} else {
-		name = style.Render(name)
+		nameStr = style.Render(nameStr)
 		totalStr = style.Render(totalStr)
 	}
 
-	return prefix + name + " " + totalStr + "  " + bar
+	return prefix + nameStr + " " + totalStr + "  " + bar
 }
 
 // renderVendorRow is kept for backward compatibility (used by bottom strip logic).
@@ -3410,8 +3928,8 @@ func (m dashModel) renderHelpTab(w, h int) string {
 		stMuted.Render(strings.Repeat("─", w)),
 		"",
 		stBold.Render("  Tab switching"),
-		"  " + stAccent.Render("1-7") + "              switch tabs (when not in text field)",
-		"  " + stAccent.Render("alt+1-7") + "          switch tabs (works from any context)",
+		"  " + stAccent.Render("1-8") + "              switch tabs (when not in text field)",
+		"  " + stAccent.Render("ctrl+alt+1-8") + "       switch tabs (works from any context)",
 		"  " + stAccent.Render("ctrl+← →") + "         cycle tabs (works from any context)",
 		"  " + stAccent.Render("← →") + "              cycle tabs (when not in text field)",
 		"",
@@ -3527,6 +4045,120 @@ func (m dashModel) renderDeployTab(w, h int) string {
 	return strings.Join(lines[:min(len(lines), h)], "\n")
 }
 
+// ─── deps tab ────────────────────────────────────────────────────────────────
+
+// updateDepsTab handles key events on the deps tab.
+func (m dashModel) updateDepsTab(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.Type
+	switch {
+	case key == tea.KeyTab || key == tea.KeyDown:
+		m.depsFocused = (m.depsFocused + 1) % 2
+	case key == tea.KeyShiftTab || key == tea.KeyUp:
+		m.depsFocused = (m.depsFocused - 1 + 2) % 2
+	case key == tea.KeyEnter || key == tea.KeySpace:
+		if m.depsRunning {
+			return m, nil
+		}
+		cfg := m.cfg
+		switch m.depsFocused {
+		case 0: // check button
+			m.depsRunning = true
+			m.depsStatus = "checking…"
+			return m, func() tea.Msg {
+				return depsCheckMsg{
+					tools:  installer.CheckDeps(cfg),
+					images: installer.CheckProviderImages(cfg),
+				}
+			}
+		case 1: // upgrade button
+			m.depsRunning = true
+			m.depsStatus = "upgrading…"
+			return m, func() tea.Msg {
+				return depsUpgradeMsg{err: installer.UpgradeDeps(cfg)}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m dashModel) renderDepsTab(w, h int) string {
+	var lines []string
+	lines = append(lines, stHdr.Render(" Dependencies"))
+	lines = append(lines, stMuted.Render(strings.Repeat("─", w)))
+	lines = append(lines, "")
+
+	// buttons
+	btnCheck := "[Check]"
+	btnUpgrade := "[Upgrade All]"
+	if m.depsFocused == 0 {
+		btnCheck = stAccent.Render("▸ " + btnCheck)
+		btnUpgrade = stMuted.Render("  " + btnUpgrade)
+	} else {
+		btnCheck = stMuted.Render("  " + btnCheck)
+		btnUpgrade = stAccent.Render("▸ " + btnUpgrade)
+	}
+	lines = append(lines, btnCheck+"  "+btnUpgrade)
+	lines = append(lines, "")
+
+	// status line
+	if m.depsStatus != "" {
+		lines = append(lines, stMuted.Render("  "+m.depsStatus))
+		lines = append(lines, "")
+	}
+
+	if len(m.depsTools) > 0 {
+		lines = append(lines, stBold.Render("  CLI tools"))
+		for _, t := range m.depsTools {
+			var badge string
+			switch {
+			case t.Skip:
+				badge = stMuted.Render("  ◦")
+			case t.OK:
+				badge = stOK.Render("  ✓")
+			default:
+				badge = stBad.Render("  ✗")
+			}
+			have := t.Have
+			if len(have) > 20 {
+				have = have[:20]
+			}
+			line := fmt.Sprintf("%s %-12s  have: %-20s  want: %s", badge, t.Name, have, t.Want)
+			lines = append(lines, line)
+		}
+		lines = append(lines, "")
+	}
+
+	if len(m.depsImages) > 0 {
+		lines = append(lines, stBold.Render("  Provider images (arm64)"))
+		for _, img := range m.depsImages {
+			var badge string
+			switch {
+			case img.Err:
+				badge = stWarn.Render("  ?")
+			case img.Arm64:
+				badge = stOK.Render("  ✓")
+			default:
+				badge = stBad.Render("  ✗")
+			}
+			ref := img.Image
+			if len(ref) > 55 {
+				ref = "…" + ref[len(ref)-54:]
+			}
+			lines = append(lines, fmt.Sprintf("%s %-18s  %s", badge, img.Name, stMuted.Render(ref)))
+		}
+		lines = append(lines, "")
+	}
+
+	if len(m.depsTools) == 0 && len(m.depsImages) == 0 && m.depsStatus == "" {
+		lines = append(lines, stMuted.Render("  Press [Check] to scan installed CLI versions and provider image availability."))
+	}
+
+	for len(lines) < h {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines[:min(len(lines), h)], "\n")
+}
+
 // sortedCostRows returns the cost rows sorted cheapest-first (errors last).
 func (m dashModel) sortedCostRows() []cost.CloudCost {
 	sorted := make([]cost.CloudCost, len(m.costRows))
@@ -3570,10 +4202,49 @@ func runDashboard(w io.Writer, cfg *config.Config, s *state) dashResult {
 	}
 	if final.selects[siMode].value() == "on-prem" {
 		s.fork = forkOnPrem
+		// Copy loaded cfg back to caller's pointer (handles cfgEntryLoadMsg replacement).
+		*cfg = *final.cfg
 		return dashResult{saved: true}
 	}
 	final.flushToCfg()
+	// Copy flushed cfg back to caller's pointer.
+	*cfg = *final.cfg
 	return dashResult{saved: true, deployRequested: final.deployRequested}
+}
+
+// ─── cost period helpers ──────────────────────────────────────────────────────
+
+// activeCostWindow returns the currently selected time window preset.
+func (m dashModel) activeCostWindow() costWindowPreset {
+	if m.costPeriodIdx < 0 || m.costPeriodIdx >= len(costWindows) {
+		return costWindows[costDefaultPeriodIdx]
+	}
+	return costWindows[m.costPeriodIdx]
+}
+
+// costForPeriod scales a monthly USD figure to the active window.
+func (m dashModel) costForPeriod(monthly float64) float64 {
+	w := m.activeCostWindow()
+	return monthly * w.d.Seconds() / costMonthSecs
+}
+
+// formatCost renders an amount with the active window's short suffix.
+func (m dashModel) formatCost(monthly float64) string {
+	if monthly == 0 {
+		return "n/a"
+	}
+	amt := m.costForPeriod(monthly)
+	w := m.activeCostWindow()
+	switch {
+	case amt < 0.01:
+		return fmt.Sprintf("$%.4f%s", amt, w.short)
+	case amt < 1:
+		return fmt.Sprintf("$%.3f%s", amt, w.short)
+	case amt < 100:
+		return fmt.Sprintf("$%.2f%s", amt, w.short)
+	default:
+		return fmt.Sprintf("$%.0f%s", amt, w.short)
+	}
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -91,9 +91,14 @@ const (
 	tiGateway
 	tiIPPrefix
 	tiDNSServers
-	tiMgmtCPEndpointIP // mgmt control-plane VIP (on-prem)
-	tiMgmtNodeIPRanges // mgmt node IP ranges (on-prem)
-	tiArgoURL          // AppOfApps git URL
+	tiMgmtCPEndpointIP   // mgmt control-plane VIP (on-prem)
+	tiMgmtNodeIPRanges   // mgmt node IP ranges (on-prem)
+	tiProxmoxDefaultTmpl // Proxmox default VM template ID
+	tiProxmoxWLCPTmpl    // Proxmox workload control-plane template ID
+	tiProxmoxWLWorkerTmpl // Proxmox workload worker template ID
+	tiProxmoxMgmtCPTmpl  // Proxmox mgmt control-plane template ID
+	tiProxmoxMgmtWorkerTmpl // Proxmox mgmt worker template ID
+	tiArgoURL            // AppOfApps git URL
 	tiArgoPath      // AppOfApps git path
 	tiArgoRef       // AppOfApps git ref
 	tiImgMirror     // image registry mirror
@@ -166,41 +171,46 @@ const (
 	focHasCache            // 18
 	focCacheCPU            // 19
 	focCacheMem            // 20
-	focBootstrap           // 21
-	focOvercommit          // 22
-	focCPEndpointIP        // 23
-	focNodeIPRanges        // 24
-	focGateway             // 25
-	focIPPrefix            // 26
-	focDNSServers          // 27
-	focMgmtCPEndpointIP   // 28 — on-prem mgmt cluster VIP
-	focMgmtNodeIPRanges   // 29 — on-prem mgmt node IP ranges
-	focArgoURL             // 30
-	focArgoPath            // 31
-	focArgoRef             // 32
-	focAirgapped           // 33
-	focImgMirror           // 34
-	focCABundle            // 35
-	focHelmMirror          // 36
-	focKyverno             // 37
-	focCertMgr             // 38
-	focCNPG                // 39
-	focCrossplane          // 40
-	focExtSecrets          // 41
-	focOTEL                // 42
-	focGrafana             // 43
-	focVictoria            // 44
-	focMetrics             // 45
-	focSPIRE               // 46
-	focDCLoc               // 47
-	focBudget              // 48
-	focHeadroom            // 49
-	focTCO                 // 50 — TCO toggle (on-prem only)
-	focHWCost              // 51
-	focHWWatts             // 52
-	focHWKWH               // 53
-	focHWSupport           // 54
-	focCount               // 55 — must be last
+	focBootstrap              // 21
+	focOvercommit             // 22
+	focProxmoxDefaultTmpl    // 23 — Proxmox default VM template ID
+	focProxmoxWLCPTmpl       // 24 — Proxmox workload CP template ID
+	focProxmoxWLWorkerTmpl   // 25 — Proxmox workload worker template ID
+	focProxmoxMgmtCPTmpl     // 26 — Proxmox mgmt CP template ID
+	focProxmoxMgmtWorkerTmpl // 27 — Proxmox mgmt worker template ID
+	focCPEndpointIP          // 28
+	focNodeIPRanges           // 29
+	focGateway                // 30
+	focIPPrefix               // 31
+	focDNSServers             // 32
+	focMgmtCPEndpointIP      // 33 — on-prem mgmt cluster VIP
+	focMgmtNodeIPRanges      // 34 — on-prem mgmt node IP ranges
+	focArgoURL                // 35
+	focArgoPath               // 36
+	focArgoRef                // 37
+	focAirgapped              // 38
+	focImgMirror              // 39
+	focCABundle               // 40
+	focHelmMirror             // 41
+	focKyverno                // 42
+	focCertMgr                // 43
+	focCNPG                   // 44
+	focCrossplane             // 45
+	focExtSecrets             // 46
+	focOTEL                   // 47
+	focGrafana                // 48
+	focVictoria               // 49
+	focMetrics                // 50
+	focSPIRE                  // 51
+	focDCLoc                  // 52
+	focBudget                 // 53
+	focHeadroom               // 54
+	focTCO                    // 55 — TCO toggle (on-prem only)
+	focHWCost                 // 56
+	focHWWatts                // 57
+	focHWKWH                  // 58
+	focHWSupport              // 59
+	focCount                  // 60 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -252,7 +262,13 @@ var dashFields = []fieldMeta{
 	// ── Bootstrap (on-prem only) ─────────────────────────────────────────── fid 21-22
 	{fkSelect, siBootstrap, "bootstrap mode", "Bootstrap", false},
 	{fkToggle, toiOvercommit, "allow overcommit", "", false},
-	// ── Workload Network (on-prem only) ──────────────────────────────────── fid 23-27
+	// ── Proxmox Templates (proxmox only) ─────────────────────────────────── fid 23-27
+	{fkText, tiProxmoxDefaultTmpl, "default tmpl ID", "Proxmox Templates", false},
+	{fkText, tiProxmoxWLCPTmpl, "  wl CP tmpl ID", "", false},
+	{fkText, tiProxmoxWLWorkerTmpl, "  wl worker tmpl ID", "", false},
+	{fkText, tiProxmoxMgmtCPTmpl, "  mgmt CP tmpl ID", "", false},
+	{fkText, tiProxmoxMgmtWorkerTmpl, "  mgmt worker tmpl ID", "", false},
+	// ── Workload Network (on-prem only) ──────────────────────────────────── fid 28-32
 	{fkText, tiCPEndpointIP, "CP endpoint IP", "Workload Network", false},
 	{fkText, tiNodeIPRanges, "node IP ranges", "", false},
 	{fkText, tiGateway, "gateway", "", false},
@@ -551,6 +567,11 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.textInputs[tiDNSServers].SetValue(cfg.DNSServers)
 	m.textInputs[tiMgmtCPEndpointIP].SetValue(cfg.Mgmt.ControlPlaneEndpointIP)
 	m.textInputs[tiMgmtNodeIPRanges].SetValue(cfg.Mgmt.NodeIPRanges)
+	m.textInputs[tiProxmoxDefaultTmpl].SetValue(cfg.Providers.Proxmox.TemplateID)
+	m.textInputs[tiProxmoxWLCPTmpl].SetValue(cfg.WorkloadControlPlaneTemplateID)
+	m.textInputs[tiProxmoxWLWorkerTmpl].SetValue(cfg.WorkloadWorkerTemplateID)
+	m.textInputs[tiProxmoxMgmtCPTmpl].SetValue(cfg.Providers.Proxmox.Mgmt.ControlPlaneTemplateID)
+	m.textInputs[tiProxmoxMgmtWorkerTmpl].SetValue(cfg.Providers.Proxmox.Mgmt.WorkerTemplateID)
 	m.textInputs[tiArgoURL].SetValue(cfg.ArgoCD.AppOfAppsGitURL)
 	m.textInputs[tiArgoPath].SetValue(cfg.ArgoCD.AppOfAppsGitPath)
 	m.textInputs[tiArgoRef].SetValue(cfg.ArgoCD.AppOfAppsGitRef)
@@ -778,6 +799,10 @@ func (m *dashModel) isHidden(fid int) bool {
 	// On-prem only.
 	case focBootstrap, focOvercommit:
 		return isCloud
+	// Proxmox-specific: only when provider=proxmox.
+	case focProxmoxDefaultTmpl, focProxmoxWLCPTmpl, focProxmoxWLWorkerTmpl,
+		focProxmoxMgmtCPTmpl, focProxmoxMgmtWorkerTmpl:
+		return m.selects[siProvider].value() != "proxmox"
 	// Workload network: on-prem only (cloud VPCs are fully managed).
 	case focCPEndpointIP, focNodeIPRanges, focGateway, focIPPrefix, focDNSServers:
 		return isCloud
@@ -2204,6 +2229,13 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 	snap.DNSServers = strings.TrimSpace(m.textInputs[tiDNSServers].Value())
 	snap.Mgmt.ControlPlaneEndpointIP = strings.TrimSpace(m.textInputs[tiMgmtCPEndpointIP].Value())
 	snap.Mgmt.NodeIPRanges = strings.TrimSpace(m.textInputs[tiMgmtNodeIPRanges].Value())
+	if t := strings.TrimSpace(m.textInputs[tiProxmoxDefaultTmpl].Value()); t != "" {
+		snap.Providers.Proxmox.TemplateID = t
+	}
+	snap.WorkloadControlPlaneTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxWLCPTmpl].Value())
+	snap.WorkloadWorkerTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxWLWorkerTmpl].Value())
+	snap.Providers.Proxmox.Mgmt.ControlPlaneTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxMgmtCPTmpl].Value())
+	snap.Providers.Proxmox.Mgmt.WorkerTemplateID = strings.TrimSpace(m.textInputs[tiProxmoxMgmtWorkerTmpl].Value())
 
 	// ArgoCD git coordinates.
 	if u := strings.TrimSpace(m.textInputs[tiArgoURL].Value()); u != "" {
@@ -2398,6 +2430,11 @@ func (m *dashModel) flushToCfg() {
 	m.cfg.DNSServers = snap.DNSServers
 	m.cfg.Mgmt.ControlPlaneEndpointIP = snap.Mgmt.ControlPlaneEndpointIP
 	m.cfg.Mgmt.NodeIPRanges = snap.Mgmt.NodeIPRanges
+	m.cfg.Providers.Proxmox.TemplateID = snap.Providers.Proxmox.TemplateID
+	m.cfg.WorkloadControlPlaneTemplateID = snap.WorkloadControlPlaneTemplateID
+	m.cfg.WorkloadWorkerTemplateID = snap.WorkloadWorkerTemplateID
+	m.cfg.Providers.Proxmox.Mgmt.ControlPlaneTemplateID = snap.Providers.Proxmox.Mgmt.ControlPlaneTemplateID
+	m.cfg.Providers.Proxmox.Mgmt.WorkerTemplateID = snap.Providers.Proxmox.Mgmt.WorkerTemplateID
 	m.cfg.Airgapped = snap.Airgapped
 	m.cfg.ImageRegistryMirror = snap.ImageRegistryMirror
 	m.cfg.InternalCABundle = snap.InternalCABundle

--- a/internal/ui/xapiri/georegions.go
+++ b/internal/ui/xapiri/georegions.go
@@ -14,11 +14,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -30,10 +28,6 @@ import (
 
 const geojsURL = "https://get.geojs.io/v1/ip/geo.json"
 
-type regionPoint struct {
-	id string
-	lat, lon float64
-}
 
 // fetchOutboundIPGeo returns approximate lat/lon from the public
 // GeoJS endpoint (no API key). Fails soft on timeout / airgap.
@@ -103,195 +97,24 @@ func coerceFloat(v any) (float64, error) {
 	}
 }
 
-func haversineKm(lat1, lon1, lat2, lon2 float64) float64 {
-	const rEarth = 6371.0
-	p1 := lat1 * math.Pi / 180
-	p2 := lat2 * math.Pi / 180
-	dlat := (lat2 - lat1) * math.Pi / 180
-	dlon := (lon2 - lon1) * math.Pi / 180
-	a := math.Sin(dlat/2)*math.Sin(dlat/2) + math.Cos(p1)*math.Cos(p2)*math.Sin(dlon/2)*math.Sin(dlon/2)
-	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
-	return rEarth * c
-}
-
-func regionCentroids(provider string) []regionPoint {
-	switch provider {
-	case "aws":
-		return []regionPoint{
-			{"us-east-1", 39.04, -77.49},
-			{"us-east-2", 39.96, -83.00},
-			{"us-west-1", 37.35, -121.96},
-			{"us-west-2", 45.51, -122.68},
-			{"ca-central-1", 45.50, -73.57},
-			{"eu-west-1", 53.35, -6.26},
-			{"eu-west-2", 51.51, -0.13},
-			{"eu-west-3", 48.86, 2.35},
-			{"eu-central-1", 50.11, 8.68},
-			{"eu-north-1", 59.33, 18.07},
-			{"ap-southeast-1", 1.35, 103.82},
-			{"ap-southeast-2", -33.87, 151.21},
-			{"ap-northeast-1", 35.68, 139.65},
-			{"ap-northeast-2", 37.57, 126.98},
-			{"ap-south-1", 19.08, 72.88},
-			{"sa-east-1", -23.55, -46.63},
-			{"me-south-1", 26.07, 50.56},
-			{"af-south-1", -33.92, 18.42},
-		}
-	case "azure":
-		return []regionPoint{
-			{"eastus", 37.37, -79.82},
-			{"eastus2", 36.67, -78.80},
-			{"westus2", 47.23, -119.85},
-			{"westus3", 33.45, -112.07},
-			{"centralus", 41.88, -87.63},
-			{"northeurope", 53.35, -6.26},
-			{"westeurope", 52.37, 4.89},
-			{"uksouth", 51.51, -0.13},
-			{"francecentral", 48.86, 2.35},
-			{"germanywestcentral", 50.11, 8.68},
-			{"switzerlandnorth", 47.38, 8.54},
-			{"norwayeast", 59.91, 10.75},
-			{"swedencentral", 59.33, 18.07},
-			{"polandcentral", 52.23, 21.01},
-			{"italynorth", 45.46, 9.19},
-			{"australiaeast", -33.87, 151.21},
-			{"southeastasia", 1.35, 103.82},
-			{"japaneast", 35.68, 139.65},
-			{"japanwest", 34.69, 135.50},
-			{"koreacentral", 37.57, 126.98},
-			{"brazilsouth", -23.55, -46.63},
-			{"southafricanorth", -25.75, 28.23},
-		}
-	case "gcp":
-		return []regionPoint{
-			{"us-central1", 41.26, -95.86},
-			{"us-east1", 33.84, -81.16},
-			{"us-east4", 39.04, -77.49},
-			{"us-west1", 45.51, -122.68},
-			{"us-west2", 34.05, -118.24},
-			{"europe-west1", 50.45, 3.98},
-			{"europe-west2", 51.51, -0.13},
-			{"europe-west3", 50.11, 8.68},
-			{"europe-west4", 53.44, 6.84},
-			{"europe-west6", 47.38, 8.54},
-			{"europe-west8", 41.90, 12.50},
-			{"europe-west9", 48.86, 2.35},
-			{"europe-north1", 60.17, 24.94},
-			{"asia-east1", 25.03, 121.57},
-			{"asia-northeast1", 35.68, 139.65},
-			{"asia-southeast1", 1.35, 103.82},
-			{"asia-south1", 19.08, 72.88},
-			{"australia-southeast1", -37.81, 144.96},
-		}
-	case "hetzner":
-		return []regionPoint{
-			{"fsn1", 50.48, 12.36},
-			{"nbg1", 49.45, 11.08},
-			{"hel1", 60.17, 24.94},
-			{"ash", 39.04, -77.49},
-			{"hil", 45.52, -122.99},
-			{"sin", 1.35, 103.82},
-		}
-	case "digitalocean":
-		return []regionPoint{
-			{"nyc3", 40.71, -74.01},
-			{"nyc1", 40.71, -74.01},
-			{"sfo3", 37.77, -122.42},
-			{"ams3", 52.37, 4.90},
-			{"fra1", 50.11, 8.68},
-			{"lon1", 51.51, -0.13},
-			{"sgp1", 1.35, 103.82},
-			{"tor1", 43.65, -79.38},
-			{"blr1", 12.97, 77.59},
-			{"syd1", -33.87, 151.21},
-		}
-	case "linode":
-		return []regionPoint{
-			{"us-east", 40.74, -74.17},
-			{"us-central", 32.78, -96.80},
-			{"us-west", 37.55, -121.99},
-			{"us-southeast", 33.75, -84.39},
-			{"us-iowa", 43.15, -93.20},
-			{"ca-central", 43.65, -79.38},
-			{"eu-west", 51.51, -0.13},
-			{"eu-central", 50.11, 8.68},
-			{"ap-west", 1.35, 103.82},
-			{"ap-south", 19.08, 72.88},
-			{"ap-northeast", 35.68, 139.65},
-			{"ap-southeast", -33.87, 151.21},
-		}
-	case "oci":
-		return []regionPoint{
-			{"us-ashburn-1", 39.04, -77.49},
-			{"us-phoenix-1", 33.45, -112.07},
-			{"eu-frankfurt-1", 50.11, 8.68},
-			{"uk-london-1", 51.51, -0.13},
-			{"eu-amsterdam-1", 52.37, 4.90},
-			{"ap-sydney-1", -33.87, 151.21},
-			{"ap-mumbai-1", 19.08, 72.88},
-			{"ap-osaka-1", 34.69, 135.50},
-			{"ca-toronto-1", 43.65, -79.38},
-			{"sa-saopaulo-1", -23.55, -46.63},
-		}
-	case "ibmcloud":
-		return []regionPoint{
-			{"us-south", 32.78, -96.80},
-			{"eu-gb", 51.51, -0.13},
-			{"eu-de", 50.11, 8.68},
-			{"jp-tok", 35.68, 139.65},
-			{"au-syd", -33.87, 151.21},
-			{"ca-tor", 45.50, -73.57},
-		}
-	default:
-		return nil
-	}
-}
-
-// geoNearestRegionID returns the closest region / location slug for
-// provider to (lat, lon). Empty when provider has no table.
-func geoNearestRegionID(provider string, lat, lon float64) string {
-	best := geoRankedRegions(provider, lat, lon, 1)
-	if len(best) == 0 {
-		return ""
-	}
-	return best[0]
+// geoNearestRegionID returns the closest region slug for provider to
+// (lat, lon). Empty when the provider has no centroid table.
+func geoNearestRegionID(prov string, lat, lon float64) string {
+	return pricing.GeoNearestRegion(prov, lat, lon)
 }
 
 // geoRankedRegions returns the nearest region IDs for provider,
 // sorted by great-circle distance, capped at limit.
-func geoRankedRegions(provider string, lat, lon float64, limit int) []string {
-	pts := regionCentroids(provider)
-	if len(pts) == 0 || limit <= 0 {
-		return nil
-	}
-	type scored struct {
-		id  string
-		km  float64
-	}
-	var xs []scored
-	for _, p := range pts {
-		xs = append(xs, scored{id: p.id, km: haversineKm(lat, lon, p.lat, p.lon)})
-	}
-	sort.Slice(xs, func(i, j int) bool { return xs[i].km < xs[j].km })
-	seen := map[string]struct{}{}
-	var out []string
-	for _, x := range xs {
-		if _, ok := seen[x.id]; ok {
-			continue
-		}
-		seen[x.id] = struct{}{}
-		out = append(out, x.id)
-		if len(out) >= limit {
-			break
-		}
-	}
-	return out
+// Delegates to pricing.GeoRankedRegions so the centroid table lives
+// in one place and is shared with cost.WarmCaches.
+func geoRankedRegions(prov string, lat, lon float64, limit int) []string {
+	return pricing.GeoRankedRegions(prov, lat, lon, limit)
 }
 
 // geoHasCentroids reports whether we can suggest public regions for
 // this provider registry id (e.g. "aws", "ibmcloud").
-func geoHasCentroids(provider string) bool {
-	return len(regionCentroids(provider)) > 0
+func geoHasCentroids(prov string) bool {
+	return pricing.GeoHasCentroids(prov)
 }
 
 // geoRegionLikeFieldNames are cfg.Providers.* string fields we treat
@@ -407,7 +230,7 @@ func (s *state) ensureGeoLookup() {
 		return
 	}
 	s.geoDidLookup = true
-	if s.cfg.Airgapped || strings.TrimSpace(os.Getenv("YAGE_XAPIRI_NO_GEO")) == "1" {
+	if s.cfg.Airgapped || !s.cfg.GeoIPEnabled || strings.TrimSpace(os.Getenv("YAGE_XAPIRI_NO_GEO")) == "1" {
 		return
 	}
 	var lat, lon float64

--- a/internal/ui/xapiri/shared.go
+++ b/internal/ui/xapiri/shared.go
@@ -15,6 +15,7 @@ package xapiri
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -738,18 +739,45 @@ func (s *state) runSharedTail() error {
 	return s.step8_persistAndDecide()
 }
 
-// disableProvidersMissingCredentials appends to cfg.SkipProviders the names
-// of credential-requiring providers that have no key set. Azure, Linode, and
-// OCI use public APIs and are never auto-disabled here.
+// awsAnyCredentialsAvailable returns true when AWS credentials are available
+// in any form: explicit key/secret in cfg, AWS SDK env vars (AWS_ACCESS_KEY_ID,
+// AWS_PROFILE), or the standard ~/.aws/credentials / ~/.aws/config files.
+// newAWSPricingClient now falls back to the SDK default chain, so any of these
+// sources will allow a successful Pricing API call.
+func awsAnyCredentialsAvailable(cfg *config.Config) bool {
+	if cfg.Cost.Credentials.AWSAccessKeyID != "" && cfg.Cost.Credentials.AWSSecretAccessKey != "" {
+		return true
+	}
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_PROFILE") != "" {
+		return true
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		for _, rel := range []string{".aws/credentials", ".aws/config"} {
+			if _, e := os.Stat(filepath.Join(home, rel)); e == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// disableProvidersMissingCredentials syncs cfg.SkipProviders with credential
+// availability. Azure, Linode, and OCI use public APIs and are never touched.
+// AWS is skipped only when no credentials exist in any form (explicit key/secret,
+// env vars, or ~/.aws/ files) — it falls back to the SDK credential chain.
 // When cfg.InfraProvider is set explicitly (non-defaulted), only that provider
-// is checked — others are left alone.
+// is checked; others are left alone.
+//
+// Critically, providers are also REMOVED from SkipProviders when credentials
+// become available mid-session (e.g. after the [costs] credential form is
+// submitted), so the live cost bar updates without requiring a restart.
 func disableProvidersMissingCredentials(cfg *config.Config) {
 	type check struct {
 		name    string
 		missing bool
 	}
 	checks := []check{
-		{"aws", cfg.Cost.Credentials.AWSAccessKeyID == "" || cfg.Cost.Credentials.AWSSecretAccessKey == ""},
+		{"aws", !awsAnyCredentialsAvailable(cfg)},
 		{"gcp", cfg.Cost.Credentials.GCPAPIKey == ""},
 		{"hetzner", cfg.Cost.Credentials.HetznerToken == ""},
 		{"digitalocean", cfg.Cost.Credentials.DigitalOceanToken == ""},
@@ -768,6 +796,8 @@ func disableProvidersMissingCredentials(cfg *config.Config) {
 		}
 		if c.missing {
 			skipped[c.name] = struct{}{}
+		} else {
+			delete(skipped, c.name) // credentials now available — restore provider
 		}
 	}
 	names := make([]string, 0, len(skipped))

--- a/internal/ui/xapiri/shared.go
+++ b/internal/ui/xapiri/shared.go
@@ -761,6 +761,16 @@ func awsAnyCredentialsAvailable(cfg *config.Config) bool {
 	return false
 }
 
+// gcpAnyCredentialsAvailable mirrors awsAnyCredentialsAvailable for GCP: checks
+// the explicit cfg credential first, then the same env-var fallbacks that the
+// pricing fetcher uses (YAGE_GCP_API_KEY, GOOGLE_BILLING_API_KEY).
+func gcpAnyCredentialsAvailable(cfg *config.Config) bool {
+	if cfg.Cost.Credentials.GCPAPIKey != "" {
+		return true
+	}
+	return os.Getenv("YAGE_GCP_API_KEY") != "" || os.Getenv("GOOGLE_BILLING_API_KEY") != ""
+}
+
 // disableProvidersMissingCredentials syncs cfg.SkipProviders with credential
 // availability. Azure, Linode, and OCI use public APIs and are never touched.
 // AWS is skipped only when no credentials exist in any form (explicit key/secret,
@@ -778,7 +788,7 @@ func disableProvidersMissingCredentials(cfg *config.Config) {
 	}
 	checks := []check{
 		{"aws", !awsAnyCredentialsAvailable(cfg)},
-		{"gcp", cfg.Cost.Credentials.GCPAPIKey == ""},
+		{"gcp", !gcpAnyCredentialsAvailable(cfg)},
 		{"hetzner", cfg.Cost.Credentials.HetznerToken == ""},
 		{"digitalocean", cfg.Cost.Credentials.DigitalOceanToken == ""},
 		{"ibmcloud", cfg.Cost.Credentials.IBMCloudAPIKey == ""},

--- a/internal/ui/xapiri/xapiri.go
+++ b/internal/ui/xapiri/xapiri.go
@@ -83,17 +83,14 @@ func (h *multiHandler) WithGroup(name string) slog.Handler {
 // [logs] tab.
 var globalLogRing = &logRing{}
 
-// installLogTee wraps the global obs.Logger with a multiHandler that also
-// writes plain-text lines to globalLogRing.
+// installLogTee wraps the global obs.Logger with a multiHandler that writes
+// plain-text lines to globalLogRing (visible in [logs] tab). stdout/stderr
+// are discarded: the TUI is running in alt-screen and any direct write to
+// those file descriptors would corrupt the rendered output.
 func installLogTee() {
-	existing := obs.Global()
-	// Retrieve the underlying slog.Handler via a slog.Logger adapter.
-	// obs.Logger wraps *slog.Logger; we create a new one from the current
-	// logger's handler (accessed by promoting through obs.NewLoggerFromHandler).
-	primary := obs.NewPrettyHandler()
+	primary := obs.NewPrettyHandlerWithWriters(io.Discard, io.Discard, true)
 	teeHandler := &multiHandler{primary: primary, ring: globalLogRing}
 	obs.SetGlobal(obs.NewLoggerFromHandler(teeHandler))
-	_ = existing // existing logger is replaced; its handler is superseded
 }
 
 // Run starts the interactive walkthrough. Returns the exit code

--- a/internal/ui/xapiri/xapiri.go
+++ b/internal/ui/xapiri/xapiri.go
@@ -123,17 +123,20 @@ func Run(w io.Writer, cfg *config.Config) int {
 	if err := s.stepKindClusterName(); err != nil {
 		return s.exit(err)
 	}
-	// Load all previously saved state now that we know the kind cluster
-	// name. Two stores exist:
-	//   1. yage-system/proxmox-bootstrap-config — the orchestrator's
-	//      store, written after a real deployment. Contains network
-	//      fields, provider URL/tokens, workload cluster name.
-	//   2. yage-system/bootstrap-config — xapiri's own store, written
-	//      at the end of a successful walkthrough. Contains a full
-	//      snapshot including everything from store 1.
-	// Call 1 first so store 2 (which is fresher when it exists) wins
-	// on overlap. Both are best-effort no-ops when the cluster or Secret
-	// is not yet reachable (first-run case).
+	// Pick (or create) the bootstrap config to load before merging.
+	// Must run after stepKindClusterName so cfg.KindClusterName is set.
+	if err := s.stepConfigSelection(); err != nil {
+		return s.exit(err)
+	}
+	// Load all previously saved state. Two stores exist:
+	//   1. yage-system/proxmox-bootstrap-config — the Proxmox provider
+	//      snapshot written after a real deployment (network fields,
+	//      provider URL/tokens, workload cluster name).
+	//   2. yage-system/<ConfigName>-bootstrap-config — xapiri's per-config
+	//      store, written at the end of each walkthrough. Contains a full
+	//      snapshot that wins over store 1 on overlap (fresher).
+	// Both are best-effort no-ops when the cluster or Secret is not yet
+	// reachable (first-run case).
 	kindsync.MergeBootstrapSecretsFromKind(cfg)
 	_ = kindsync.MergeBootstrapConfigFromKind(cfg)
 	_ = kindsync.ReadCostCompareSecret(cfg) // sets CostCompareEnabled + loads credentials when secret exists
@@ -170,21 +173,13 @@ func useHuhTUI() bool {
 	return strings.EqualFold(strings.TrimSpace(os.Getenv("YAGE_XAPIRI_TUI")), "huh")
 }
 
-// runHuhBranch is the YAGE_XAPIRI_TUI=huh entry. The kind prelude
-// still runs (every later step needs the cluster), then the huh
-// form covers steps 1..4 of the cloud fork; cost-compare and the
-// shared tail run unchanged afterwards.
+// runHuhBranch is the YAGE_XAPIRI_TUI=huh entry. The kind prelude brings
+// the management cluster up; the dashboard handles config selection and all
+// subsequent steps interactively.
 func runHuhBranch(w io.Writer, cfg *config.Config, s *state) int {
-	// Speculative merge using the default cluster name so the huh form
-	// sees saved values as its initial field values.
 	if cfg.KindClusterName == "" {
 		cfg.KindClusterName = "yage-mgmt"
 	}
-	kindsync.MergeBootstrapSecretsFromKind(cfg)
-	_ = kindsync.MergeBootstrapConfigFromKind(cfg)
-	_ = kindsync.ReadCostCompareSecret(cfg) // sets CostCompareEnabled + loads credentials when secret exists
-	disableProvidersMissingCredentials(cfg)
-	s.initFromConfig(cfg) // re-seed walkthrough state now that kind merges have run
 	if !skipKindPrelude() {
 		if err := kind.EnsureClusterUp(cfg, w); err != nil {
 			fmt.Fprintf(w, "xapiri: kind management cluster could not be brought up: %v\n", err)
@@ -197,20 +192,13 @@ func runHuhBranch(w io.Writer, cfg *config.Config, s *state) int {
 	if !res.saved {
 		return 0
 	}
-	if s.fork == forkOnPrem {
-		return s.runOnPremFork()
-	}
 	if !res.deployRequested {
-		// User saved config but did not press Start Deploy — exit cleanly.
 		return 0
 	}
 	if strings.TrimSpace(cfg.InfraProvider) == "" {
-		return s.exit(fmt.Errorf("xapiri: no infrastructure provider selected for cloud deployment; choose a provider before continuing"))
+		return s.exit(fmt.Errorf("xapiri: no infrastructure provider selected for deployment; choose a provider in the config tab before deploying"))
 	}
-	// User pressed Start Deploy — proceed directly to the orchestrator.
-	if err := s.runSharedTail(); err != nil {
-		return s.exit(err)
-	}
+	s.cfg.XapiriDeployNow = true
 	return 0
 }
 
@@ -220,6 +208,15 @@ func runHuhBranch(w io.Writer, cfg *config.Config, s *state) int {
 func skipKindPrelude() bool {
 	v := strings.TrimSpace(os.Getenv("YAGE_XAPIRI_SKIP_KIND"))
 	return v == "1" || strings.EqualFold(v, "true")
+}
+
+// stepConfigSelection offers the user a huh picker to choose (or create)
+// a bootstrap config on the already-set cfg.KindClusterName. It sets
+// cfg.ConfigName so the subsequent MergeBootstrapConfigFromKind call
+// reads the right Secret. No-op when cfg.ConfigNameExplicit is true.
+// Always uses huh regardless of which xapiri path is active.
+func (s *state) stepConfigSelection() error {
+	return kindsync.SelectBootstrapConfigForXapiri(s.cfg)
 }
 
 // providerSubStruct resolves cfg.Providers.<ProperCase(name)> via


### PR DESCRIPTION
## Summary

- **config**: adds `ConfigName` field (defaults to `WorkloadClusterName`) and `YAGE_CONFIG_NAME` env/flag as a discriminator for the orchestrator-state Secret, enabling N named profiles and draft scenarios per kind cluster
- **kindsync**: replaces the fixed `bootstrap-config` Secret name with `<ConfigName>-bootstrap-config` + a rich label set; adds `huh.Select` picker when multiple Secrets coexist; `PromoteBootstrapConfigToRealized` patches the status label on orchestrator success; hand-off now copies all labeled bootstrap-config Secrets to the management cluster
- **pricing**: GCP compact-record disk cache (24h, avoids repeated Cloud Billing Catalog pagination across restarts) + AWS process-lifetime in-memory cache (avoids repeated 440 MB disk reads per `yage` run)
- **pricing/georegion**: new nearest-region ranking table for AWS/Azure/GCP/Hetzner/DO/Linode/OCI/IBMCloud by great-circle distance
- **cost**: `StreamWithRegions` fans out one goroutine per `(provider, region)` pair for the dashboard's region-ranked cost rows
- **installer**: extract inner funcs from each CLI installer; add `CheckDeps` and `UpgradeDeps` for safe TUI use without `os.Exit`
- **xapiri**: `stepConfigSelection` huh picker between kind-setup and merge; dashboard region-ranked cost display; country-centroid geo table; deps tab
- **cli**: `--geoip` and `--config-name` flags with help text and shell completion

## Test plan

- [ ] `make test` passes (all packages)
- [ ] `make build` produces `bin/yage`
- [ ] `kindsync` unit tests cover all three ConfigName modes, label sanitization, promoted status, and non-TTY auto-pick
- [ ] New `YAGE_CONFIG_NAME` round-trips through `SnapshotYAML` → `ApplySnapshotKV` with explicit guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)