### PR TITLE
feat(csi): implement longhorn driver (cross-provider opt-in)

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
+	_ "github.com/lpasquali/yage/internal/csi/longhorn"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"
 	_ "github.com/lpasquali/yage/internal/csi/openebs"
 	_ "github.com/lpasquali/yage/internal/csi/proxmoxcsi"

--- a/internal/csi/csi_test.go
+++ b/internal/csi/csi_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
+	_ "github.com/lpasquali/yage/internal/csi/longhorn"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"
 	_ "github.com/lpasquali/yage/internal/csi/vspherecsi"
 )
@@ -82,7 +83,8 @@ func TestSelectorUnknownNamesDropped(t *testing.T) {
 		},
 	}
 	got := names(csi.Selector(cfg))
-	want := []string{"aws-ebs"}
+	// longhorn is now registered; hcloud is not. Both aws-ebs and longhorn resolve.
+	want := []string{"aws-ebs", "longhorn"}
 	if !equalStringSlices(got, want) {
 		t.Errorf("Selector with unknowns = %v, want %v (only registered names survive)", got, want)
 	}
@@ -118,7 +120,7 @@ func TestSelectorNoProviderNoExplicit(t *testing.T) {
 func TestRegisteredContainsScopedDrivers(t *testing.T) {
 	got := csi.Registered()
 	sort.Strings(got)
-	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
+	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "longhorn", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
 		found := false
 		for _, n := range got {
 			if n == want {

--- a/internal/csi/longhorn/longhorn.go
+++ b/internal/csi/longhorn/longhorn.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package longhorn implements the Longhorn CSI driver registration
+// for yage's CSI add-on registry (internal/csi). Longhorn is a
+// cloud-native distributed block storage system built on local node
+// storage — no cloud credentials are required. It operates entirely
+// within the cluster, replicating data across nodes via their local
+// disks.
+//
+// Longhorn is a cross-provider opt-in: it works on any infrastructure
+// where worker nodes have dedicated local disks and open-iscsi is
+// installed. Operators enable it by setting cfg.CSI.Drivers =
+// ["longhorn"] (or appending it alongside a cloud CSI driver for
+// mixed workloads).
+//
+// Pinned chart version v1.7.2 — a stable release as of early 2025
+// that supports K8s 1.25+. Chart updates are a follow-up commit
+// (bumped alongside `helm-up` runs, not silently).
+package longhorn
+
+import (
+	"strings"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+func init() {
+	csi.Register(&driver{})
+}
+
+type driver struct{}
+
+func (driver) Name() string             { return "longhorn" }
+func (driver) K8sCSIDriverName() string { return "driver.longhorn.io" }
+
+// Defaults returns an empty slice — Longhorn is a cross-provider
+// opt-in, not the default choice for any single infrastructure
+// provider. Operators enable it explicitly via cfg.CSI.Drivers.
+func (driver) Defaults() []string { return []string{} }
+
+func (driver) DefaultStorageClass() string { return "longhorn" }
+
+// HelmChart pins to v1.7.2 of the Longhorn chart from the official
+// Longhorn Helm repository.
+func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err error) {
+	return "https://charts.longhorn.io",
+		"longhorn",
+		"v1.7.2",
+		nil
+}
+
+// RenderValues emits a minimal Helm values document. Longhorn's
+// defaults are production-ready out of the box; no required overrides
+// exist for a standard install. The only tunable emitted here is
+// defaultSettings.defaultReplicaCount — set to 3, which is Longhorn's
+// own default and gives one replica per worker node in a three-node
+// cluster. Operators reduce it to 2 on two-node setups or 1 for
+// single-node dev environments via a Helm CLI override.
+func (driver) RenderValues(cfg *config.Config) (string, error) {
+	var b strings.Builder
+	b.WriteString("# Rendered by yage internal/csi/longhorn.\n")
+	b.WriteString("# Longhorn defaults are production-ready; no required overrides.\n")
+	b.WriteString("# Adjust defaultReplicaCount to match your cluster's worker node count.\n")
+	b.WriteString("defaultSettings:\n")
+	b.WriteString("  defaultReplicaCount: 3\n")
+	return b.String(), nil
+}
+
+// EnsureSecret returns ErrNotApplicable: Longhorn uses local node
+// storage and requires no cloud credential Secret. The orchestrator
+// treats this as a clean skip.
+func (driver) EnsureSecret(cfg *config.Config, workloadKubeconfigPath string) error {
+	return csi.ErrNotApplicable
+}
+
+func (driver) DescribeInstall(w plan.Writer, cfg *config.Config) {
+	w.Section("Longhorn CSI")
+	w.Bullet("driver: %s (chart longhorn pinned v1.7.2)", "driver.longhorn.io")
+	w.Bullet("prerequisite: open-iscsi must be installed and running on every worker node")
+	w.Bullet("replica count: 3 (adjust defaultSettings.defaultReplicaCount for non-3-node clusters)")
+	w.Bullet("cross-provider opt-in: works on any infrastructure with local node disks — not a provider default")
+	w.Bullet("default StorageClass: longhorn (no cloud credential Secret required)")
+}

--- a/internal/csi/longhorn/longhorn_test.go
+++ b/internal/csi/longhorn/longhorn_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package longhorn
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/csi"
+)
+
+func TestDriverConstants(t *testing.T) {
+	d := driver{}
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Name", d.Name(), "longhorn"},
+		{"K8sCSIDriverName", d.K8sCSIDriverName(), "driver.longhorn.io"},
+		{"DefaultStorageClass", d.DefaultStorageClass(), "longhorn"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("%s() = %q, want %q", c.name, c.got, c.want)
+			}
+		})
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	d := driver{}
+	defs := d.Defaults()
+	if len(defs) != 0 {
+		t.Errorf("Defaults() = %v, want empty slice (cross-provider opt-in)", defs)
+	}
+}
+
+func TestHelmChart(t *testing.T) {
+	d := driver{}
+	cases := []struct {
+		name      string
+		checkFunc func(repo, chart, version string, err error)
+	}{
+		{
+			name: "no error",
+			checkFunc: func(repo, chart, version string, err error) {
+				if err != nil {
+					t.Fatalf("HelmChart() unexpected err: %v", err)
+				}
+			},
+		},
+		{
+			name: "chart name",
+			checkFunc: func(repo, chart, version string, err error) {
+				if chart != "longhorn" {
+					t.Errorf("chart = %q, want %q", chart, "longhorn")
+				}
+			},
+		},
+		{
+			name: "version pinned",
+			checkFunc: func(repo, chart, version string, err error) {
+				if version != "v1.7.2" {
+					t.Errorf("version = %q, want %q", version, "v1.7.2")
+				}
+			},
+		},
+		{
+			name: "repo not empty",
+			checkFunc: func(repo, chart, version string, err error) {
+				if repo == "" {
+					t.Errorf("repo must not be empty")
+				}
+			},
+		},
+		{
+			name: "repo url correct",
+			checkFunc: func(repo, chart, version string, err error) {
+				if repo != "https://charts.longhorn.io" {
+					t.Errorf("repo = %q, want %q", repo, "https://charts.longhorn.io")
+				}
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo, chart, version, err := d.HelmChart(nil)
+			c.checkFunc(repo, chart, version, err)
+		})
+	}
+}
+
+func TestRenderValues(t *testing.T) {
+	d := driver{}
+	cases := []struct {
+		name    string
+		checkFn func(out string, err error)
+	}{
+		{
+			name: "no error",
+			checkFn: func(out string, err error) {
+				if err != nil {
+					t.Fatalf("RenderValues() unexpected err: %v", err)
+				}
+			},
+		},
+		{
+			name: "contains defaultReplicaCount 3",
+			checkFn: func(out string, err error) {
+				if !strings.Contains(out, "defaultReplicaCount: 3") {
+					t.Errorf("RenderValues() missing defaultReplicaCount: 3\n%s", out)
+				}
+			},
+		},
+		{
+			name: "contains no required overrides comment",
+			checkFn: func(out string, err error) {
+				if !strings.Contains(out, "no required overrides") {
+					t.Errorf("RenderValues() missing explanatory comment about no required overrides\n%s", out)
+				}
+			},
+		},
+		{
+			name: "non-empty output",
+			checkFn: func(out string, err error) {
+				if out == "" {
+					t.Errorf("RenderValues() returned empty string")
+				}
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := d.RenderValues(nil)
+			c.checkFn(out, err)
+		})
+	}
+}
+
+func TestEnsureSecretNotApplicable(t *testing.T) {
+	d := driver{}
+	err := d.EnsureSecret(nil, "/nonexistent/kubeconfig")
+	if !errors.Is(err, csi.ErrNotApplicable) {
+		t.Errorf("EnsureSecret() = %v, want csi.ErrNotApplicable", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/csi/longhorn` package implementing the `Driver` interface: `Name()="longhorn"`, `K8sCSIDriverName()="driver.longhorn.io"`, `HelmChart()` pinned to `https://charts.longhorn.io` chart `longhorn` v1.7.2, `RenderValues()` emitting `defaultSettings.defaultReplicaCount: 3`, `EnsureSecret()` returning `csi.ErrNotApplicable` (local node storage — no cloud credential needed), `Defaults()` returning `[]string{}` (cross-provider opt-in).
- Registers the driver via blank import in `cmd/yage/main.go`.
- Updates `internal/csi/csi_test.go` to import the longhorn package and reflect that `longhorn` is now a registered driver (fixes `TestSelectorUnknownNamesDropped` + `TestRegisteredContainsScopedDrivers`).

Closes #89

## Definition of Done — Level 1

- [x] `make build` passes
- [x] `go test ./...` passes (all packages green, including `internal/csi/longhorn`)
- [x] Table-driven tests for Name/K8sCSIDriverName/DefaultStorageClass, RenderValues content, HelmChart fields, EnsureSecret returns `csi.ErrNotApplicable`, Defaults returns empty slice
- [x] `DefaultsFor("longhorn")` returns nil via `default: return nil` in `defaults.go` — no new case needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)