### PR TITLE
feat(csi): implement ibm-vpc-block driver

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
+	_ "github.com/lpasquali/yage/internal/csi/ibmvpcblock"
 	_ "github.com/lpasquali/yage/internal/csi/linodebs"
 	_ "github.com/lpasquali/yage/internal/csi/longhorn"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"

--- a/internal/csi/csi_test.go
+++ b/internal/csi/csi_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/lpasquali/yage/internal/csi/doblock"
 	_ "github.com/lpasquali/yage/internal/csi/gcppd"
 	_ "github.com/lpasquali/yage/internal/csi/hcloud"
+	_ "github.com/lpasquali/yage/internal/csi/ibmvpcblock"
 	_ "github.com/lpasquali/yage/internal/csi/linodebs"
 	_ "github.com/lpasquali/yage/internal/csi/longhorn"
 	_ "github.com/lpasquali/yage/internal/csi/ociblock"
@@ -121,7 +122,7 @@ func TestSelectorNoProviderNoExplicit(t *testing.T) {
 func TestRegisteredContainsScopedDrivers(t *testing.T) {
 	got := csi.Registered()
 	sort.Strings(got)
-	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "linode-block-storage", "longhorn", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
+	for _, want := range []string{"aws-ebs", "azure-disk", "do-block-storage", "gcp-pd", "hcloud-csi", "ibm-vpc-block", "linode-block-storage", "longhorn", "oci-block-storage", "openstack-cinder", "vsphere-csi"} {
 		found := false
 		for _, n := range got {
 			if n == want {
@@ -139,15 +140,15 @@ func TestRegisteredContainsScopedDrivers(t *testing.T) {
 // non-nil only for providers we ship drivers for. Phase F scoped
 // shipped AWS/Azure/GCP; Wave 3 added Proxmox (migrated off
 // Provider.EnsureCSISecret onto the registry); issue #84 adds Hetzner;
-// issue #88 added OpenStack (openstack-cinder); Wave 4 added OCI, DigitalOcean, and Linode.
+// issue #88 added OpenStack (openstack-cinder); Wave 4 added OCI, DigitalOcean, Linode, and IBM VPC Block.
 func TestDefaultsForOnlyImplementedProviders(t *testing.T) {
-	for _, p := range []string{"aws", "azure", "digitalocean", "gcp", "hetzner", "linode", "oci", "openstack", "proxmox", "vsphere"} {
+	for _, p := range []string{"aws", "azure", "digitalocean", "gcp", "hetzner", "ibmcloud", "linode", "oci", "openstack", "proxmox", "vsphere"} {
 		if got := csi.DefaultsFor(p); len(got) == 0 {
 			t.Errorf("DefaultsFor(%q) = empty, expected at least one driver", p)
 		}
 	}
 	// Unimplemented-yet providers get nil.
-	for _, p := range []string{"ibmcloud"} {
+	for _, p := range []string{} {
 		if got := csi.DefaultsFor(p); got != nil {
 			t.Errorf("DefaultsFor(%q) = %v, expected nil (driver not yet shipped)", p, got)
 		}

--- a/internal/csi/defaults.go
+++ b/internal/csi/defaults.go
@@ -36,6 +36,8 @@ func DefaultsFor(provider string) []string {
 		return []string{"openstack-cinder"}
 	case "proxmox":
 		return []string{"proxmox-csi"}
+	case "ibmcloud":
+		return []string{"ibm-vpc-block"}
 	case "linode":
 		return []string{"linode-block-storage"}
 	case "oci":

--- a/internal/csi/ibmvpcblock/ibmvpcblock.go
+++ b/internal/csi/ibmvpcblock/ibmvpcblock.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package ibmvpcblock implements the IBM VPC Block CSI driver
+// registration for yage's CSI add-on registry (internal/csi).
+//
+// The upstream Helm chart is published at icr.io/helm/ibm-helm under
+// the name ibm-vpc-block-csi-driver. Auth is via an IBM Cloud API key
+// stored in a Kubernetes Secret (ibm-vpc-block-csi-storageclasses) in
+// kube-system — the driver reads the apiKey field at runtime to call
+// the IBM VPC API for volume operations.
+//
+// Pinned chart version 5.2.0 — a recent stable release that supports
+// IBM VPC Gen2 on Kubernetes 1.26+. Update the pin alongside a
+// helm-up run, not silently.
+package ibmvpcblock
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+const (
+	secretNamespace = "kube-system"
+	secretName      = "ibm-vpc-block-csi-storageclasses"
+	apiKeyField     = "apiKey"
+)
+
+func init() {
+	csi.Register(&driver{})
+}
+
+type driver struct{}
+
+func (driver) Name() string             { return "ibm-vpc-block" }
+func (driver) K8sCSIDriverName() string { return "vpc.block.csi.ibm.io" }
+func (driver) Defaults() []string       { return []string{"ibmcloud"} }
+
+// HelmChart pins to version 5.2.0 of ibm-vpc-block-csi-driver from
+// the IBM Container Registry Helm repository.
+func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err error) {
+	return "https://icr.io/helm/ibm-helm",
+		"ibm-vpc-block-csi-driver",
+		"5.2.0",
+		nil
+}
+
+// RenderValues emits a minimal Helm values document. The IBM VPC Block
+// CSI driver requires cluster-level configuration (cluster ID, resource
+// group) that operators typically set via the chart's own ConfigMap or
+// via Helm value overrides at install time.
+//
+// Operators must set the following in their Helm values override:
+//   - clusterInfo.clusterID: the IKS/VPC cluster ID
+//   - clusterInfo.resourceGroupID: the IBM Cloud resource group ID
+//   - image.ibmVpcBlockDriver: the driver image if using a private registry
+//
+// The IBM API key is supplied via the Secret created by EnsureSecret,
+// not through Helm values.
+func (driver) RenderValues(cfg *config.Config) (string, error) {
+	var b strings.Builder
+	b.WriteString("# Rendered by yage internal/csi/ibmvpcblock.\n")
+	b.WriteString("# Operator MUST set the following via --csi-values-file or Helm override:\n")
+	b.WriteString("#   clusterInfo.clusterID: <your VPC cluster ID>\n")
+	b.WriteString("#   clusterInfo.resourceGroupID: <your IBM Cloud resource group ID>\n")
+	b.WriteString("# To use a private registry, also set:\n")
+	b.WriteString("#   image.ibmVpcBlockDriver: <registry/ibm-vpc-block-csi-driver:tag>\n")
+	b.WriteString("# The IBM Cloud API key is supplied via the kube-system/")
+	b.WriteString(secretName + " Secret.\n")
+	return b.String(), nil
+}
+
+// EnsureSecret creates or updates the kube-system/ibm-vpc-block-csi-storageclasses
+// Secret on the workload cluster. The apiKey field is set from
+// cfg.Cost.Credentials.IBMCloudAPIKey. Returns an error if the API
+// key is empty — the driver cannot authenticate without it.
+func (driver) EnsureSecret(cfg *config.Config, workloadKubeconfigPath string) error {
+	if cfg.Cost.Credentials.IBMCloudAPIKey == "" {
+		return fmt.Errorf("ibmvpcblock: cfg.Cost.Credentials.IBMCloudAPIKey is empty; set IBMCLOUD_API_KEY or provide it via the bootstrap config Secret")
+	}
+	cli, err := k8sclient.ForKubeconfigFile(workloadKubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("ibmvpcblock: load workload kubeconfig %s: %w", workloadKubeconfigPath, err)
+	}
+	sec := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretNamespace,
+			Name:      secretName,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			apiKeyField: []byte(cfg.Cost.Credentials.IBMCloudAPIKey),
+		},
+	}
+	yamlBody, err := yaml.Marshal(sec)
+	if err != nil {
+		return fmt.Errorf("ibmvpcblock: marshal secret: %w", err)
+	}
+	js, err := yaml.YAMLToJSON(yamlBody)
+	if err != nil {
+		return fmt.Errorf("ibmvpcblock: yaml→json: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	force := true
+	_, err = cli.Typed.CoreV1().Secrets(secretNamespace).Patch(
+		ctx, secretName, types.ApplyPatchType, js,
+		metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: &force},
+	)
+	if err != nil {
+		return fmt.Errorf("ibmvpcblock: apply %s/%s: %w", secretNamespace, secretName, err)
+	}
+	return nil
+}
+
+func (driver) DefaultStorageClass() string { return "ibmc-vpc-block-10iops-tier" }
+
+func (driver) DescribeInstall(w plan.Writer, cfg *config.Config) {
+	w.Section("IBM VPC Block CSI")
+	w.Bullet("driver: %s (chart ibm-vpc-block-csi-driver pinned 5.2.0)", "vpc.block.csi.ibm.io")
+	w.Bullet("auth: IBM Cloud API key via Secret %s/%s", secretNamespace, secretName)
+	if cfg.Cost.Credentials.IBMCloudAPIKey == "" {
+		w.Bullet("note: IBMCloudAPIKey is unset — EnsureSecret will fail; set IBMCLOUD_API_KEY")
+	}
+	w.Bullet("region: %s, resource group: %s",
+		nonEmpty(cfg.Providers.IBMCloud.Region, "<unset>"),
+		nonEmpty(cfg.Providers.IBMCloud.ResourceGroup, "<unset>"))
+	w.Bullet("default StorageClass: ibmc-vpc-block-10iops-tier")
+	w.Bullet("note: operator must supply clusterInfo.clusterID and clusterInfo.resourceGroupID via Helm values override")
+}
+
+// nonEmpty returns a if non-empty, otherwise fallback.
+func nonEmpty(a, fallback string) string {
+	if a != "" {
+		return a
+	}
+	return fallback
+}

--- a/internal/csi/ibmvpcblock/ibmvpcblock_test.go
+++ b/internal/csi/ibmvpcblock/ibmvpcblock_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package ibmvpcblock
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+)
+
+func TestDriverConstants(t *testing.T) {
+	d := driver{}
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Name", d.Name(), "ibm-vpc-block"},
+		{"K8sCSIDriverName", d.K8sCSIDriverName(), "vpc.block.csi.ibm.io"},
+		{"DefaultStorageClass", d.DefaultStorageClass(), "ibmc-vpc-block-10iops-tier"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+	defs := d.Defaults()
+	if len(defs) != 1 || defs[0] != "ibmcloud" {
+		t.Errorf("Defaults() = %v, want [ibmcloud]", defs)
+	}
+}
+
+func TestHelmChart(t *testing.T) {
+	d := driver{}
+	repo, chart, ver, err := d.HelmChart(nil)
+	if err != nil {
+		t.Fatalf("HelmChart() unexpected err: %v", err)
+	}
+	if chart != "ibm-vpc-block-csi-driver" {
+		t.Errorf("chart = %q, want ibm-vpc-block-csi-driver", chart)
+	}
+	if ver != "5.2.0" {
+		t.Errorf("version = %q, want 5.2.0", ver)
+	}
+	if repo == "" {
+		t.Errorf("repo must not be empty")
+	}
+	if !strings.Contains(repo, "icr.io") {
+		t.Errorf("repo %q should reference icr.io", repo)
+	}
+}
+
+func TestRenderValues(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	out, err := d.RenderValues(cfg)
+	if err != nil {
+		t.Fatalf("RenderValues() unexpected err: %v", err)
+	}
+	if !strings.Contains(out, "clusterInfo.clusterID") {
+		t.Errorf("RenderValues missing clusterInfo.clusterID operator note: %s", out)
+	}
+	if !strings.Contains(out, secretName) {
+		t.Errorf("RenderValues missing Secret name %q: %s", secretName, out)
+	}
+}
+
+func TestEnsureSecretEmptyAPIKey(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	// IBMCloudAPIKey is zero-value (empty)
+	err := d.EnsureSecret(cfg, "/nonexistent/kubeconfig")
+	if err == nil {
+		t.Fatal("EnsureSecret should return an error when IBMCloudAPIKey is empty")
+	}
+	if !strings.Contains(err.Error(), "IBMCloudAPIKey") {
+		t.Errorf("error message should mention IBMCloudAPIKey, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/csi/ibmvpcblock` package implementing the IBM VPC Block CSI driver for yage's CSI registry
- Driver name: `ibm-vpc-block`, K8s CSI driver name: `vpc.block.csi.ibm.io`, chart pinned at `5.2.0` from `icr.io/helm/ibm-helm`
- `EnsureSecret` pushes `kube-system/ibm-vpc-block-csi-storageclasses` (key: `apiKey`) via server-side apply, returning an error when `IBMCloudAPIKey` is empty
- Wires `ibmcloud` into `defaults.go` and adds blank import in `cmd/yage/main.go`
- Updates `internal/csi/csi_test.go` to reflect ibmcloud is now a shipped driver

Closes #90

## Test plan

- [x] `make build` — compiles cleanly
- [x] `go test ./...` — all tests pass including new `ibmvpcblock` package tests
- [x] `TestDriverConstants` — Name/K8sCSIDriverName/DefaultStorageClass verified
- [x] `TestHelmChart` — repo/chart/version asserted
- [x] `TestRenderValues` — operator notes present in output
- [x] `TestEnsureSecretEmptyAPIKey` — returns error with `IBMCloudAPIKey` in message
- [x] `TestDefaultsForOnlyImplementedProviders` — ibmcloud now passes the "implemented" assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)