### PR TITLE
Config system revamp: per-ns layout, fork restore, dual-arch image check

### DIFF
--- a/internal/cluster/kindsync/bootstrap_config.go
+++ b/internal/cluster/kindsync/bootstrap_config.go
@@ -3,10 +3,10 @@
 
 package kindsync
 
-// bootstrap_config.go manages per-config orchestrator-state Secrets in
-// the yage-system namespace. Each Secret is named
-// "<cfg.ConfigName>-bootstrap-config" and carries a full env-var
-// snapshot (config.yaml) plus labeled metadata for discovery.
+// bootstrap_config.go manages per-config orchestrator-state Secrets.
+// Each config lives in its own Kubernetes namespace named
+// "yage-<sanitized cfg.ConfigName>" (e.g. "yage-dev", "yage-prod-eu").
+// Inside that namespace the Secret is always called "bootstrap-config".
 //
 // Three coexistence modes (cfg.ConfigName is the discriminator):
 //
@@ -17,7 +17,12 @@ package kindsync
 //  3. N draft scenarios: ConfigName set to a scenario label, no realized
 //     workload yet.
 //
-// Labels written on every Secret:
+// Namespace labels (updated on every save):
+//
+//	infra.yage-deployment.bucaniere.us:  "true"
+//	infra.capi-provider.bucaniere.us:    <cfg.InfraProvider>   (omitted when empty)
+//
+// Secret labels (written inside the per-config namespace):
 //
 //	app.kubernetes.io/managed-by:  yage
 //	app.kubernetes.io/component:   bootstrap-config
@@ -27,6 +32,10 @@ package kindsync
 //	yage.io/provider:              <cfg.InfraProvider>           (when set)
 //	yage.io/region:                <provider.Region or "">       (when set)
 //
+// Discovery: list namespaces with infra.yage-deployment.bucaniere.us=true,
+// then fetch "bootstrap-config" from each.
+//
+// Shared resources (cost credentials) remain in YageSystemNamespace.
 // The Proxmox provider-snapshot Secret (proxmox-bootstrap-config, written
 // by applyBootstrapConfigToManagementCluster) is a separate concept and is
 // not affected by this file.
@@ -50,19 +59,38 @@ import (
 	"github.com/lpasquali/yage/internal/ui/logx"
 )
 
-// BootstrapConfigNamespace is the kind-side namespace yage owns
-// for its bootstrap state Secret.
-const BootstrapConfigNamespace = "yage-system"
+// YageSystemNamespace is the shared kind-side namespace for non-per-config
+// yage resources (cost credentials, operator state).
+const YageSystemNamespace = "yage-system"
 
