### PR TITLE
feat(vsphere): PatchManifest — honor VSphereMachineTemplate sizing fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,23 @@ type VsphereConfig struct {
 	// can round-trip.
 	Username string
 	Password string
+
+	// ---- Per-role VSphereMachineTemplate sizing ----
+	//
+	// These map onto the inline sizing fields in VSphereMachineTemplate
+	// spec.template.spec: numCPUs, numCoresPerSocket, memoryMiB, diskGiB.
+	// PatchManifest rewrites them post-render so the operator can override
+	// defaults without editing the manifest by hand.
+	// Env vars follow the VSPHERE_* namespace to stay consistent with the
+	// rest of VsphereConfig.
+	ControlPlaneNumCPUs          string // VSPHERE_CONTROL_PLANE_NUM_CPUS (e.g. "2")
+	ControlPlaneNumCoresPerSocket string // VSPHERE_CONTROL_PLANE_NUM_CORES_PER_SOCKET (e.g. "1")
+	ControlPlaneMemoryMiB        string // VSPHERE_CONTROL_PLANE_MEMORY_MIB (e.g. "4096")
+	ControlPlaneDiskGiB          string // VSPHERE_CONTROL_PLANE_DISK_GIB (e.g. "25")
+	WorkerNumCPUs                string // VSPHERE_WORKER_NUM_CPUS (e.g. "2")
+	WorkerNumCoresPerSocket      string // VSPHERE_WORKER_NUM_CORES_PER_SOCKET (e.g. "1")
+	WorkerMemoryMiB              string // VSPHERE_WORKER_MEMORY_MIB (e.g. "4096")
+	WorkerDiskGiB                string // VSPHERE_WORKER_DISK_GIB (e.g. "25")
 }
 
 // AzureConfig is the per-provider Azure (CAPZ) configuration.
