### PR TITLE
feat(csi): implement hcloud-csi driver package (hetzner cloud volumes)

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -51,6 +51,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/awsebs"
 	_ "github.com/lpasquali/yage/internal/csi/azuredisk"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
+	_ "github.com/lpasquali/yage/internal/csi/hcloud"
 	_ "github.com/lpasquali/yage/internal/csi/proxmoxcsi"
 )
 

--- a/internal/csi/csi_test.go
+++ b/internal/csi/csi_test.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/awsebs"
 	_ "github.com/lpasquali/yage/internal/csi/azuredisk"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
+	_ "github.com/lpasquali/yage/internal/csi/hcloud"
 )
 
 func names(ds []csi.Driver) []string {
@@ -38,6 +39,7 @@ func TestSelectorEmptyCfgUsesProviderDefault(t *testing.T) {
 		{"aws", []string{"aws-ebs"}},
 		{"azure", []string{"azure-disk"}},
 		{"gcp", []string{"gcp-pd"}},
+		{"hetzner", []string{"hcloud-csi"}},
 	}
 	for _, c := range cases {
 		t.Run(c.provider, func(t *testing.T) {
@@ -107,12 +109,12 @@ func TestSelectorNoProviderNoExplicit(t *testing.T) {
 	}
 }
 
-// TestRegisteredContainsScopedDrivers: the three drivers this
-// commit ships should all be in Registered().
+// TestRegisteredContainsScopedDrivers: the shipped drivers should all
+// be in Registered().
 func TestRegisteredContainsScopedDrivers(t *testing.T) {
 	got := csi.Registered()
 	sort.Strings(got)
-	for _, want := range []string{"aws-ebs", "azure-disk", "gcp-pd"} {
+	for _, want := range []string{"aws-ebs", "azure-disk", "gcp-pd", "hcloud-csi"} {
 		found := false
 		for _, n := range got {
 			if n == want {
@@ -129,15 +131,15 @@ func TestRegisteredContainsScopedDrivers(t *testing.T) {
 // TestDefaultsForOnlyImplementedProviders: DefaultsFor returns
 // non-nil only for providers we ship drivers for. Phase F scoped
 // shipped AWS/Azure/GCP; Wave 3 added Proxmox (migrated off
-// Provider.EnsureCSISecret onto the registry).
+// Provider.EnsureCSISecret onto the registry); issue #84 adds Hetzner.
 func TestDefaultsForOnlyImplementedProviders(t *testing.T) {
-	for _, p := range []string{"aws", "azure", "gcp", "proxmox"} {
+	for _, p := range []string{"aws", "azure", "gcp", "hetzner", "proxmox"} {
 		if got := csi.DefaultsFor(p); len(got) == 0 {
 			t.Errorf("DefaultsFor(%q) = empty, expected at least one driver", p)
 		}
 	}
 	// Unimplemented-yet providers get nil.
-	for _, p := range []string{"hetzner", "linode", "oci", "digitalocean", "ibmcloud", "openstack", "vsphere"} {
+	for _, p := range []string{"linode", "oci", "digitalocean", "ibmcloud", "openstack", "vsphere"} {
 		if got := csi.DefaultsFor(p); got != nil {
 			t.Errorf("DefaultsFor(%q) = %v, expected nil (driver not yet shipped)", p, got)
 		}

--- a/internal/csi/defaults.go
+++ b/internal/csi/defaults.go
@@ -28,6 +28,8 @@ func DefaultsFor(provider string) []string {
 		return []string{"azure-disk"}
 	case "gcp":
 		return []string{"gcp-pd"}
+	case "hetzner":
+		return []string{"hcloud-csi"}
 	case "proxmox":
 		return []string{"proxmox-csi"}
 	default:

--- a/internal/csi/hcloud/hcloud.go
+++ b/internal/csi/hcloud/hcloud.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package hcloud implements the Hetzner Cloud CSI driver registration
+// for yage's CSI add-on registry (internal/csi). The upstream chart is
+// hcloud-csi published by Hetzner at https://charts.hetzner.cloud; auth
+// is via a Hetzner Cloud project API token materialized as a Kubernetes
+// Secret (kube-system/hcloud-csi, key "token") on the workload cluster.
+//
+// The chart reads the token from that well-known Secret at controller
+// startup — no Helm values are needed to wire the credential, only a
+// stable secret reference in the values YAML.
+//
+// Pinned chart version v2.6.0 — a stable release that supports
+// Kubernetes 1.27+. Updating the pin is a follow-up commit.
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+const (
+	secretNamespace = "kube-system"
+	secretName      = "hcloud-csi"
+	tokenKey        = "token"
+)
+
+func init() {
+	csi.Register(&driver{})
+}
+
+type driver struct{}
+
+func (driver) Name() string             { return "hcloud-csi" }
+func (driver) K8sCSIDriverName() string { return "csi.hetzner.cloud" }
+func (driver) Defaults() []string       { return []string{"hetzner"} }
+
+// HelmChart pins to v2.6.0 of hcloud-csi from the official Hetzner
+// Helm chart repository.
+func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err error) {
+	return "https://charts.hetzner.cloud",
+		"hcloud-csi",
+		"v2.6.0",
+		nil
+}
+
+// RenderValues emits a minimal Helm values document. The API token is
+// read by the controller from the kube-system/hcloud-csi Secret applied
+// by EnsureSecret — this values block points the chart at that Secret
+// rather than inlining the token value.
+func (driver) RenderValues(cfg *config.Config) (string, error) {
+	var b strings.Builder
+	b.WriteString("# Rendered by yage internal/csi/hcloud.\n")
+	b.WriteString("# Auth: Kubernetes Secret applied by EnsureSecret\n")
+	b.WriteString("# (kube-system/hcloud-csi, key \"token\").\n")
+	b.WriteString("secret:\n")
+	b.WriteString("  name: " + secretName + "\n")
+	b.WriteString("storageClasses:\n")
+	b.WriteString("  - name: hcloud-volumes\n")
+	b.WriteString("    annotations:\n")
+	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
+	b.WriteString("    reclaimPolicy: Delete\n")
+	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
+	return b.String(), nil
+}
+
+// EnsureSecret creates (or updates) the kube-system/hcloud-csi Secret
+// on the workload cluster with the Hetzner Cloud API token. The token
+// is required — an empty token returns an error immediately rather than
+// applying a broken Secret.
+func (driver) EnsureSecret(cfg *config.Config, workloadKubeconfigPath string) error {
+	if cfg.Providers.Hetzner.Token == "" {
+		return fmt.Errorf("hcloud: HCLOUD_TOKEN is required")
+	}
+	cli, err := k8sclient.ForKubeconfigFile(workloadKubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("hcloud: load workload kubeconfig %s: %w", workloadKubeconfigPath, err)
+	}
+	sec := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretNamespace,
+			Name:      secretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{tokenKey: []byte(cfg.Providers.Hetzner.Token)},
+	}
+	yamlBody, err := yaml.Marshal(sec)
+	if err != nil {
+		return fmt.Errorf("hcloud: marshal secret: %w", err)
+	}
+	js, err := yaml.YAMLToJSON(yamlBody)
+	if err != nil {
+		return fmt.Errorf("hcloud: yaml→json: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	force := true
+	_, err = cli.Typed.CoreV1().Secrets(secretNamespace).Patch(
+		ctx, secretName, types.ApplyPatchType, js,
+		metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: &force},
+	)
+	if err != nil {
+		return fmt.Errorf("hcloud: apply %s/%s: %w", secretNamespace, secretName, err)
+	}
+	return nil
+}
+
+func (driver) DefaultStorageClass() string { return "hcloud-volumes" }
+
+func (driver) DescribeInstall(w plan.Writer, cfg *config.Config) {
+	w.Section("Hetzner Cloud CSI")
+	w.Bullet("driver: %s (chart hcloud-csi pinned v2.6.0)", "csi.hetzner.cloud")
+	w.Bullet("auth: Kubernetes Secret %s/%s (key %q) applied by EnsureSecret",
+		secretNamespace, secretName, tokenKey)
+	w.Bullet("token source: HCLOUD_TOKEN / YAGE_HCLOUD_TOKEN → cfg.Providers.Hetzner.Token")
+	w.Bullet("default StorageClass: hcloud-volumes (WaitForFirstConsumer)")
+}

--- a/internal/csi/hcloud/hcloud_test.go
+++ b/internal/csi/hcloud/hcloud_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package hcloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+)
+
+func TestDriverConstants(t *testing.T) {
+	d := driver{}
+	if got, want := d.Name(), "hcloud-csi"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if got, want := d.K8sCSIDriverName(), "csi.hetzner.cloud"; got != want {
+		t.Errorf("K8sCSIDriverName() = %q, want %q", got, want)
+	}
+	if got, want := d.DefaultStorageClass(), "hcloud-volumes"; got != want {
+		t.Errorf("DefaultStorageClass() = %q, want %q", got, want)
+	}
+	defs := d.Defaults()
+	if len(defs) != 1 || defs[0] != "hetzner" {
+		t.Errorf("Defaults() = %v, want [hetzner]", defs)
+	}
+}
+
+func TestHelmChart(t *testing.T) {
+	d := driver{}
+	repo, chart, ver, err := d.HelmChart(nil)
+	if err != nil {
+		t.Fatalf("HelmChart() unexpected err: %v", err)
+	}
+	if repo == "" {
+		t.Errorf("repo must not be empty")
+	}
+	if chart != "hcloud-csi" {
+		t.Errorf("chart = %q, want hcloud-csi", chart)
+	}
+	if ver != "v2.6.0" {
+		t.Errorf("version = %q, want v2.6.0", ver)
+	}
+}
+
+func TestRenderValues(t *testing.T) {
+	d := driver{}
+	out, err := d.RenderValues(&config.Config{})
+	if err != nil {
+		t.Fatalf("RenderValues() unexpected err: %v", err)
+	}
+	if out == "" {
+		t.Error("RenderValues() returned empty string")
+	}
+	if !strings.Contains(out, "hcloud-volumes") {
+		t.Errorf("RenderValues() missing hcloud-volumes: %s", out)
+	}
+	if !strings.Contains(out, "secret") {
+		t.Errorf("RenderValues() missing secret reference: %s", out)
+	}
+}
+
+func TestEnsureSecretEmptyToken(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	// Ensure no token is set.
+	cfg.Providers.Hetzner.Token = ""
+	err := d.EnsureSecret(cfg, "/nonexistent/kubeconfig")
+	if err == nil {
+		t.Fatal("EnsureSecret() with empty token should return an error")
+	}
+	if !strings.Contains(err.Error(), "HCLOUD_TOKEN") {
+		t.Errorf("EnsureSecret() error should mention HCLOUD_TOKEN, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/csi/hcloud` package implementing `csi.Driver` for the Hetzner Cloud CSI driver (`csi.hetzner.cloud`)
- `EnsureSecret` applies a `kube-system/hcloud-csi` Kubernetes Secret via `k8sclient` SSA using `cfg.Providers.Hetzner.Token`; returns an error immediately when the token is empty
- Updates `internal/csi/defaults.go` to return `["hcloud-csi"]` for provider `"hetzner"` and registers the driver with a blank import in `cmd/yage/main.go`
- Updates `internal/csi/csi_test.go` to include the new driver in registry and defaults assertions

Closes #84

## Definition of Done (Level 1)

- [x] `make build` passes
- [x] `go test ./...` passes (including new `internal/csi/hcloud` tests)
- [x] `Name()` → `"hcloud-csi"`, `K8sCSIDriverName()` → `"csi.hetzner.cloud"`, `DefaultStorageClass()` → `"hcloud-volumes"`
- [x] `HelmChart()` → `https://charts.hetzner.cloud`, `hcloud-csi`, `v2.6.0`
- [x] `EnsureSecret()` errors on empty token (no kubeconfig attempt)
- [x] `DefaultsFor("hetzner")` returns `["hcloud-csi"]`
- [x] Driver self-registers via `init()` and is blank-imported in `cmd/yage/main.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)