### PR TITLE
feat(xapiri): dashboard as default entry point; add YAGE_XAPIRI_TUI=legacy opt-out (ADR 0007 Phase 1)

### DIFF
--- a/internal/ui/cli/help/kind.txt
+++ b/internal/ui/cli/help/kind.txt
@@ -19,3 +19,8 @@ xapiri integration
     yage-system/bootstrap-config Secret without falling back to disk). YAGE_XAPIRI_SKIP_KIND=1
     runs the wizard offline. YAGE_XAPIRI_DISK_FALLBACK=1 re-enables the legacy ~/.config/yage/
     bootstrap.yaml path.
+
+    YAGE_XAPIRI_TUI    Selects the xapiri UI. Default: dashboard (bubbletea).
+                       Set to "legacy" or "bufio" to opt back to the bufio
+                       walkthrough (deprecated, removed in a future release).
+                       "huh" is accepted as a synonym for the default.

--- a/internal/ui/xapiri/xapiri.go
+++ b/internal/ui/xapiri/xapiri.go
@@ -119,6 +119,7 @@ func Run(w io.Writer, cfg *config.Config) int {
 	if useHuhTUI() {
 		return runHuhBranch(w, cfg, s)
 	}
+	// Deprecated: use YAGE_XAPIRI_TUI=legacy to opt back; removed in a future release.
 	s.greet()
 	if err := s.stepKindClusterName(); err != nil {
 		return s.exit(err)
@@ -166,14 +167,16 @@ func Run(w io.Writer, cfg *config.Config) int {
 	return s.runCloudFork()
 }
 
-// useHuhTUI reports whether YAGE_XAPIRI_TUI=huh asks for the spike
-// flow. Any other value (or unset) keeps the legacy bufio-driven
-// walkthrough.
+// useHuhTUI reports whether the bubbletea dashboard should run.
+// Default (env unset or empty) and YAGE_XAPIRI_TUI=huh both select
+// the dashboard. Set YAGE_XAPIRI_TUI=legacy or YAGE_XAPIRI_TUI=bufio
+// to opt back to the legacy bufio-driven walkthrough (deprecated).
 func useHuhTUI() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("YAGE_XAPIRI_TUI")), "huh")
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("YAGE_XAPIRI_TUI")))
+	return v != "legacy" && v != "bufio"
 }
 
-// runHuhBranch is the YAGE_XAPIRI_TUI=huh entry. The kind prelude brings
+// runHuhBranch is the bubbletea dashboard entry point. The kind prelude brings
 // the management cluster up; the dashboard handles config selection and all
 // subsequent steps interactively.
 func runHuhBranch(w io.Writer, cfg *config.Config, s *state) int {


### PR DESCRIPTION
## Summary

- Flips `useHuhTUI()` so the bubbletea dashboard runs by default (env unset or `YAGE_XAPIRI_TUI=huh`).
- `YAGE_XAPIRI_TUI=legacy` or `YAGE_XAPIRI_TUI=bufio` opts back to the legacy bufio walkthrough.
- Marks the legacy code path `// Deprecated:` in `Run()` (code not removed — that is Phase 2 / #105).
- Documents `YAGE_XAPIRI_TUI` in `internal/ui/cli/help/kind.txt` under the "xapiri integration" block alongside sibling vars `YAGE_XAPIRI_SKIP_KIND` and `YAGE_XAPIRI_DISK_FALLBACK`.

Closes #103

## Test plan

- [x] `make build` passes
- [x] `go test ./...` passes (all packages, including `internal/ui/xapiri`)
- [x] `useHuhTUI()` returns `true` for empty env (default → dashboard)
- [x] `useHuhTUI()` returns `true` for `YAGE_XAPIRI_TUI=huh` (backward compat synonym)
- [x] `useHuhTUI()` returns `false` for `YAGE_XAPIRI_TUI=legacy` (opt-out)
- [x] `useHuhTUI()` returns `false` for `YAGE_XAPIRI_TUI=bufio` (opt-out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)