-// BootstrapConfigSecretName returns the name of the bootstrap-config
-// Secret for cfg in BootstrapConfigNamespace. The name is
-// "<cfg.ConfigName>-bootstrap-config"; when ConfigName is empty
-// (should not happen after Load()) falls back to "bootstrap-config".
-func BootstrapConfigSecretName(cfg *config.Config) string {
-	if cfg.ConfigName == "" {
-		return "bootstrap-config"
+// BootstrapConfigNamespace returns the per-config namespace for cfg.
+// Named "yage-<sanitized ConfigName>". Falls back to "yage-default" when
+// ConfigName is empty (callers that write data should guard against this
+// separately via an error return).
+func BootstrapConfigNamespace(cfg *config.Config) string {
+	if cfg == nil || cfg.ConfigName == "" {
+		return "yage-default"
 	}
-	return cfg.ConfigName + "-bootstrap-config"
+	return "yage-" + sanitizeLabelValue(cfg.ConfigName)
+}
+
+// BootstrapConfigSecretName returns the name of the bootstrap-config Secret
+// inside the per-config namespace. Always "bootstrap-config" — the namespace
+// is the discriminator so no config-name prefix is needed.
+func BootstrapConfigSecretName(_ *config.Config) string {
+	return "bootstrap-config"
+}
+
+// configNamespaceLabels returns the labels applied to the per-config namespace
+// on every save so callers can discover all yage configs via label-selector.
+func configNamespaceLabels(cfg *config.Config) map[string]string {
+	lbl := map[string]string{
+		"infra.yage-deployment.bucaniere.us": "true",
+	}
+	if cfg != nil && cfg.InfraProvider != "" {
+		lbl["infra.capi-provider.bucaniere.us"] = sanitizeLabelValue(cfg.InfraProvider)
+	}
+	return lbl
 }
 
 // sanitizeLabelValue maps s to a valid Kubernetes label value
@@ -144,22 +172,28 @@ func isTTY() bool {
 	return err == nil && fi.Mode()&os.ModeCharDevice != 0
 }
 
-// WriteBootstrapConfigSecret emits cfg into Secret/yage-system/
-// bootstrap-config, using the prefix-based schema documented at
-// the top of this file. Returns nil best-effort: when the kind
-// cluster isn't reachable (e.g. xapiri running before any cluster
-// exists), logs and returns nil so the caller can fall through to
-// a local-file fallback.
+// WriteBootstrapConfigSecret emits cfg into the per-config namespace
+// (yage-<ConfigName>) as Secret "bootstrap-config". The namespace is
+// created on first write and its labels are updated on every save so the
+// label-based discovery in ListBootstrapCandidates stays current.
+// Returns nil best-effort: when the kind cluster isn't reachable (e.g.
+// xapiri running before any cluster exists), logs and returns nil so the
+// caller can fall through to a local-file fallback.
 func WriteBootstrapConfigSecret(cfg *config.Config) error {
+	if cfg.ConfigName == "" {
+		return fmt.Errorf("kindsync: ConfigName is required to write bootstrap config; set --config-name or YAGE_CONFIG_NAME")
+	}
 	kctx := "kind-" + cfg.KindClusterName
 	cli, err := k8sclient.ForContext(kctx)
 	if err != nil {
 		// Kind cluster not reachable — best-effort skip.
-		logx.Warn("kindsync: kind context %s not reachable; skipping %s/%s write (%v)", kctx, BootstrapConfigNamespace, BootstrapConfigSecretName(cfg), err)
+		logx.Warn("kindsync: kind context %s not reachable; skipping %s/%s write (%v)", kctx, BootstrapConfigNamespace(cfg), BootstrapConfigSecretName(cfg), err)
 		return nil
 	}
 	bg := context.Background()
-	if err := cli.EnsureNamespace(bg, BootstrapConfigNamespace); err != nil {
+	// Always apply namespace with labels — creates on first run, updates
+	// provider label on subsequent saves.
+	if err := cli.EnsureNamespaceWithLabels(bg, BootstrapConfigNamespace(cfg), configNamespaceLabels(cfg)); err != nil {
 		return err
 	}
 
@@ -198,7 +232,7 @@ func WriteBootstrapConfigSecret(cfg *config.Config) error {
 		data["config.yaml"] = []byte(yaml)
 	}
 
-	return applySecret(bg, cli, BootstrapConfigNamespace, BootstrapConfigSecretName(cfg), data, bootstrapLabels(cfg, "draft"))
+	return applySecret(bg, cli, BootstrapConfigNamespace(cfg), BootstrapConfigSecretName(cfg), data, bootstrapLabels(cfg, "draft"))
 }
 
 // MergeBootstrapConfigFromKind reads Secret/yage-system/
@@ -226,7 +260,7 @@ func MergeBootstrapConfigFromKind(cfg *config.Config) error {
 		return nil // no discriminator; caller must populate ConfigName first
 	}
 	bg := context.Background()
-	sec, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Get(bg, BootstrapConfigSecretName(cfg), metav1.GetOptions{})
+	sec, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace(cfg)).Get(bg, BootstrapConfigSecretName(cfg), metav1.GetOptions{})
 	if err != nil {
 		return nil // not present yet → first-run case
 	}
@@ -309,13 +343,13 @@ func PromoteBootstrapConfigToRealized(cfg *config.Config) {
 		return
 	}
 	patch := []byte(`{"metadata":{"labels":{"yage.io/config-status":"realized"}}}`)
-	_, err = cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Patch(
+	_, err = cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace(cfg)).Patch(
 		context.Background(), BootstrapConfigSecretName(cfg),
 		types.MergePatchType, patch, metav1.PatchOptions{},
 	)
 	if err != nil {
 		logx.Warn("kindsync: PromoteBootstrapConfigToRealized: patch %s/%s: %v",
-			BootstrapConfigNamespace, BootstrapConfigSecretName(cfg), err)
+			BootstrapConfigNamespace(cfg), BootstrapConfigSecretName(cfg), err)
 	}
 }
 
@@ -338,24 +372,30 @@ func (c BootstrapCandidate) Label() string {
 		c.ConfigName, st, c.Workload, c.Provider, c.Region)
 }
 
-// ListBootstrapCandidates returns all bootstrap-config Secrets in
-// yage-system on the given kind cluster identified by kindClusterName.
+// ListBootstrapCandidates discovers all per-config namespaces on the given
+// kind cluster by looking for namespaces labeled
+// infra.yage-deployment.bucaniere.us=true, then fetches the
+// "bootstrap-config" Secret from each to read the rich label metadata.
 func ListBootstrapCandidates(kindClusterName string) []BootstrapCandidate {
 	kctx := "kind-" + kindClusterName
 	cli, err := k8sclient.ForContext(kctx)
 	if err != nil {
 		return nil
 	}
-	list, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).List(
-		context.Background(), metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/managed-by=yage,app.kubernetes.io/component=bootstrap-config",
-		},
-	)
+	bg := context.Background()
+	nsList, err := cli.Typed.CoreV1().Namespaces().List(bg, metav1.ListOptions{
+		LabelSelector: "infra.yage-deployment.bucaniere.us=true",
+	})
 	if err != nil {
 		return nil
 	}
