### PR TITLE
feat(csi): implement linode-block-storage driver

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
+	_ "github.com/lpasquali/yage/internal/csi/linodebs"
 	_ "github.com/lpasquali/yage/internal/csi/longhorn"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"
 	_ "github.com/lpasquali/yage/internal/csi/openebs"

--- a/internal/csi/csi_test.go
+++ b/internal/csi/csi_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
+	_ "github.com/lpasquali/yage/internal/csi/linodebs"
 	_ "github.com/lpasquali/yage/internal/csi/longhorn"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"
 	_ "github.com/lpasquali/yage/internal/csi/vspherecsi"
@@ -120,7 +121,7 @@ func TestSelectorNoProviderNoExplicit(t *testing.T) {
 func TestRegisteredContainsScopedDrivers(t *testing.T) {
 	got := csi.Registered()
 	sort.Strings(got)
-	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "longhorn", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
+	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "linode-block-storage", "longhorn", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
 		found := false
 		for _, n := range got {
 			if n == want {
@@ -138,15 +139,15 @@ func TestRegisteredContainsScopedDrivers(t *testing.T) {
 // non-nil only for providers we ship drivers for. Phase F scoped
 // shipped AWS/Azure/GCP; Wave 3 added Proxmox (migrated off
 // Provider.EnsureCSISecret onto the registry); issue #84 adds Hetzner;
-// issue #88 added OpenStack (openstack-cinder); Wave 4 added OCI and DigitalOcean.
+// issue #88 added OpenStack (openstack-cinder); Wave 4 added OCI, DigitalOcean, and Linode.
 func TestDefaultsForOnlyImplementedProviders(t *testing.T) {
-	for _, p := range []string{"aws", "azure", "digitalocean", "gcp", "hetzner", "oci", "openstack", "proxmox", "vsphere"} {
+	for _, p := range []string{"aws", "azure", "digitalocean", "gcp", "hetzner", "linode", "oci", "openstack", "proxmox", "vsphere"} {
 		if got := csi.DefaultsFor(p); len(got) == 0 {
 			t.Errorf("DefaultsFor(%q) = empty, expected at least one driver", p)
 		}
 	}
 	// Unimplemented-yet providers get nil.
-	for _, p := range []string{"ibmcloud", "linode"} {
+	for _, p := range []string{"ibmcloud"} {
 		if got := csi.DefaultsFor(p); got != nil {
 			t.Errorf("DefaultsFor(%q) = %v, expected nil (driver not yet shipped)", p, got)
 		}

--- a/internal/csi/defaults.go
+++ b/internal/csi/defaults.go
@@ -36,6 +36,8 @@ func DefaultsFor(provider string) []string {
 		return []string{"openstack-cinder"}
 	case "proxmox":
 		return []string{"proxmox-csi"}
+	case "linode":
+		return []string{"linode-block-storage"}
 	case "oci":
 		return []string{"oci-block-storage"}
 	case "vsphere":

--- a/internal/csi/linodebs/linodebs.go
+++ b/internal/csi/linodebs/linodebs.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package linodebs implements the Linode Block Storage CSI driver
+// registration for yage's CSI add-on registry (internal/csi).
+//
+// Chart coordinates: the task spec referenced
+// https://linode.github.io/linode-cloud-controller-manager with chart
+// "linode-csi-driver" — that repo hosts only ccm-linode (the Cloud
+// Controller Manager), not the CSI driver. The canonical CSI chart is
+// published at https://linode.github.io/linode-blockstorage-csi-driver
+// with chart name "linode-blockstorage-csi-driver". The coordinates
+// below were verified against the live Helm index.
+//
+// Auth model: a Kubernetes Secret named "linode" in kube-system holds
+// the Linode API token under the key "token". The CSI driver reads this
+// Secret to authenticate against the Linode Block Storage API. There is
+// no Workload Identity equivalent for Linode, so EnsureSecret returns an
+// error when the token is empty — the operator must supply
+// YAGE_LINODE_TOKEN or LINODE_TOKEN before running the orchestrator.
+//
+// Pinned chart version v1.1.2 — the latest stable release as of 2026.
+package linodebs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+const (
+	secretNamespace = "kube-system"
+	secretName      = "linode"
+	tokenKey        = "token"
+)
+
+func init() {
+	csi.Register(&driver{})
+}
+
+type driver struct{}
+
+func (driver) Name() string             { return "linode-block-storage" }
+func (driver) K8sCSIDriverName() string { return "linodebs.csi.linode.com" }
+func (driver) Defaults() []string       { return []string{"linode"} }
+
+// HelmChart pins to v1.1.2 of linode-blockstorage-csi-driver from the
+// Linode-published Helm repo. Note: the task spec referenced the CCM
+// repo (linode-cloud-controller-manager); the actual CSI chart lives at
+// linode-blockstorage-csi-driver — see package doc for details.
+func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err error) {
+	return "https://linode.github.io/linode-blockstorage-csi-driver",
+		"linode-blockstorage-csi-driver",
+		"v1.1.2",
+		nil
+}
+
+// RenderValues emits a minimal Helm values document. The chart expects
+// a pre-existing Secret named "linode" in kube-system with a "token"
+// key (ensured by EnsureSecret before Helm install).
+func (driver) RenderValues(cfg *config.Config) (string, error) {
+	var b strings.Builder
+	b.WriteString("# Rendered by yage internal/csi/linodebs.\n")
+	b.WriteString("# Requires kube-system/linode Secret with key 'token' (see EnsureSecret).\n")
+	b.WriteString("secret:\n")
+	b.WriteString("  name: " + secretName + "\n")
+	b.WriteString("  namespace: " + secretNamespace + "\n")
+	b.WriteString("storageClasses:\n")
+	b.WriteString("  - name: linode-block-storage\n")
+	b.WriteString("    annotations:\n")
+	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
+	b.WriteString("    parameters:\n")
+	b.WriteString("      type: namedtype\n")
+	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
+	b.WriteString("    reclaimPolicy: Delete\n")
+	return b.String(), nil
+}
+
+// EnsureSecret applies the kube-system/linode Secret to the workload
+// cluster. The token comes from cfg.Cost.Credentials.LinodeToken which
+// is populated from YAGE_LINODE_TOKEN or LINODE_TOKEN. Returns an error
+// if the token is empty — unlike cloud-native identity (IRSA, Workload
+// Identity), Linode has no equivalent and the Secret is always required.
+func (driver) EnsureSecret(cfg *config.Config, workloadKubeconfigPath string) error {
+	token := cfg.Cost.Credentials.LinodeToken
+	if token == "" {
+		return fmt.Errorf("linodebs: Linode API token is empty; set YAGE_LINODE_TOKEN or LINODE_TOKEN")
+	}
+	cli, err := k8sclient.ForKubeconfigFile(workloadKubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("linodebs: load workload kubeconfig %s: %w", workloadKubeconfigPath, err)
+	}
+	sec := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretNamespace,
+			Name:      secretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{tokenKey: []byte(token)},
+	}
+	yamlBody, err := yaml.Marshal(sec)
+	if err != nil {
+		return fmt.Errorf("linodebs: marshal secret: %w", err)
+	}
+	js, err := yaml.YAMLToJSON(yamlBody)
+	if err != nil {
+		return fmt.Errorf("linodebs: yaml→json: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	force := true
+	_, err = cli.Typed.CoreV1().Secrets(secretNamespace).Patch(
+		ctx, secretName, types.ApplyPatchType, js,
+		metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: &force},
+	)
+	if err != nil {
+		return fmt.Errorf("linodebs: apply %s/%s: %w", secretNamespace, secretName, err)
+	}
+	return nil
+}
+
+func (driver) DefaultStorageClass() string { return "linode-block-storage" }
+
+func (driver) DescribeInstall(w plan.Writer, cfg *config.Config) {
+	w.Section("Linode Block Storage CSI")
+	w.Bullet("driver: %s (chart linode-blockstorage-csi-driver pinned v1.1.2)", "linodebs.csi.linode.com")
+	w.Bullet("auth: API token Secret %s/%s (key: %s)", secretNamespace, secretName, tokenKey)
+	if cfg.Cost.Credentials.LinodeToken == "" {
+		w.Bullet("note: YAGE_LINODE_TOKEN / LINODE_TOKEN is unset — EnsureSecret will fail at install time")
+	}
+	w.Bullet("default StorageClass: linode-block-storage (volumeBindingMode WaitForFirstConsumer)")
+}

--- a/internal/csi/linodebs/linodebs_test.go
+++ b/internal/csi/linodebs/linodebs_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package linodebs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+)
+
+func TestDriverConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Name", driver{}.Name(), "linode-block-storage"},
+		{"K8sCSIDriverName", driver{}.K8sCSIDriverName(), "linodebs.csi.linode.com"},
+		{"DefaultStorageClass", driver{}.DefaultStorageClass(), "linode-block-storage"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("%s() = %q, want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	d := driver{}
+	defs := d.Defaults()
+	if len(defs) != 1 || defs[0] != "linode" {
+		t.Errorf("Defaults() = %v, want [linode]", defs)
+	}
+}
+
+func TestHelmChart(t *testing.T) {
+	d := driver{}
+	repo, chart, ver, err := d.HelmChart(nil)
+	if err != nil {
+		t.Fatalf("HelmChart() unexpected error: %v", err)
+	}
+	if repo == "" {
+		t.Error("repo must not be empty")
+	}
+	if chart != "linode-blockstorage-csi-driver" {
+		t.Errorf("chart = %q, want linode-blockstorage-csi-driver", chart)
+	}
+	if ver != "v1.1.2" {
+		t.Errorf("version = %q, want v1.1.2", ver)
+	}
+}
+
+func TestRenderValues(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	out, err := d.RenderValues(cfg)
+	if err != nil {
+		t.Fatalf("RenderValues() unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "linode") {
+		t.Errorf("RenderValues output does not reference the linode secret: %s", out)
+	}
+	if !strings.Contains(out, "linode-block-storage") {
+		t.Errorf("RenderValues output missing storage class name: %s", out)
+	}
+	if !strings.Contains(out, "WaitForFirstConsumer") {
+		t.Errorf("RenderValues output missing volumeBindingMode: %s", out)
+	}
+}
+
+func TestEnsureSecretEmptyToken(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	// token is empty — must return an error
+	err := d.EnsureSecret(cfg, "/nonexistent/kubeconfig")
+	if err == nil {
+		t.Fatal("EnsureSecret with empty token should return an error")
+	}
+	if !strings.Contains(err.Error(), "YAGE_LINODE_TOKEN") && !strings.Contains(err.Error(), "LINODE_TOKEN") {
+		t.Errorf("error message should mention the env var, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/csi/linodebs` package: full `csi.Driver` implementation for the Linode Block Storage CSI driver
- Registers `linode-block-storage` as default CSI driver for the `linode` provider in `defaults.go`
- Wires the blank import in `cmd/yage/main.go`
- **Chart coordinates corrected**: the task spec referenced `linode-cloud-controller-manager` (CCM only); verified the canonical CSI chart is at `https://linode.github.io/linode-blockstorage-csi-driver`, chart `linode-blockstorage-csi-driver`, pinned to `v1.1.2` (latest stable)

Closes #87

## DoD Level 1

- [x] `make build` passes
- [x] `go test ./...` passes (including new table-driven tests: Name/K8sCSIDriverName/DefaultStorageClass, Defaults, HelmChart, RenderValues, EnsureSecret empty-token error)
- [x] Updated `TestDefaultsForOnlyImplementedProviders` and `csi_test.go` imports to include `linodebs`
- [x] `EnsureSecret` uses k8sclient server-side apply (same pattern as gcppd)
- [x] `EnsureSecret` returns a descriptive error mentioning `YAGE_LINODE_TOKEN`/`LINODE_TOKEN` when token is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)