### PR TITLE
fix(manifest): avoid E2BIG when clusterctl env inherits large parent vars

### DIFF
--- a/internal/capi/manifest/generate.go
+++ b/internal/capi/manifest/generate.go
@@ -372,7 +372,7 @@ func GenerateWorkloadManifestIfMissing(
 			"--infrastructure", cfg.InfraProvider,
 		}
 		cmd = exec.Command("clusterctl", args...)
-		cmd.Env = append(os.Environ(),
+		cmd.Env = BuildEnv(
 			"PROXMOX_URL="+cfg.Providers.Proxmox.URL,
 			"PROXMOX_REGION="+cfg.Providers.Proxmox.Region,
 			"PROXMOX_NODE="+cfg.Providers.Proxmox.Node,
@@ -421,7 +421,7 @@ func GenerateWorkloadManifestIfMissing(
 		if nodeType == "" {
 			nodeType = "t3.medium"
 		}
-		cmd.Env = append(os.Environ(),
+		cmd.Env = BuildEnv(
 			"AWS_REGION="+region,
 			"AWS_CONTROL_PLANE_MACHINE_TYPE="+cpType,
 			"AWS_NODE_MACHINE_TYPE="+nodeType,
@@ -590,6 +590,31 @@ func EnsureWorkloadClusterLabel(cfg *config.Config, manifestPath, clusterName st
 }
 
 // --- helpers ---
+
+// BuildEnv returns os.Environ() with any keys present in overrides
+// removed, then appends overrides. This prevents duplicate env
+// entries — and avoids E2BIG ("argument list too long") — when a
+// var we are about to set (e.g. VM_SSH_KEYS) is already present and
+// possibly large in the parent-process environment.
+func BuildEnv(overrides ...string) []string {
+	block := make(map[string]struct{}, len(overrides))
+	for _, kv := range overrides {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			block[kv[:i]] = struct{}{}
+		}
+	}
+	base := os.Environ()
+	out := make([]string, 0, len(base)+len(overrides))
+	for _, kv := range base {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			if _, dup := block[kv[:i]]; dup {
+				continue
+			}
+		}
+		out = append(out, kv)
+	}
+	return append(out, overrides...)
+}
 
 func fileExists(p string) bool {
 	_, err := os.Stat(p)

--- a/internal/provider/proxmox/mgmt_manifest.go
+++ b/internal/provider/proxmox/mgmt_manifest.go
@@ -103,7 +103,7 @@ func (p *Provider) RenderMgmtManifest(cfg *config.Config, clusterctlCfgPath stri
 		"--infrastructure", cfg.InfraProvider,
 	}
 	cmd := exec.Command("clusterctl", args...)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = capimanifest.BuildEnv(
 		"PROXMOX_URL="+cfg.Providers.Proxmox.URL,
 		"PROXMOX_REGION="+cfg.Providers.Proxmox.Region,
 		"PROXMOX_NODE="+cfg.Providers.Proxmox.Node,


### PR DESCRIPTION
## Summary

- `append(os.Environ(), overrides...)` in the clusterctl generate paths caused `fork/exec /usr/local/bin/clusterctl: argument list too long` when the parent yage process carried large inherited env vars (e.g. `VM_SSH_KEYS` loaded from `~/.ssh/authorized_keys`) that were also being set as overrides — counting them twice toward the Linux `ARG_MAX` (2 MB) limit.
- Add `BuildEnv(...overrides)` in `internal/capi/manifest` that filters out from `os.Environ()` any key present in the overrides before appending — deduplicating and preventing the double-count.
- Applied to all three clusterctl call sites: Proxmox + AWS paths in `generate.go`, and `RenderMgmtManifest` in `mgmt_manifest.go`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/capi/manifest/... ./internal/provider/proxmox/...` passes
- [ ] Deploy with a large `~/.ssh/authorized_keys` (10+ keys) and confirm `clusterctl generate cluster` no longer exits with `argument list too long`

Fixes: `pivot: EnsureManagementCluster: render mgmt manifest: clusterctl generate cluster (mgmt) failed: fork/exec /usr/local/bin/clusterctl: argument list too long`

🤖 Generated with [Claude Code](https://claude.com/claude-code)