-	out := make([]BootstrapCandidate, 0, len(list.Items))
-	for _, sec := range list.Items {
+	out := make([]BootstrapCandidate, 0, len(nsList.Items))
+	for _, ns := range nsList.Items {
+		sec, err := cli.Typed.CoreV1().Secrets(ns.Name).Get(bg, "bootstrap-config", metav1.GetOptions{})
+		if err != nil {
+			// Namespace exists but secret not yet written — skip.
+			continue
+		}
 		lbl := sec.Labels
 		out = append(out, BootstrapCandidate{
 			KindCluster: kindClusterName,
@@ -497,7 +537,7 @@ func SelectBootstrapConfigForXapiri(cfg *config.Config) error {
 		if err := huh.NewForm(huh.NewGroup(
 			huh.NewInput().
 				Title("New config name").
-				Description("Prefix for the bootstrap-config Secret in yage-system (default: workload cluster name).").
+				Description("Names the yage-<config-name> namespace (default: workload cluster name).").
 				Value(&newName),
 		)).Run(); err != nil {
 			return err

--- a/internal/cluster/kindsync/bootstrap_config_test.go
+++ b/internal/cluster/kindsync/bootstrap_config_test.go
@@ -146,27 +146,32 @@ func TestKindSyncExplicitGuardPreservedOnMerge(t *testing.T) {
 	}
 }
 
-// TestBootstrapConfigSecretName verifies the naming function for all three
-// supported modes.
+// TestBootstrapConfigSecretName verifies that the Secret name is always
+// "bootstrap-config" — the namespace is the discriminator.
 func TestBootstrapConfigSecretName(t *testing.T) {
-	// Case 1 / 2 / 3: ConfigName is non-empty.
 	cfg := config.Load()
-	cfg.ConfigName = "dev"
-	if got := BootstrapConfigSecretName(cfg); got != "dev-bootstrap-config" {
-		t.Errorf("case 1: got %q, want %q", got, "dev-bootstrap-config")
+	for _, name := range []string{"dev", "prod-eu-low-cost", "scenario-aws-vs-hetzner", ""} {
+		cfg.ConfigName = name
+		if got := BootstrapConfigSecretName(cfg); got != "bootstrap-config" {
+			t.Errorf("ConfigName=%q: got %q, want %q", name, got, "bootstrap-config")
+		}
 	}
-	cfg.ConfigName = "prod-eu-low-cost"
-	if got := BootstrapConfigSecretName(cfg); got != "prod-eu-low-cost-bootstrap-config" {
-		t.Errorf("case 2: got %q, want %q", got, "prod-eu-low-cost-bootstrap-config")
+}
+
+// TestBootstrapConfigNamespace verifies the per-config namespace naming.
+func TestBootstrapConfigNamespace(t *testing.T) {
+	cfg := config.Load()
+	cases := []struct{ configName, want string }{
+		{"dev", "yage-dev"},
+		{"prod-eu-low-cost", "yage-prod-eu-low-cost"},
+		{"scenario-aws-vs-hetzner", "yage-scenario-aws-vs-hetzner"},
+		{"", "yage-default"},
 	}
-	cfg.ConfigName = "scenario-aws-vs-hetzner"
-	if got := BootstrapConfigSecretName(cfg); got != "scenario-aws-vs-hetzner-bootstrap-config" {
-		t.Errorf("case 3: got %q, want %q", got, "scenario-aws-vs-hetzner-bootstrap-config")
-	}
-	// Empty ConfigName falls back to "bootstrap-config".
-	cfg.ConfigName = ""
-	if got := BootstrapConfigSecretName(cfg); got != "bootstrap-config" {
-		t.Errorf("empty fallback: got %q, want %q", got, "bootstrap-config")
+	for _, c := range cases {
+		cfg.ConfigName = c.configName
+		if got := BootstrapConfigNamespace(cfg); got != c.want {
+			t.Errorf("ConfigName=%q: got %q, want %q", c.configName, got, c.want)
+		}
 	}
 }
 
@@ -196,8 +201,7 @@ func TestSanitizeLabelValue(t *testing.T) {
 }
 
 // TestBootstrapLabelsCase1 verifies that two configs with distinct WorkloadClusterNames
-// (ConfigName defaults to WorkloadClusterName) produce distinct Secret names
-// and carry the correct labels.
+// live in distinct namespaces (yage-<name>) with the correct Secret labels.
 func TestBootstrapLabelsCase1(t *testing.T) {
 	for _, wl := range []string{"dev", "staging", "prod"} {
 		cfg := config.Load()
@@ -205,9 +209,12 @@ func TestBootstrapLabelsCase1(t *testing.T) {
 		cfg.ConfigName = wl // default rule applied in Load()
 		cfg.InfraProvider = "aws"
 
-		name := BootstrapConfigSecretName(cfg)
-		if name != wl+"-bootstrap-config" {
-			t.Errorf("case1 %s: Secret name %q, want %q", wl, name, wl+"-bootstrap-config")
+		// Secret is always "bootstrap-config"; namespace is the discriminator.
+		if got := BootstrapConfigSecretName(cfg); got != "bootstrap-config" {
+			t.Errorf("case1 %s: Secret name %q, want %q", wl, got, "bootstrap-config")
+		}
+		if got := BootstrapConfigNamespace(cfg); got != "yage-"+wl {
+			t.Errorf("case1 %s: namespace %q, want %q", wl, got, "yage-"+wl)
 		}
 
 		lbl := bootstrapLabels(cfg, "draft")
@@ -223,11 +230,20 @@ func TestBootstrapLabelsCase1(t *testing.T) {
 		if lbl["yage.io/provider"] != "aws" {
 			t.Errorf("case1 %s: provider label %q", wl, lbl["yage.io/provider"])
 		}
+
+		// Namespace labels carry the discovery marker + provider.
+		nsLbl := configNamespaceLabels(cfg)
+		if nsLbl["infra.yage-deployment.bucaniere.us"] != "true" {
+			t.Errorf("case1 %s: missing discovery label", wl)
+		}
+		if nsLbl["infra.capi-provider.bucaniere.us"] != "aws" {
+			t.Errorf("case1 %s: provider ns-label %q", wl, nsLbl["infra.capi-provider.bucaniere.us"])
+		}
 	}
 }
 
 // TestBootstrapLabelsCase2 verifies two configs for the same workload cluster
-// (different ConfigName) both carry workload-cluster=prod but distinct Secret names.
+// (different ConfigName) live in distinct namespaces, both carrying workload-cluster=prod.
 func TestBootstrapLabelsCase2(t *testing.T) {
 	for _, configName := range []string{"prod", "prod-eu-low-cost"} {
 		cfg := config.Load()
@@ -235,9 +251,12 @@ func TestBootstrapLabelsCase2(t *testing.T) {
 		cfg.ConfigName = configName
 		cfg.InfraProvider = "azure"
 
-		name := BootstrapConfigSecretName(cfg)
-		if name != configName+"-bootstrap-config" {
-			t.Errorf("case2 %s: Secret name %q", configName, name)
+		// Secret name is always "bootstrap-config"; namespace differs.
+		if got := BootstrapConfigSecretName(cfg); got != "bootstrap-config" {
+			t.Errorf("case2 %s: Secret name %q, want bootstrap-config", configName, got)
+		}
+		if got := BootstrapConfigNamespace(cfg); got != "yage-"+configName {
+			t.Errorf("case2 %s: namespace %q, want %q", configName, got, "yage-"+configName)
 		}
 		lbl := bootstrapLabels(cfg, "draft")
 		if lbl["yage.io/workload-cluster"] != "prod" {
@@ -250,7 +269,7 @@ func TestBootstrapLabelsCase2(t *testing.T) {
 }
 
 // TestBootstrapLabelsCase3 verifies a draft scenario config has status="draft"
-// in its labels.
+// in its labels, and the namespace discovery label is present but provider label absent.
 func TestBootstrapLabelsCase3(t *testing.T) {
 	cfg := config.Load()
 	cfg.ConfigName = "scenario-aws-vs-hetzner"
@@ -266,6 +285,15 @@ func TestBootstrapLabelsCase3(t *testing.T) {
 	}
 	if _, ok := lbl["yage.io/provider"]; ok {
 		t.Errorf("case3: provider label should be absent when InfraProvider is empty")
+	}
+
+	// Namespace labels: discovery marker always present, provider absent when empty.
+	nsLbl := configNamespaceLabels(cfg)
+	if nsLbl["infra.yage-deployment.bucaniere.us"] != "true" {
+		t.Errorf("case3: missing discovery label on namespace")
+	}
+	if _, ok := nsLbl["infra.capi-provider.bucaniere.us"]; ok {
+		t.Errorf("case3: provider ns-label should be absent when InfraProvider is empty")
 	}
 }
 

--- a/internal/cluster/kindsync/cost_creds.go
+++ b/internal/cluster/kindsync/cost_creds.go
@@ -44,7 +44,7 @@ func CostCompareSecretExists(cfg *config.Config) bool {
 	if err != nil {
 		return false
 	}
-	_, err = cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Get(
+	_, err = cli.Typed.CoreV1().Secrets(YageSystemNamespace).Get(
 		context.Background(), costCredsSecretName, metav1.GetOptions{})
 	return err == nil
 }
@@ -63,7 +63,7 @@ func ReadCostCompareSecret(cfg *config.Config) error {
 		return nil // cluster unreachable — not an error
 	}
 	bg := context.Background()
-	sec, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Get(bg, costCredsSecretName, metav1.GetOptions{})
+	sec, err := cli.Typed.CoreV1().Secrets(YageSystemNamespace).Get(bg, costCredsSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil // secret absent — first-run case, not an error
 	}
@@ -102,7 +102,7 @@ func WriteCostCompareSecret(cfg *config.Config, creds map[string]string) error {
 	if len(data) == 0 {
 		return nil
 	}
-	return applySecret(context.Background(), cli, BootstrapConfigNamespace, costCredsSecretName, data, map[string]string{
+	return applySecret(context.Background(), cli, YageSystemNamespace, costCredsSecretName, data, map[string]string{
 		"app.kubernetes.io/managed-by": "yage",
 		"yage.io/secret-type":          "cost-credentials",
 	})

--- a/internal/cluster/kindsync/handoff.go
+++ b/internal/cluster/kindsync/handoff.go
@@ -202,61 +202,66 @@ func HandOffBootstrapSecretsToManagement(cfg *config.Config, kindCtx, mgmtKubeco
 			tgt.Namespace, tgt.Name, tgt.Description, kindCtx)
 	}
 
-	// Also hand off all per-config bootstrap-config Secrets in yage-system
-	// (labeled app.kubernetes.io/component=bootstrap-config). These are the
-	// orchestrator-state Secrets written by xapiri and promoted by the
-	// success path — one per ConfigName.
-	if bcList, listErr := srcCli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).List(
-		bg, metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/managed-by=yage,app.kubernetes.io/component=bootstrap-config",
-		},
-	); listErr == nil {
-		if !ensuredNS[BootstrapConfigNamespace] {
-			if nsErr := dstCli.EnsureNamespace(bg, BootstrapConfigNamespace); nsErr != nil {
-				logx.Warn("Hand-off: failed to ensure namespace %s on management: %v", BootstrapConfigNamespace, nsErr)
+	// Hand off all per-config namespaces (labeled infra.yage-deployment.bucaniere.us=true).
+	// Each namespace holds a "bootstrap-config" Secret. Mirror namespace + labels + secret.
+	if nsList, nsListErr := srcCli.Typed.CoreV1().Namespaces().List(bg, metav1.ListOptions{
+		LabelSelector: "infra.yage-deployment.bucaniere.us=true",
+	}); nsListErr == nil {
+		for _, srcNS := range nsList.Items {
+			nsName := srcNS.Name
+			// Ensure the namespace exists on management with the same labels.
+			nsLabels := map[string]string{"infra.yage-deployment.bucaniere.us": "true"}
+			if prov, ok := srcNS.Labels["infra.capi-provider.bucaniere.us"]; ok && prov != "" {
+				nsLabels["infra.capi-provider.bucaniere.us"] = prov
+			}
+			if !ensuredNS[nsName] {
+				if nsErr := dstCli.EnsureNamespaceWithLabels(bg, nsName, nsLabels); nsErr != nil {
+					logx.Warn("Hand-off: failed to ensure namespace %s on management: %v", nsName, nsErr)
+					if firstErr == nil {
+						firstErr = nsErr
+					}
+					continue
+				}
+				ensuredNS[nsName] = true
+			}
+			// Copy the bootstrap-config Secret if present.
+			src, secErr := srcCli.Typed.CoreV1().Secrets(nsName).Get(bg, "bootstrap-config", metav1.GetOptions{})
+			if secErr != nil {
+				continue // namespace exists but secret not yet written — normal during first-run
+			}
+			clean := corev1.Secret{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+				ObjectMeta: metav1.ObjectMeta{Name: src.Name, Namespace: nsName, Labels: src.Labels, Annotations: stripServerAnnotations(src.Annotations)},
+				Type:       src.Type,
+				Data:       src.Data,
+				StringData: src.StringData,
+				Immutable:  src.Immutable,
+			}
+			if clean.Type == "" {
+				clean.Type = corev1.SecretTypeOpaque
+			}
+			body, merr := json.Marshal(clean)
+			if merr != nil {
+				logx.Warn("Hand-off: failed to marshal %s/bootstrap-config: %v", nsName, merr)
 				if firstErr == nil {
-					firstErr = nsErr
+					firstErr = merr
 				}
-			} else {
-				ensuredNS[BootstrapConfigNamespace] = true
+				continue
 			}
-		}
-		if ensuredNS[BootstrapConfigNamespace] {
-			for _, src := range bcList.Items {
-				clean := corev1.Secret{
-					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
-					ObjectMeta: metav1.ObjectMeta{Name: src.Name, Namespace: src.Namespace, Labels: src.Labels, Annotations: stripServerAnnotations(src.Annotations)},
-					Type:       src.Type,
-					Data:       src.Data,
-					StringData: src.StringData,
-					Immutable:  src.Immutable,
+			_, perr := dstCli.Typed.CoreV1().Secrets(nsName).Patch(
+				bg, "bootstrap-config", types.ApplyPatchType, body,
+				metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: boolTrue()},
+			)
+			if perr != nil {
+				logx.Warn("Hand-off: failed to apply %s/bootstrap-config on management: %v", nsName, perr)
+				if firstErr == nil {
+					firstErr = perr
 				}
-				if clean.Type == "" {
-					clean.Type = corev1.SecretTypeOpaque
-				}
-				body, merr := json.Marshal(clean)
-				if merr != nil {
-					logx.Warn("Hand-off: failed to marshal %s/%s: %v", src.Namespace, src.Name, merr)
-					if firstErr == nil {
-						firstErr = merr
-					}
-					continue
-				}
-				_, perr := dstCli.Typed.CoreV1().Secrets(BootstrapConfigNamespace).Patch(
-					bg, src.Name, types.ApplyPatchType, body,
-					metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: boolTrue()},
-				)
-				if perr != nil {
-					logx.Warn("Hand-off: failed to apply %s/%s on management: %v", src.Namespace, src.Name, perr)
-					if firstErr == nil {
-						firstErr = perr
-					}
-					continue
-				}
-				copied++
-				logx.Log("Hand-off: copied %s/%s (bootstrap config %s) from %s to management cluster.",
-					src.Namespace, src.Name, src.Labels["yage.io/config-name"], kindCtx)
+				continue
 			}
+			copied++
+			logx.Log("Hand-off: copied %s/bootstrap-config (config %s) from %s to management cluster.",
+				nsName, src.Labels["yage.io/config-name"], kindCtx)
 		}
 	}
 

--- a/internal/platform/installer/installer.go
+++ b/internal/platform/installer/installer.go
@@ -404,16 +404,25 @@ func fetchAll(url string) (string, error) {
 // JSON parsing. Returns false on any error (docker missing, network,
 // image absent).
 func HasArm64Image(image string) bool {
+	_, arm64, _ := checkImageArch(image)
+	return arm64
+}
+
+// checkImageArch probes a container image's manifest list and reports which
+// architectures are present. hasAmd64 covers amd64/x86_64; hasArm64 covers
+// arm64/aarch64. queryErr is true when docker is absent or the call fails.
+func checkImageArch(image string) (hasAmd64, hasArm64, queryErr bool) {
 	if !shell.CommandExists("docker") {
-		return false
+		return false, false, true
 	}
 	out, _, err := shell.Capture("docker", "manifest", "inspect", image)
 	if err != nil || out == "" {
-		return false
+		return false, false, true
 	}
 	type entry struct {
 		Platform struct {
 			Architecture string `json:"architecture"`
+			OS           string `json:"os"`
 		} `json:"platform"`
 	}
 	var m struct {
@@ -422,11 +431,14 @@ func HasArm64Image(image string) bool {
 	}
 	_ = json.Unmarshal([]byte(out), &m)
 	for _, x := range append(m.Manifests, m.ManifestsAlt...) {
-		if x.Platform.Architecture == "arm64" {
-			return true
+		switch x.Platform.Architecture {
+		case "amd64", "x86_64":
+			hasAmd64 = true
+		case "arm64", "aarch64":
+			hasArm64 = true
 		}
 	}
-	return false
+	return hasAmd64, hasArm64, false
 }
 
 // BuildIfNoArm64 ports build_if_no_arm64(). If an arm64 variant exists in
@@ -642,10 +654,11 @@ type DepCheck struct {
 	Skip bool // built-in (no check needed)
 }
 
-// ImageCheck records arm64 availability for one container image.
+// ImageCheck records architecture availability for one container image.
 type ImageCheck struct {
 	Name  string // human-friendly label
 	Image string // full image:tag reference
+	Amd64 bool   // has amd64/x86-64 in manifest list
 	Arm64 bool   // has arm64 in manifest list
 	Err   bool   // docker absent or network failure
 }
@@ -720,8 +733,8 @@ func CheckProviderImages(cfg *config.Config) []ImageCheck {
 	}
 	var out []ImageCheck
 	for _, img := range images {
-		arm64 := HasArm64Image(img.ref)
-		out = append(out, ImageCheck{Name: img.name, Image: img.ref, Arm64: arm64})
+		amd64, arm64, queryErr := checkImageArch(img.ref)
+		out = append(out, ImageCheck{Name: img.name, Image: img.ref, Amd64: amd64, Arm64: arm64, Err: queryErr})
 	}
 	return out
 }

--- a/internal/platform/k8sclient/client.go
+++ b/internal/platform/k8sclient/client.go
@@ -313,8 +313,9 @@ func (c *Client) EnsureNamespaceWithLabels(ctx context.Context, name string, lab
 		for k, v := range labels {
 			sb.WriteString("\n    ")
 			sb.WriteString(k)
-			sb.WriteString(": ")
+			sb.WriteString(": \"")
 			sb.WriteString(v)
+			sb.WriteString("\"")
 		}
 	}
 	sb.WriteByte('\n')

--- a/internal/platform/k8sclient/client.go
+++ b/internal/platform/k8sclient/client.go
@@ -301,6 +301,26 @@ func (c *Client) EnsureNamespace(ctx context.Context, name string) error {
 	return c.ApplyYAML(ctx, []byte(body))
 }
 
+// EnsureNamespaceWithLabels creates the namespace if absent, or updates its
+// labels via server-side apply when the namespace already exists. The labels
+// map is always applied (idempotent for both create and label-update paths).
+func (c *Client) EnsureNamespaceWithLabels(ctx context.Context, name string, labels map[string]string) error {
+	var sb strings.Builder
+	sb.WriteString("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ")
+	sb.WriteString(name)
+	if len(labels) > 0 {
+		sb.WriteString("\n  labels:")
+		for k, v := range labels {
+			sb.WriteString("\n    ")
+			sb.WriteString(k)
+			sb.WriteString(": ")
+			sb.WriteString(v)
+		}
+	}
+	sb.WriteByte('\n')
+	return c.ApplyYAML(ctx, []byte(sb.String()))
+}
+
 // FileBacked materialises a kubeconfig file derived from a Secret data key
 // to a temp file path; callers use it to drive workflows that still need a
 // KUBECONFIG file (e.g. helm). Returns the temp file path and a cleanup fn.

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -2062,7 +2062,8 @@ func (m dashModel) loadEditorResourcesCmd() tea.Cmd {
 		bg := context.Background()
 		var items []editorResource
 
-		secrets, err := cli.Typed.CoreV1().Secrets(kindsync.BootstrapConfigNamespace).List(bg, metav1.ListOptions{})
+		cfgNS := kindsync.BootstrapConfigNamespace(cfg)
+		secrets, err := cli.Typed.CoreV1().Secrets(cfgNS).List(bg, metav1.ListOptions{})
 		if err != nil {
 			return editorResourcesMsg{err: fmt.Errorf("list secrets: %w", err)}
 		}
@@ -2070,7 +2071,7 @@ func (m dashModel) loadEditorResourcesCmd() tea.Cmd {
 			items = append(items, editorResource{Kind: "Secret", Name: s.Name})
 		}
 
-		cms, err := cli.Typed.CoreV1().ConfigMaps(kindsync.BootstrapConfigNamespace).List(bg, metav1.ListOptions{})
+		cms, err := cli.Typed.CoreV1().ConfigMaps(cfgNS).List(bg, metav1.ListOptions{})
 		if err == nil {
 			for _, cm := range cms.Items {
 				items = append(items, editorResource{Kind: "ConfigMap", Name: cm.Name})
@@ -2130,19 +2131,20 @@ func (m dashModel) openKindResourceEditorCmd(res editorResource) tea.Cmd {
 		bg := context.Background()
 
 		var body string
+		cfgNS2 := kindsync.BootstrapConfigNamespace(cfg)
 		switch res.Kind {
 		case "Secret":
-			sec, err := cli.Typed.CoreV1().Secrets(kindsync.BootstrapConfigNamespace).Get(bg, res.Name, metav1.GetOptions{})
+			sec, err := cli.Typed.CoreV1().Secrets(cfgNS2).Get(bg, res.Name, metav1.GetOptions{})
 			if err != nil {
 				return editorResourcesMsg{err: fmt.Errorf("get secret %s: %w", res.Name, err)}
 			}
-			body = secretToEditableYAML(sec.Data, res)
+			body = secretToEditableYAML(sec.Data, res, cfgNS2)
 		case "ConfigMap":
-			cm, err := cli.Typed.CoreV1().ConfigMaps(kindsync.BootstrapConfigNamespace).Get(bg, res.Name, metav1.GetOptions{})
+			cm, err := cli.Typed.CoreV1().ConfigMaps(cfgNS2).Get(bg, res.Name, metav1.GetOptions{})
 			if err != nil {
 				return editorResourcesMsg{err: fmt.Errorf("get configmap %s: %w", res.Name, err)}
 			}
-			body = configMapToEditableYAML(cm.Data, res)
+			body = configMapToEditableYAML(cm.Data, res, cfgNS2)
 		default:
 			return editorResourcesMsg{err: fmt.Errorf("unknown kind %s", res.Kind)}
 		}
@@ -2165,11 +2167,11 @@ func (m dashModel) openKindResourceEditorCmd(res editorResource) tea.Cmd {
 
 // secretToEditableYAML converts Secret data to a cleartext YAML for editing.
 // Values are base64-decoded and JSON-quoted.
-func secretToEditableYAML(data map[string][]byte, res editorResource) string {
+func secretToEditableYAML(data map[string][]byte, res editorResource, ns string) string {
 	var sb strings.Builder
 	sb.WriteString("# ⚠️  🔓  🎥  WARNING: CLEARTEXT SECRETS VISIBLE ON SCREEN  🎥  🔓  ⚠️\n")
 	sb.WriteString("# This file contains the decoded contents of Secret: ")
-	sb.WriteString(kindsync.BootstrapConfigNamespace + "/" + res.Name + "\n")
+	sb.WriteString(ns + "/" + res.Name + "\n")
 	sb.WriteString("# Anyone watching your screen can see these values!\n")
 	sb.WriteString("# The temp file is deleted automatically after you close the editor.\n")
 	sb.WriteString("#\n# Format: key: \"json-quoted-value\"  (one entry per line)\n\n")
@@ -2186,10 +2188,10 @@ func secretToEditableYAML(data map[string][]byte, res editorResource) string {
 }
 
 // configMapToEditableYAML converts ConfigMap data to a simple YAML for editing.
-func configMapToEditableYAML(data map[string]string, res editorResource) string {
+func configMapToEditableYAML(data map[string]string, res editorResource, ns string) string {
 	var sb strings.Builder
 	sb.WriteString("# ConfigMap: ")
-	sb.WriteString(kindsync.BootstrapConfigNamespace + "/" + res.Name + "\n\n")
+	sb.WriteString(ns + "/" + res.Name + "\n\n")
 	keys := make([]string, 0, len(data))
 	for k := range data {
 		keys = append(keys, k)
@@ -2219,7 +2221,7 @@ func applyEditedResourceToKind(cfg *config.Config, res *editorResource, tmpFile 
 		return err
 	}
 	bg := context.Background()
-	ns := kindsync.BootstrapConfigNamespace
+	ns := kindsync.BootstrapConfigNamespace(cfg)
 
 	switch res.Kind {
 	case "Secret":
@@ -2293,7 +2295,7 @@ func (m dashModel) renderEditorTab(w, h int) string {
 		lines = append(lines, stBad.Render("  "+m.editorErr))
 		lines = append(lines, stMuted.Render("  r = retry"))
 	} else if len(m.editorItems) == 0 {
-		lines = append(lines, stMuted.Render("  no resources found in "+kindsync.BootstrapConfigNamespace))
+		lines = append(lines, stMuted.Render("  no resources found in "+kindsync.BootstrapConfigNamespace(m.cfg)))
 		lines = append(lines, stMuted.Render("  r = refresh"))
 	} else {
 		for i, res := range m.editorItems {
@@ -4129,22 +4131,29 @@ func (m dashModel) renderDepsTab(w, h int) string {
 	}
 
 	if len(m.depsImages) > 0 {
-		lines = append(lines, stBold.Render("  Provider images (arm64)"))
+		provLabel := m.cfg.InfraProvider
+		if provLabel == "" {
+			provLabel = "provider"
+		}
+		lines = append(lines, stBold.Render("  "+provLabel+" images"))
+		archOK := func(ok bool) string {
+			if ok {
+				return stOK.Render("✓")
+			}
+			return stBad.Render("✗")
+		}
 		for _, img := range m.depsImages {
-			var badge string
-			switch {
-			case img.Err:
-				badge = stWarn.Render("  ?")
-			case img.Arm64:
-				badge = stOK.Render("  ✓")
-			default:
-				badge = stBad.Render("  ✗")
-			}
 			ref := img.Image
-			if len(ref) > 55 {
-				ref = "…" + ref[len(ref)-54:]
+			if len(ref) > 45 {
+				ref = "…" + ref[len(ref)-44:]
 			}
-			lines = append(lines, fmt.Sprintf("%s %-18s  %s", badge, img.Name, stMuted.Render(ref)))
+			var archStr string
+			if img.Err {
+				archStr = stWarn.Render("  ? [amd64:?] [arm64:?]")
+			} else {
+				archStr = fmt.Sprintf("  [amd64:%s] [arm64:%s]", archOK(img.Amd64), archOK(img.Arm64))
+			}
+			lines = append(lines, fmt.Sprintf("  %-18s %s  %s", img.Name, archStr, stMuted.Render(ref)))
 		}
 		lines = append(lines, "")
 	}

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -1412,7 +1412,7 @@ func (m dashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.saveKindErr = nil
 				cfg := m.cfg
 				return m, func() tea.Msg {
-					return saveKindMsg{err: kindsync.ApplyBootstrapConfigToManagementCluster(cfg)}
+					return saveKindMsg{err: kindsync.WriteBootstrapConfigSecret(cfg)}
 				}
 			}
 			return m, nil
@@ -1874,13 +1874,13 @@ func (m dashModel) updateDeployTab(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch m.deployFocused {
 		case 0:
 			if !m.saveKindLoading {
+				m.flushToCfg()
 				m.saveKindLoading = true
 				m.saveKindDone = false
 				m.saveKindErr = nil
 				cfg := m.cfg
 				return m, func() tea.Msg {
-					err := kindsync.ApplyBootstrapConfigToManagementCluster(cfg)
-					return saveKindMsg{err: err}
+					return saveKindMsg{err: kindsync.WriteBootstrapConfigSecret(cfg)}
 				}
 			}
 		case 1:

--- a/internal/ui/xapiri/state.go
+++ b/internal/ui/xapiri/state.go
@@ -31,6 +31,7 @@ import (
 	"os"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/provider"
 )
 
 // forkType discriminates the on-prem vs cloud branches of the
@@ -189,6 +190,13 @@ func newStateWithReader(w io.Writer, cfg *config.Config, in io.Reader) *state {
 func (s *state) initFromConfig(cfg *config.Config) {
 	if cfg == nil {
 		return
+	}
+	// Restore fork from saved InfraProvider so the dashboard opens in
+	// the correct on-prem/cloud view without a manual mode switch.
+	if provider.AirgapCompatible(cfg.InfraProvider) {
+		s.fork = forkOnPrem
+	} else if cfg.InfraProvider != "" {
+		s.fork = forkCloud
 	}
 	switch cfg.Workload.Environment {
 	case "staging":


### PR DESCRIPTION
## Summary

- **Req 1 — Per-config namespace**: Each config lives in `yage-<config-name>` (e.g. `yage-dev`, `yage-prod-eu`) instead of a shared `yage-system`. The namespace carries two labels updated on every save for discovery: `infra.yage-deployment.bucaniere.us: "true"` and `infra.capi-provider.bucaniere.us: <provider>`. Secret inside is always `bootstrap-config`; namespace is the discriminator. `ListBootstrapCandidates` uses namespace label-selector. `k8sclient.EnsureNamespaceWithLabels` (new) does SSA so labels stay fresh on every save. Shared resources (cost credentials) stay in `YageSystemNamespace = "yage-system"`. Handoff mirrors per-config namespaces + labels to management cluster.
- **Req 2 — Fork restoration**: `initFromConfig` now sets `s.fork` via `provider.AirgapCompatible` so reopening a Proxmox config always opens the on-prem dashboard view.
- **Req 3 — Dual-arch image check**: `ImageCheck` gains `Amd64 bool`; new `checkImageArch()` probes both architectures in one `docker manifest inspect` call. `renderDepsTab` shows `[amd64:✓/✗] [arm64:✓/✗]` per image with the provider name in the section header.

## Test plan

- [ ] `go test ./...` passes (all green before opening PR)
- [ ] `YAGE_XAPIRI_TUI=huh YAGE_XAPIRI_SKIP_KIND=1 yage --xapiri` — save a Proxmox config, reopen: should land on on-prem tab
- [ ] Deps tab [Check]: verify both arch columns render per image
- [ ] `kubectl get ns -l infra.yage-deployment.bucaniere.us=true` after an xapiri save shows the per-config namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)