@@ -1315,6 +1332,20 @@ func Load() *Config {
 	c.Providers.Vsphere.TLSThumbprint = getenv("VSPHERE_TLS_THUMBPRINT", "")
 	c.Providers.Vsphere.Username = getenv("VSPHERE_USERNAME", "")
 	c.Providers.Vsphere.Password = getenv("VSPHERE_PASSWORD", "")
+	// VSphereMachineTemplate sizing — PatchManifest writes these into
+	// numCPUs / numCoresPerSocket / memoryMiB / diskGiB post-render.
+	// Defaults mirror the literals in the K3s template (25 GiB disk,
+	// 1 core-per-socket; CPU and memory left empty so the template
+	// placeholder substitution takes effect when the operator has not
+	// set the VSPHERE_* override).
+	c.Providers.Vsphere.ControlPlaneNumCPUs = getenv("VSPHERE_CONTROL_PLANE_NUM_CPUS", "")
+	c.Providers.Vsphere.ControlPlaneNumCoresPerSocket = getenv("VSPHERE_CONTROL_PLANE_NUM_CORES_PER_SOCKET", "")
+	c.Providers.Vsphere.ControlPlaneMemoryMiB = getenv("VSPHERE_CONTROL_PLANE_MEMORY_MIB", "")
+	c.Providers.Vsphere.ControlPlaneDiskGiB = getenv("VSPHERE_CONTROL_PLANE_DISK_GIB", "")
+	c.Providers.Vsphere.WorkerNumCPUs = getenv("VSPHERE_WORKER_NUM_CPUS", "")
+	c.Providers.Vsphere.WorkerNumCoresPerSocket = getenv("VSPHERE_WORKER_NUM_CORES_PER_SOCKET", "")
+	c.Providers.Vsphere.WorkerMemoryMiB = getenv("VSPHERE_WORKER_MEMORY_MIB", "")
+	c.Providers.Vsphere.WorkerDiskGiB = getenv("VSPHERE_WORKER_DISK_GIB", "")
 	c.Providers.Hetzner.ControlPlaneMachineType = getenv("HCLOUD_CONTROL_PLANE_MACHINE_TYPE", "cx23")
 	c.Providers.Hetzner.NodeMachineType = getenv("HCLOUD_NODE_MACHINE_TYPE", "cx23")
 	c.Providers.Hetzner.Location = getenv("HCLOUD_REGION", "fsn1")

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -160,6 +160,15 @@ func (c *Config) Snapshot() []SnapshotField {
 		sp("WORKER_NUM_SOCKETS", &c.Providers.Proxmox.WorkerNumSockets),
 		sp("WORKER_NUM_CORES", &c.Providers.Proxmox.WorkerNumCores),
 		sp("WORKER_MEMORY_MIB", &c.Providers.Proxmox.WorkerMemoryMiB),
+		// --- vSphere VSphereMachineTemplate sizing ---
+		sp("VSPHERE_CONTROL_PLANE_NUM_CPUS", &c.Providers.Vsphere.ControlPlaneNumCPUs),
+		sp("VSPHERE_CONTROL_PLANE_NUM_CORES_PER_SOCKET", &c.Providers.Vsphere.ControlPlaneNumCoresPerSocket),
+		sp("VSPHERE_CONTROL_PLANE_MEMORY_MIB", &c.Providers.Vsphere.ControlPlaneMemoryMiB),
+		sp("VSPHERE_CONTROL_PLANE_DISK_GIB", &c.Providers.Vsphere.ControlPlaneDiskGiB),
+		sp("VSPHERE_WORKER_NUM_CPUS", &c.Providers.Vsphere.WorkerNumCPUs),
+		sp("VSPHERE_WORKER_NUM_CORES_PER_SOCKET", &c.Providers.Vsphere.WorkerNumCoresPerSocket),
+		sp("VSPHERE_WORKER_MEMORY_MIB", &c.Providers.Vsphere.WorkerMemoryMiB),
+		sp("VSPHERE_WORKER_DISK_GIB", &c.Providers.Vsphere.WorkerDiskGiB),
 		// --- Workload cluster (EXPLICIT-guarded for NAME/NAMESPACE) ---
 		spEx("YAGE_CONFIG_NAME", "YAGE_CONFIG_NAME_EXPLICIT", &c.ConfigName),
 		spEx("WORKLOAD_CLUSTER_NAME", "WORKLOAD_CLUSTER_NAME_EXPLICIT", &c.WorkloadClusterName),

--- a/internal/provider/vsphere/vsphere.go
+++ b/internal/provider/vsphere/vsphere.go
@@ -21,14 +21,16 @@
 // (apiVersion infrastructure.cluster.x-k8s.io/v1beta1 — CAPV is one
 // version behind the v1beta2 the rest of CAPI is on). The
 // MachineTemplate spec carries inline sizing fields (numCPUs,
-// numCoresPerSocket, memoryMiB, diskGiB) that map cleanly onto
-// yage's CONTROL_PLANE_* / WORKER_* config knobs — the
-// template wires the placeholders today and a future PatchManifest
-// can rewrite them post-render if richer per-role overrides are
-// needed.
+// numCoresPerSocket, memoryMiB, diskGiB) that map to
+// cfg.Providers.Vsphere.*NumCPUs / *MemoryMiB / *DiskGiB. PatchManifest
+// rewrites them post-render when the corresponding config fields are set.
 package vsphere
 
 import (
+	"os"
+	"regexp"
+	"strings"
+
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/provider"
 )
@@ -230,17 +232,108 @@ func (p *Provider) K3sTemplate(cfg *config.Config, mgmt bool) (string, error) {
 	return k3sTemplate, nil
 }
 
-// PatchManifest is a no-op for vSphere today: the K3s template above
-// already wires CONTROL_PLANE_NUM_CORES / CONTROL_PLANE_MEMORY_MIB /
-// WORKER_NUM_CORES / WORKER_MEMORY_MIB into the right VSphereMachine-
-// Template fields, so the renderer covers per-role sizing on its own.
+// PatchManifest rewrites the VSphereMachineTemplate sizing fields
+// (numCPUs, numCoresPerSocket, memoryMiB, diskGiB) in the rendered
+// manifest at manifestPath.
 //
-// TODO: VSphereMachineTemplate has its own sizing field set
-// (`spec.template.spec.numCPUs`, `numCoresPerSocket`, `memoryMiB`,
-// `diskGiB`) that a future patch could honor based on the existing
-// CONTROL_PLANE_* / WORKER_* config fields.
+// Role detection: a template whose metadata.name contains "control-plane"
+// receives CP sizing; all other VSphereMachineTemplate documents receive
+// worker sizing. This matches the naming convention in K3sTemplate:
+// "${CLUSTER_NAME}-control-plane" and "${CLUSTER_NAME}-md-0".
+//
+// Only non-empty cfg.Providers.Vsphere.* fields are patched; an empty
+// value means "leave whatever the template rendered". mgmt=true is a
+// no-op (the vSphere path does not pivot to a vSphere mgmt cluster today).
 func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt bool) error {
-	return nil
+	if mgmt {
+		return nil
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	text := string(raw)
+	vs := cfg.Providers.Vsphere
+
+	type sizing struct {
+		numCPUs          string
+		numCoresPerSocket string
+		memoryMiB        string
+		diskGiB          string
+	}
+	cp := sizing{vs.ControlPlaneNumCPUs, vs.ControlPlaneNumCoresPerSocket, vs.ControlPlaneMemoryMiB, vs.ControlPlaneDiskGiB}
+	wk := sizing{vs.WorkerNumCPUs, vs.WorkerNumCoresPerSocket, vs.WorkerMemoryMiB, vs.WorkerDiskGiB}
+
+	// Nothing to patch if all fields are empty.
+	if cp == (sizing{}) && wk == (sizing{}) {
+		return nil
+	}
+
+	// Line-anchored regex to identify VSphereMachineTemplate documents.
+	// Never use strings.Contains: infrastructureRef blocks embed the same
+	// kind string nested inside other documents.
+	vmtKindRE := regexp.MustCompile(`(?m)^kind:\s*VSphereMachineTemplate\s*$`)
+	nameRE := regexp.MustCompile(`(?m)^  name:\s*(\S+)\s*$`)
+
+	parts := strings.Split(text, "\n---\n")
+	for i, doc := range parts {
+		if !vmtKindRE.MatchString(doc) {
+			continue
+		}
+		// Determine role from metadata.name.
+		m := nameRE.FindStringSubmatch(doc)
+		if m == nil {
+			continue
+		}
+		var sz sizing
+		if strings.Contains(m[1], "control-plane") {
+			sz = cp
+		} else {
+			sz = wk
+		}
+		if sz == (sizing{}) {
+			continue
+		}
+		if sz.numCPUs != "" {
+			doc = replaceFirstField(doc, "numCPUs", sz.numCPUs)
+		}
+		if sz.numCoresPerSocket != "" {
+			doc = replaceFirstField(doc, "numCoresPerSocket", sz.numCoresPerSocket)
+		}
+		if sz.memoryMiB != "" {
+			doc = replaceFirstField(doc, "memoryMiB", sz.memoryMiB)
+		}
+		if sz.diskGiB != "" {
+			doc = replaceFirstField(doc, "diskGiB", sz.diskGiB)
+		}
+		parts[i] = doc
+	}
+
+	out := strings.Join(parts, "\n---\n")
+	if out == text {
+		return nil
+	}
+	return os.WriteFile(manifestPath, []byte(out), 0o644)
+}
+
+// replaceFirstField replaces the value of a YAML scalar field within a
+// single document. Matches `<key>: <anything>` at any indentation and
+// replaces only the first occurrence (there is exactly one of each
+// sizing field per VSphereMachineTemplate document).
+func replaceFirstField(doc, key, value string) string {
+	re := regexp.MustCompile(`(?m)^([ \t]*` + regexp.QuoteMeta(key) + `:\s*)(\S+)`)
+	replaced := false
+	return re.ReplaceAllStringFunc(doc, func(match string) string {
+		if replaced {
+			return match
+		}
+		replaced = true
+		sub := re.FindStringSubmatch(match)
+		if sub == nil {
+			return match
+		}
+		return sub[1] + value
+	})
 }
 
 // EstimateMonthlyCostUSD — vSphere is self-hosted; vendor licensing

--- a/internal/provider/vsphere/vsphere_patchmanifest_test.go
+++ b/internal/provider/vsphere/vsphere_patchmanifest_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package vsphere
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+)
+
+// minimalManifest is a trimmed-down multi-document YAML that mirrors the
+// structure of k3sTemplate: one Cluster, one VSphereCluster, two
+// VSphereMachineTemplate (control-plane + worker), one KThreesControlPlane,
+// one MachineDeployment, one KThreesConfigTemplate.
+//
+// The VSphereMachineTemplate docs use the same field ordering as the real
+// template (diskGiB / memoryMiB / numCPUs / numCoresPerSocket).
+const minimalManifest = `apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: test-cluster
+  namespace: default
+spec:
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: VSphereCluster
+    name: test-cluster
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  name: test-cluster
+  namespace: default
+spec:
+  server: vcenter.example.com
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-cluster-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      diskGiB: 25
+      memoryMiB: 4096
+      numCPUs: 2
+      numCoresPerSocket: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KThreesControlPlane
+metadata:
+  name: test-cluster-control-plane
+  namespace: default
+spec:
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: test-cluster-control-plane
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: test-cluster-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: test-cluster-md-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-cluster-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      diskGiB: 25
+      memoryMiB: 4096
+      numCPUs: 2
+      numCoresPerSocket: 1
+---
+apiVersion: orchestrator.cluster.x-k8s.io/v1beta2
+kind: KThreesConfigTemplate
+metadata:
+  name: test-cluster-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      agentConfig: {}
+`
+
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "manifest-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func readManifest(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return string(raw)
+}
+
+// TestPatchManifest_NoopWhenFieldsEmpty verifies that PatchManifest is a
+// no-op when no sizing fields are set on cfg.
+func TestPatchManifest_NoopWhenFieldsEmpty(t *testing.T) {
+	path := writeManifest(t, minimalManifest)
+	cfg := &config.Config{}
+	p := &Provider{}
+	if err := p.PatchManifest(cfg, path, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := readManifest(t, path)
+	if got != minimalManifest {
+		t.Errorf("manifest was modified when all sizing fields are empty")
+	}
+}
+
+// TestPatchManifest_NoopForMgmt verifies that mgmt=true is always a no-op.
+func TestPatchManifest_NoopForMgmt(t *testing.T) {
+	path := writeManifest(t, minimalManifest)
+	cfg := &config.Config{}
+	cfg.Providers.Vsphere.ControlPlaneNumCPUs = "8"
+	cfg.Providers.Vsphere.WorkerNumCPUs = "4"
+	p := &Provider{}
+	if err := p.PatchManifest(cfg, path, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := readManifest(t, path)
+	if got != minimalManifest {
+		t.Errorf("manifest was modified for mgmt=true")
+	}
+}
+
+// TestPatchManifest_ControlPlaneAndWorkerSizing verifies that the correct
+// sizing fields are written into each VSphereMachineTemplate document and
+// that unrelated documents are untouched.
+func TestPatchManifest_ControlPlaneAndWorkerSizing(t *testing.T) {
+	path := writeManifest(t, minimalManifest)
+	cfg := &config.Config{}
+	cfg.Providers.Vsphere.ControlPlaneNumCPUs = "4"
+	cfg.Providers.Vsphere.ControlPlaneNumCoresPerSocket = "2"
+	cfg.Providers.Vsphere.ControlPlaneMemoryMiB = "8192"
+	cfg.Providers.Vsphere.ControlPlaneDiskGiB = "50"
+	cfg.Providers.Vsphere.WorkerNumCPUs = "2"
+	cfg.Providers.Vsphere.WorkerNumCoresPerSocket = "1"
+	cfg.Providers.Vsphere.WorkerMemoryMiB = "4096"
+	cfg.Providers.Vsphere.WorkerDiskGiB = "30"
+
+	p := &Provider{}
+	if err := p.PatchManifest(cfg, path, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := readManifest(t, path)
+	docs := strings.Split(got, "\n---\n")
+
+	// Use line-anchored matching (same rule as PatchManifest itself):
+	// the KThreesControlPlane doc contains `kind: VSphereMachineTemplate`
+	// inside its infrastructureRef — a plain Contains would match it.
+	vmtKindLine := regexp.MustCompile(`(?m)^kind:\s*VSphereMachineTemplate\s*$`)
+	var cpDoc, wkDoc string
+	for _, d := range docs {
+		if !vmtKindLine.MatchString(d) {
+			continue
+		}
+		if strings.Contains(d, "name: test-cluster-control-plane") {
+			cpDoc = d
+		} else if strings.Contains(d, "name: test-cluster-md-0") {
+			wkDoc = d
+		}
+	}
+
+	// Control-plane assertions.
+	for _, want := range []string{
+		"numCPUs: 4",
+		"numCoresPerSocket: 2",
+		"memoryMiB: 8192",
+		"diskGiB: 50",
+	} {
+		if !strings.Contains(cpDoc, want) {
+			t.Errorf("control-plane doc missing %q\ndoc:\n%s", want, cpDoc)
+		}
+	}
+	// Worker assertions.
+	for _, want := range []string{
+		"numCPUs: 2",
+		"numCoresPerSocket: 1",
+		"memoryMiB: 4096",
+		"diskGiB: 30",
+	} {
+		if !strings.Contains(wkDoc, want) {
+			t.Errorf("worker doc missing %q\ndoc:\n%s", want, wkDoc)
+		}
+	}
+
+	// Documents that are not VSphereMachineTemplate must be identical to
+	// the originals (verifies the line-anchored kind check).
+	origDocs := strings.Split(minimalManifest, "\n---\n")
+	for i, orig := range origDocs {
+		if vmtKindLine.MatchString(orig) {
+			continue
+		}
+		if docs[i] != orig {
+			t.Errorf("non-VMT document %d was modified:\noriginal:\n%s\ngot:\n%s", i, orig, docs[i])
+		}
+	}
+}
+
+// TestPatchManifest_PartialFields verifies that only explicitly set fields
+// are rewritten; unset fields keep the original value.
+func TestPatchManifest_PartialFields(t *testing.T) {
+	path := writeManifest(t, minimalManifest)
+	cfg := &config.Config{}
+	// Only set memory for control-plane; leave CPU/disk/worker untouched.
+	cfg.Providers.Vsphere.ControlPlaneMemoryMiB = "16384"
+
+	p := &Provider{}
+	if err := p.PatchManifest(cfg, path, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := readManifest(t, path)
+	docs := strings.Split(got, "\n---\n")
+
+	vmtKindLine := regexp.MustCompile(`(?m)^kind:\s*VSphereMachineTemplate\s*$`)
+	var cpDoc string
+	for _, d := range docs {
+		if vmtKindLine.MatchString(d) && strings.Contains(d, "name: test-cluster-control-plane") {
+			cpDoc = d
+		}
+	}
+	if !strings.Contains(cpDoc, "memoryMiB: 16384") {
+		t.Errorf("control-plane doc missing patched memoryMiB: 16384\ndoc:\n%s", cpDoc)
+	}
+	// Other fields must remain at their original values.
+	if !strings.Contains(cpDoc, "numCPUs: 2") {
+		t.Errorf("control-plane numCPUs should be unchanged (2)\ndoc:\n%s", cpDoc)
+	}
+	if !strings.Contains(cpDoc, "diskGiB: 25") {
+		t.Errorf("control-plane diskGiB should be unchanged (25)\ndoc:\n%s", cpDoc)
+	}
+
+	// Worker doc must be identical to original.
+	origDocs := strings.Split(minimalManifest, "\n---\n")
+	for i, orig := range origDocs {
+		if vmtKindLine.MatchString(orig) && strings.Contains(orig, "name: test-cluster-md-0") {
+			if docs[i] != orig {
+				t.Errorf("worker VMT doc was modified when no worker fields were set:\noriginal:\n%s\ngot:\n%s", orig, docs[i])
+			}
+		}
+	}
+}

--- a/internal/ui/cli/help/vsphere.txt
+++ b/internal/ui/cli/help/vsphere.txt
@@ -13,6 +13,30 @@ vsphere — vSphere / vCenter / CAPV flags
     --vsphere-username USER       vCenter username. Env: VSPHERE_USERNAME.
     --vsphere-password PASS       vCenter password. Env: VSPHERE_PASSWORD.
 
+VSphereMachineTemplate sizing
+    These are written into numCPUs / numCoresPerSocket / memoryMiB / diskGiB in
+    every VSphereMachineTemplate by PatchManifest after clusterctl renders the
+    manifest. Fields left empty are not patched (the template placeholder value
+    is kept).
+
+    --vsphere-control-plane-num-cpus N
+        Number of vCPUs for control-plane VMs. Env: VSPHERE_CONTROL_PLANE_NUM_CPUS.
+    --vsphere-control-plane-num-cores-per-socket N
+        Cores per socket for control-plane VMs.
+        Env: VSPHERE_CONTROL_PLANE_NUM_CORES_PER_SOCKET.
+    --vsphere-control-plane-memory-mib N
+        Memory in MiB for control-plane VMs. Env: VSPHERE_CONTROL_PLANE_MEMORY_MIB.
+    --vsphere-control-plane-disk-gib N
+        Boot disk size in GiB for control-plane VMs. Env: VSPHERE_CONTROL_PLANE_DISK_GIB.
+    --vsphere-worker-num-cpus N
+        Number of vCPUs for worker VMs. Env: VSPHERE_WORKER_NUM_CPUS.
+    --vsphere-worker-num-cores-per-socket N
+        Cores per socket for worker VMs. Env: VSPHERE_WORKER_NUM_CORES_PER_SOCKET.
+    --vsphere-worker-memory-mib N
+        Memory in MiB for worker VMs. Env: VSPHERE_WORKER_MEMORY_MIB.
+    --vsphere-worker-disk-gib N
+        Boot disk size in GiB for worker VMs. Env: VSPHERE_WORKER_DISK_GIB.
+
 Cost model
     vSphere is on-prem, so the cost estimator uses the same TCO knobs as Proxmox:
         --hardware-cost-usd N           Capex; required to enable on-prem cost

--- a/internal/ui/cli/parse.go
+++ b/internal/ui/cli/parse.go
@@ -594,6 +594,22 @@ func Parse(c *config.Config, argv []string) {
 			c.Providers.Vsphere.Username = shiftVal(a)
 		case "--vsphere-password":
 			c.Providers.Vsphere.Password = shiftVal(a)
+		case "--vsphere-control-plane-num-cpus":
+			c.Providers.Vsphere.ControlPlaneNumCPUs = shiftVal(a)
+		case "--vsphere-control-plane-num-cores-per-socket":
+			c.Providers.Vsphere.ControlPlaneNumCoresPerSocket = shiftVal(a)
+		case "--vsphere-control-plane-memory-mib":
+			c.Providers.Vsphere.ControlPlaneMemoryMiB = shiftVal(a)
+		case "--vsphere-control-plane-disk-gib":
+			c.Providers.Vsphere.ControlPlaneDiskGiB = shiftVal(a)
+		case "--vsphere-worker-num-cpus":
+			c.Providers.Vsphere.WorkerNumCPUs = shiftVal(a)
+		case "--vsphere-worker-num-cores-per-socket":
+			c.Providers.Vsphere.WorkerNumCoresPerSocket = shiftVal(a)
+		case "--vsphere-worker-memory-mib":
+			c.Providers.Vsphere.WorkerMemoryMiB = shiftVal(a)
+		case "--vsphere-worker-disk-gib":
+			c.Providers.Vsphere.WorkerDiskGiB = shiftVal(a)
 		case "--hetzner-control-plane-machine-type":
 			c.Providers.Hetzner.ControlPlaneMachineType = shiftVal(a)
 		case "--hetzner-node-machine-type":


### PR DESCRIPTION
## Summary

- Implement `PatchManifest` on the vSphere provider to rewrite `numCPUs`, `numCoresPerSocket`, `memoryMiB`, and `diskGiB` in every `VSphereMachineTemplate` document post-render, using per-role values from `cfg.Providers.Vsphere`.
- Add 8 new sizing fields to `VsphereConfig` with env vars (`VSPHERE_CONTROL_PLANE_NUM_CPUS`, `VSPHERE_CONTROL_PLANE_NUM_CORES_PER_SOCKET`, `VSPHERE_CONTROL_PLANE_MEMORY_MIB`, `VSPHERE_CONTROL_PLANE_DISK_GIB` + worker counterparts), env loading, snapshot round-trip, CLI flags (`--vsphere-control-plane-*` / `--vsphere-worker-*`), and help text.
- Role detection: `metadata.name` contains `"control-plane"` → CP sizing; otherwise → worker sizing. Line-anchored regex (`^kind:\s*VSphereMachineTemplate\s*$`) guards against false-positives on nested `infrastructureRef` blocks.

**Note on snapshot entries:** This PR is the first to add non-Proxmox provider fields to `snapshot.go`. The 8 new vSphere sizing fields are included so they survive kindsync round-trips; this sets a precedent for future providers.

## New env vars / flags

| Env var | CLI flag |
|---------|----------|
| `VSPHERE_CONTROL_PLANE_NUM_CPUS` | `--vsphere-control-plane-num-cpus` |
| `VSPHERE_CONTROL_PLANE_NUM_CORES_PER_SOCKET` | `--vsphere-control-plane-num-cores-per-socket` |
| `VSPHERE_CONTROL_PLANE_MEMORY_MIB` | `--vsphere-control-plane-memory-mib` |
| `VSPHERE_CONTROL_PLANE_DISK_GIB` | `--vsphere-control-plane-disk-gib` |
| `VSPHERE_WORKER_NUM_CPUS` | `--vsphere-worker-num-cpus` |
| `VSPHERE_WORKER_NUM_CORES_PER_SOCKET` | `--vsphere-worker-num-cores-per-socket` |
| `VSPHERE_WORKER_MEMORY_MIB` | `--vsphere-worker-memory-mib` |
| `VSPHERE_WORKER_DISK_GIB` | `--vsphere-worker-disk-gib` |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/provider/vsphere/...` — 4 new tests pass (noop-empty, noop-mgmt, full sizing CP+worker, partial fields)
- [x] `go test ./internal/config/...` — snapshot round-trip passes
- [x] `go test ./...` — full suite passes

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)