### PR TITLE
feat(csi): implement do-block-storage driver (DigitalOcean)

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -51,6 +51,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/awsebs"
 	_ "github.com/lpasquali/yage/internal/csi/azuredisk"
 	_ "github.com/lpasquali/yage/internal/csi/cindercsi"
+	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"

--- a/internal/csi/csi_test.go
+++ b/internal/csi/csi_test.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/awsebs"
 	_ "github.com/lpasquali/yage/internal/csi/azuredisk"
 	_ "github.com/lpasquali/yage/internal/csi/cindercsi"
+	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"
@@ -117,7 +118,7 @@ func TestSelectorNoProviderNoExplicit(t *testing.T) {
 func TestRegisteredContainsScopedDrivers(t *testing.T) {
 	got := csi.Registered()
 	sort.Strings(got)
-	for _, want := range []string{"aws-ebs", "azure-disk", "gcp-pd", "hcloud-csi", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
+	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
 		found := false
 		for _, n := range got {
 			if n == want {
@@ -135,15 +136,15 @@ func TestRegisteredContainsScopedDrivers(t *testing.T) {
 // non-nil only for providers we ship drivers for. Phase F scoped
 // shipped AWS/Azure/GCP; Wave 3 added Proxmox (migrated off
 // Provider.EnsureCSISecret onto the registry); issue #84 adds Hetzner;
-// issue #88 added OpenStack (openstack-cinder); Wave 4 added OCI.
+// issue #88 added OpenStack (openstack-cinder); Wave 4 added OCI and DigitalOcean.
 func TestDefaultsForOnlyImplementedProviders(t *testing.T) {
-	for _, p := range []string{"aws", "azure", "gcp", "hetzner", "oci", "openstack", "proxmox", "vsphere"} {
+	for _, p := range []string{"aws", "azure", "digitalocean", "gcp", "hetzner", "oci", "openstack", "proxmox", "vsphere"} {
 		if got := csi.DefaultsFor(p); len(got) == 0 {
 			t.Errorf("DefaultsFor(%q) = empty, expected at least one driver", p)
 		}
 	}
 	// Unimplemented-yet providers get nil.
-	for _, p := range []string{"digitalocean", "ibmcloud", "linode"} {
+	for _, p := range []string{"ibmcloud", "linode"} {
 		if got := csi.DefaultsFor(p); got != nil {
 			t.Errorf("DefaultsFor(%q) = %v, expected nil (driver not yet shipped)", p, got)
 		}

--- a/internal/csi/defaults.go
+++ b/internal/csi/defaults.go
@@ -17,7 +17,7 @@ package csi
 // cfg.CSI.DefaultClass is empty, the first installable driver in
 // the slice supplies the default StorageClass.
 //
-// Adding hetzner/digitalocean/linode/etc. is a follow-up commit —
+// Adding hetzner/linode/etc. is a follow-up commit —
 // same shape, drop a new package under internal/csi/<name>/ and add
 // an entry here.
 func DefaultsFor(provider string) []string {
@@ -26,6 +26,8 @@ func DefaultsFor(provider string) []string {
 		return []string{"aws-ebs"}
 	case "azure":
 		return []string{"azure-disk"}
+	case "digitalocean":
+		return []string{"do-block-storage"}
 	case "gcp":
 		return []string{"gcp-pd"}
 	case "hetzner":

--- a/internal/csi/doblock/doblock.go
+++ b/internal/csi/doblock/doblock.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package doblock implements the DigitalOcean Block Storage (DOBS) CSI
+// driver registration for yage's CSI add-on registry (internal/csi).
+//
+// The upstream Helm chart is do-csi-driver published by DigitalOcean at
+// https://charts.digitalocean.com. Auth requires a DigitalOcean personal
+// access token stored in a kube-system/digitalocean Secret under the key
+// "access-token". The token comes from cfg.Cost.Credentials.DigitalOceanToken
+// (env: YAGE_DO_TOKEN / DIGITALOCEAN_TOKEN).
+//
+// Pinned chart version v4.14.0 — a stable release that supports K8s 1.24+.
+// Updating the pin is a follow-up commit (chart bumps land alongside
+// `helm-up` runs, not silently).
+package doblock
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+const (
+	secretNamespace = "kube-system"
+	secretName      = "digitalocean"
+	tokenKey        = "access-token"
+)
+
+func init() {
+	csi.Register(&driver{})
+}
+
+type driver struct{}
+
+func (driver) Name() string             { return "do-block-storage" }
+func (driver) K8sCSIDriverName() string { return "dobs.csi.digitalocean.com" }
+func (driver) Defaults() []string       { return []string{"digitalocean"} }
+
+// HelmChart pins to v4.14.0 of do-csi-driver from the DigitalOcean chart repo.
+func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err error) {
+	return "https://charts.digitalocean.com",
+		"do-csi-driver",
+		"v4.14.0",
+		nil
+}
+
+// RenderValues emits a minimal Helm values document. The DO CSI driver
+// reads the access-token from the kube-system/digitalocean Secret, which
+// EnsureSecret creates before Helm install. The chart references the
+// Secret by its conventional name; no additional values configuration is
+// required for the token path.
+func (driver) RenderValues(cfg *config.Config) (string, error) {
+	var b strings.Builder
+	b.WriteString("# Rendered by yage internal/csi/doblock.\n")
+	b.WriteString("# Auth: DigitalOcean access-token read from Secret ")
+	b.WriteString(secretNamespace + "/" + secretName + " key " + tokenKey + ".\n")
+	b.WriteString("# EnsureSecret must run before `helm install` so the Secret is present.\n")
+	b.WriteString("controller:\n")
+	b.WriteString("  replicas: 1\n")
+	b.WriteString("storageClasses:\n")
+	b.WriteString("  - name: do-block-storage\n")
+	b.WriteString("    annotations:\n")
+	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
+	b.WriteString("    parameters:\n")
+	b.WriteString("      type: pd-ssd\n")
+	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
+	b.WriteString("    reclaimPolicy: Delete\n")
+	return b.String(), nil
+}
+
+// EnsureSecret writes the kube-system/digitalocean Secret on the workload
+// cluster. The DO CSI driver requires this Secret to be present before
+// the Helm chart is installed; it reads the access-token at controller
+// start-up. Returns an error if the token is empty — the driver cannot
+// authenticate without it (there is no ambient-identity fallback for DO).
+func (driver) EnsureSecret(cfg *config.Config, workloadKubeconfigPath string) error {
+	token := cfg.Cost.Credentials.DigitalOceanToken
+	if token == "" {
+		return fmt.Errorf("doblock: DigitalOcean access token is empty; set YAGE_DO_TOKEN or DIGITALOCEAN_TOKEN")
+	}
+	cli, err := k8sclient.ForKubeconfigFile(workloadKubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("doblock: load workload kubeconfig %s: %w", workloadKubeconfigPath, err)
+	}
+	sec := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretNamespace,
+			Name:      secretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{tokenKey: []byte(token)},
+	}
+	yamlBody, err := yaml.Marshal(sec)
+	if err != nil {
+		return fmt.Errorf("doblock: marshal secret: %w", err)
+	}
+	js, err := yaml.YAMLToJSON(yamlBody)
+	if err != nil {
+		return fmt.Errorf("doblock: yaml→json: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	force := true
+	_, err = cli.Typed.CoreV1().Secrets(secretNamespace).Patch(
+		ctx, secretName, types.ApplyPatchType, js,
+		metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: &force},
+	)
+	if err != nil {
+		return fmt.Errorf("doblock: apply %s/%s: %w", secretNamespace, secretName, err)
+	}
+	return nil
+}
+
+func (driver) DefaultStorageClass() string { return "do-block-storage" }
+
+func (driver) DescribeInstall(w plan.Writer, cfg *config.Config) {
+	w.Section("DigitalOcean Block Storage CSI")
+	w.Bullet("driver: %s (chart do-csi-driver pinned v4.14.0)", "dobs.csi.digitalocean.com")
+	w.Bullet("auth: DigitalOcean access-token (Secret %s/%s key %s)", secretNamespace, secretName, tokenKey)
+	if cfg.Cost.Credentials.DigitalOceanToken == "" {
+		w.Bullet("note: YAGE_DO_TOKEN / DIGITALOCEAN_TOKEN is unset — EnsureSecret will fail until a token is provided")
+	}
+	w.Bullet("default StorageClass: do-block-storage (volumeBindingMode WaitForFirstConsumer, pd-ssd volumes)")
+}

--- a/internal/csi/doblock/doblock_test.go
+++ b/internal/csi/doblock/doblock_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package doblock
+
+import (
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+)
+
+func TestDriverConstants(t *testing.T) {
+	d := driver{}
+	if got, want := d.Name(), "do-block-storage"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if got, want := d.K8sCSIDriverName(), "dobs.csi.digitalocean.com"; got != want {
+		t.Errorf("K8sCSIDriverName() = %q, want %q", got, want)
+	}
+	if got, want := d.DefaultStorageClass(), "do-block-storage"; got != want {
+		t.Errorf("DefaultStorageClass() = %q, want %q", got, want)
+	}
+	defs := d.Defaults()
+	if len(defs) != 1 || defs[0] != "digitalocean" {
+		t.Errorf("Defaults() = %v, want [digitalocean]", defs)
+	}
+}
+
+func TestHelmChart(t *testing.T) {
+	d := driver{}
+	repo, chart, ver, err := d.HelmChart(nil)
+	if err != nil {
+		t.Fatalf("HelmChart() unexpected err: %v", err)
+	}
+	if chart != "do-csi-driver" {
+		t.Errorf("chart = %q, want %q", chart, "do-csi-driver")
+	}
+	if ver != "v4.14.0" {
+		t.Errorf("version = %q, want %q", ver, "v4.14.0")
+	}
+	if repo == "" {
+		t.Errorf("repo must not be empty")
+	}
+}
+
+func TestRenderValues(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	out, err := d.RenderValues(cfg)
+	if err != nil {
+		t.Fatalf("RenderValues() unexpected err: %v", err)
+	}
+	if out == "" {
+		t.Error("RenderValues() returned empty string")
+	}
+}
+
+func TestEnsureSecretEmptyTokenError(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	// Token is empty — EnsureSecret must return an error.
+	err := d.EnsureSecret(cfg, "/nonexistent/kubeconfig")
+	if err == nil {
+		t.Error("EnsureSecret() with empty token should return error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/csi/doblock` package implementing the DigitalOcean Block Storage (DOBS) CSI driver for yage's §20 CSI registry
- `EnsureSecret` applies `kube-system/digitalocean` Secret (key `access-token`) via server-side apply, and returns an error when the token is empty (no ambient-identity fallback for DO)
- `HelmChart` pins `do-csi-driver` v4.14.0 from `https://charts.digitalocean.com`
- `defaults.go` gains `case "digitalocean": return []string{"do-block-storage"}`
- `csi_test.go` updated: `digitalocean` moved from the "not yet shipped" list to the "implemented" list; `doblock` blank-imported so the Selector test sees the full registry
- `cmd/yage/main.go` blank-imports `internal/csi/doblock` alongside the other CSI drivers

Closes #85

## Test plan

- [x] `make build` — clean compile
- [x] `go test ./...` — all packages pass, including `internal/csi/doblock` (Name, K8sCSIDriverName, DefaultStorageClass, HelmChart, RenderValues non-empty, EnsureSecret error on empty token) and the updated `internal/csi` Selector/DefaultsFor table tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)