### PR TITLE
chore(.github): add PR template + issue templates (bug, feature, epic)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Something broken in the bootstrap pipeline, provider, or TUI
+title: "bug: "
+labels: bug, claude_cli
+assignees: lpasquali
+---
+
+## What happened
+
+<!-- Describe the incorrect behaviour. One sentence is enough. -->
+
+## What was expected
+
+<!-- What should have happened instead? -->
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Context
+
+| Field | Value |
+|---|---|
+| Provider | <!-- proxmox / aws / azure / gcp / hetzner / openstack / vsphere / capd / do / linode / oci / ibmcloud --> |
+| Bootstrap phase | <!-- dependency install / identity / kind / clusterctl init / manifest apply / pivot / argocd / plan / xapiri --> |
+| Bootstrap mode | <!-- kubeadm / k3s --> |
+| Go version | <!-- `go version` output --> |
+| yage version / commit | <!-- `git rev-parse --short HEAD` --> |
+
+## Relevant log output
+
+```
+<!-- paste logx output or stack trace here -->
+```
+
+## Acceptance criteria
+
+- [ ] The described behaviour no longer occurs on the stated path
+- [ ] Regression test added or existing test updated to cover this case (cite test name)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Architecture ADRs
+    url: https://lpasquali.github.io/yage-docs/architecture/adrs/
+    about: Read the ADR index before opening an architectural issue

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,42 @@
+---
+name: Epic
+about: Multi-issue body of work tracking a larger initiative
+title: "epic: "
+labels: epic, claude_cli
+assignees: lpasquali
+---
+
+## Goal
+
+<!-- One sentence: what does this epic deliver when complete? -->
+
+## Motivation
+
+<!-- Why is this work happening now? Business driver, architectural constraint, ADR reference. -->
+
+## Abstraction plan phase (if applicable)
+
+<!-- Phase A / B / C / D / E — or "N/A" -->
+
+## Child issues
+
+<!-- Add one checkbox per issue as they are created. Update as issues close. -->
+
+- [ ] #
+- [ ] #
+- [ ] #
+
+## Success criteria
+
+<!-- How do we know the epic is done? Specific, observable outcomes. -->
+
+- [ ] 
+- [ ] 
+
+## Out of scope
+
+<!-- What is explicitly NOT part of this epic? -->
+
+## Notes
+
+<!-- Ordering constraints, dependency graph, known risks. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,47 @@
+---
+name: Feature / Task
+about: New capability, provider implementation, refactor, or config change
+title: ""
+labels: enhancement, claude_cli
+assignees: lpasquali
+---
+
+## Motivation
+
+<!-- Why does this need to exist? One sentence. -->
+
+## Scope
+
+<!-- What exactly does this issue cover? Keep to one PR worth of work. -->
+
+## Acceptance criteria
+
+- [ ] <!-- criterion 1 -->
+- [ ] <!-- criterion 2 -->
+- [ ] <!-- criterion 3 -->
+
+## DoD level
+
+<!-- Check ONE. See yage-docs/docs/context/WORKFLOW.md §Definition of Done -->
+
+- [ ] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)
+- [ ] **Level 2 — Test / CI / Config** (test changes, CI config, linter — no runtime code)
+- [ ] **Level 3 — Documentation** (yage-docs content, ADRs, runbooks — no Go code)
+
+## Agent assignment
+
+<!-- Which agent should implement this? -->
+
+- [ ] `yage-backend` — orchestrator, provider, config, kindsync
+- [ ] `yage-frontend` — xapiri TUI, CLI UX
+- [ ] `yage-architect` — ADR, interface contract, technical doc
+- [ ] `yage-platform-engineer` — K8s/CAPI/infra, manifest review
+- [ ] `yage-po` — backlog, CURRENT_STATE.md, issue management
+
+## Epic
+
+Epic: #<!-- parent epic number, or "none" -->
+
+## Notes
+
+<!-- Implementation hints, references, gotchas. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,65 @@
+## Summary
+
+<!-- 1-3 sentences: what and why -->
+
+Closes #<!-- issue number -->
+Epic: #<!-- parent epic number, if applicable -->
+
+## DoD Level
+
+<!-- Check ONE. See yage-docs/docs/context/WORKFLOW.md §Definition of Done -->
+
+- [ ] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)
+- [ ] **Level 2 — Test / CI / Config** (test changes, CI config, linter — no runtime code)
+- [ ] **Level 3 — Documentation** (yage-docs content, ADRs, runbooks — no Go code)
+
+## Level 1 Checklist
+
+<!-- Skip if Level 2 or 3. All boxes must be checked. -->
+
+- [ ] `make build` passes
+- [ ] `go test ./...` passes
+- [ ] `govulncheck ./...` — no new findings (if `go.mod` changed; skip otherwise)
+- [ ] Manually walked affected flow **or** change fully covered by existing tests (cite test name)
+- [ ] Breaking-change audit: Secret schemas, env var renames, CAPI CRD fields, config namespacing
+
+## Level 2 Checklist
+
+<!-- Skip if Level 1 or 3. -->
+
+- [ ] Full test suite passes
+- [ ] Coverage not degraded
+- [ ] No unintended CI side effects
+
+## Level 3 Checklist
+
+<!-- Skip if Level 1 or 2. -->
+
+- [ ] `mkdocs build --strict` passes
+- [ ] No broken internal links
+
+## Audit Checks
+
+<!-- Required when trigger conditions are met. See WORKFLOW.md §Audit Triggers. -->
+<!-- Write "No triggers fired." if none apply. -->
+
+| Check | Result | Evidence |
+|---|---|---|
+| `govulncheck ./...` (go.mod changed) | PASS / FAIL / N/A | <!-- paste summary or "no new findings" --> |
+| PE review (Secret schema / CAPI YAML) | PASS / FAIL / N/A | <!-- link to pe-review doc or comment --> |
+| Supply-chain (workflow change) | PASS / FAIL / N/A | <!-- note or N/A --> |
+
+## Acceptance Criteria Evidence
+
+<!-- For each acceptance criterion from the issue, tick and attach evidence. CI green counts. -->
+
+- [ ] <!-- criterion 1 — evidence: ... -->
+- [ ] <!-- criterion 2 — evidence: ... -->
+
+## Breaking Changes
+
+<!-- Describe any backward-incompatible changes. If none, write "None." -->
+
+## Notes for Reviewer
+
+<!-- Edge cases, decisions made, open questions. -->


### PR DESCRIPTION
## Summary

Adds GitHub community health files to enforce consistent issue and PR structure across the yage repo.

Closes N/A (no issue — requested directly)
Epic: N/A

## DoD Level

- [x] **Level 2 — Test / CI / Config** (test changes, CI config, linter — no runtime code)

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded
- [x] No unintended CI side effects

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Bug report template: provider + phase fields, reproduction steps, acceptance criteria checkbox
- [x] Feature/task template: motivation, scope, AC checklist, DoD level, agent assignment, epic link
- [x] Epic template: goal, child issues checklist, success criteria, out-of-scope, ordering notes
- [x] `config.yml`: blank issues disabled; ADR link in contact_links
- [x] PR template (was written during session but never committed): DoD levels, audit checks table, AC evidence

## Breaking Changes

None.

## Notes for Reviewer

The PR template was authored in a previous session but never committed to a branch that made it to main. Included here to land it properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)