### PR TITLE
feat(config): add Phase H YAGE_REGISTRY_* and YAGE_ISSUING_CA_* config fields (#124)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1126,6 +1126,52 @@ type Config struct {
 	// NoopTracer. Set via --trace-endpoint or YAGE_TRACE_ENDPOINT.
 	TraceEndpoint string
 
+	// TofuRef is the git ref (branch, tag, or SHA) of the lpasquali/yage-tofu
+	// repository that Fetcher clones/updates. Defaults to "main".
+	// Env: YAGE_TOFU_REF.
+	// NOTE: issue #124 adds this field to config.go on a parallel branch.
+	// When that PR merges before this one, rebase and remove this addition.
+	TofuRef string
+
+	// --- On-prem platform services (Phase H, ADR 0009) ---
+
+	// RegistryNode is the Proxmox node on which to provision the bootstrap
+	// registry VM. Empty means registry provisioning is skipped.
+	// Env: YAGE_REGISTRY_NODE.
+	RegistryNode string
+
+	// RegistryVMFlavor is the Proxmox VM flavor (template) to use for the
+	// registry VM. Empty means use the provider default.
+	// Env: YAGE_REGISTRY_VM_FLAVOR.
+	RegistryVMFlavor string
+
+	// RegistryNetwork is the Proxmox network bridge for the registry VM.
+	// Env: YAGE_REGISTRY_NETWORK.
+	RegistryNetwork string
+
+	// RegistryStorage is the Proxmox storage pool for the registry VM's
+	// volumes. Env: YAGE_REGISTRY_STORAGE.
+	RegistryStorage string
+
+	// RegistryFlavor is the registry software to deploy (e.g. "harbor").
+	// Defaults to "harbor". Env: YAGE_REGISTRY_FLAVOR.
+	RegistryFlavor string
+
+	// IssuingCARootCert is the PEM-encoded root CA certificate for signing
+	// the intermediate issuing CA. Not persisted to kind Secrets. Empty
+	// means issuing CA provisioning is skipped.
+	// Env: YAGE_ISSUING_CA_ROOT_CERT.
+	IssuingCARootCert string
+
+	// IssuingCARootKey is the PEM-encoded root CA private key. Not persisted
+	// to kind Secrets.
+	// Env: YAGE_ISSUING_CA_ROOT_KEY.
+	IssuingCARootKey string
+
+	// TofuRef is the Git ref of the lpasquali/yage-tofu repo to use.
+	// Defaults to main. Env: YAGE_TOFU_REF.
+	TofuRef string
+
 }
 
 // Load reads environment variables and applies defaults to produce a
@@ -1208,6 +1254,19 @@ func Load() *Config {
 	c.HelmRepoMirror = strings.TrimRight(strings.TrimSpace(getenv("YAGE_HELM_REPO_MIRROR", "")), "/")
 	c.NodeImage = strings.TrimSpace(getenv("YAGE_NODE_IMAGE", ""))
 	c.TraceEndpoint = getenv("YAGE_TRACE_ENDPOINT", "")
+	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
+
+	// --- On-prem platform services (Phase H, ADR 0009) ---
+	c.RegistryNode = getenv("YAGE_REGISTRY_NODE", "")
+	c.RegistryVMFlavor = getenv("YAGE_REGISTRY_VM_FLAVOR", "")
+	c.RegistryNetwork = getenv("YAGE_REGISTRY_NETWORK", "")
+	c.RegistryStorage = getenv("YAGE_REGISTRY_STORAGE", "")
+	c.RegistryFlavor = getenv("YAGE_REGISTRY_FLAVOR", "harbor")
+	// Root CA material is read from env but never persisted to kind Secrets
+	// (omitted from Snapshot). See IssuingCARootCert / IssuingCARootKey docs.
+	c.IssuingCARootCert = getenv("YAGE_ISSUING_CA_ROOT_CERT", "")
+	c.IssuingCARootKey = getenv("YAGE_ISSUING_CA_ROOT_KEY", "")
+	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
 
 	// CSI add-on selection (§20 / Phase F). YAGE_CSI_DRIVERS is a
 	// comma-separated list of driver names — empty values get

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1126,13 +1126,6 @@ type Config struct {
 	// NoopTracer. Set via --trace-endpoint or YAGE_TRACE_ENDPOINT.
 	TraceEndpoint string
 
-	// TofuRef is the git ref (branch, tag, or SHA) of the lpasquali/yage-tofu
-	// repository that Fetcher clones/updates. Defaults to "main".
-	// Env: YAGE_TOFU_REF.
-	// NOTE: issue #124 adds this field to config.go on a parallel branch.
-	// When that PR merges before this one, rebase and remove this addition.
-	TofuRef string
-
 	// --- On-prem platform services (Phase H, ADR 0009) ---
 
 	// RegistryNode is the Proxmox node on which to provision the bootstrap
@@ -1266,7 +1259,6 @@ func Load() *Config {
 	// (omitted from Snapshot). See IssuingCARootCert / IssuingCARootKey docs.
 	c.IssuingCARootCert = getenv("YAGE_ISSUING_CA_ROOT_CERT", "")
 	c.IssuingCARootKey = getenv("YAGE_ISSUING_CA_ROOT_KEY", "")
-	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
 
 	// CSI add-on selection (§20 / Phase F). YAGE_CSI_DRIVERS is a
 	// comma-separated list of driver names — empty values get

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -322,6 +322,15 @@ func (c *Config) Snapshot() []SnapshotField {
 		bp("XAPIRI_WORKLOAD_HAS_QUEUE", &c.Workload.HasQueue),
 		bp("XAPIRI_WORKLOAD_HAS_OBJ_STORE", &c.Workload.HasObjStore),
 		bp("XAPIRI_WORKLOAD_HAS_CACHE", &c.Workload.HasCache),
+		// --- On-prem platform services (Phase H, ADR 0009) ---
+		// IssuingCARootCert and IssuingCARootKey are intentionally omitted:
+		// root CA material must never appear in kind Secrets.
+		sp("YAGE_REGISTRY_NODE", &c.RegistryNode),
+		sp("YAGE_REGISTRY_VM_FLAVOR", &c.RegistryVMFlavor),
+		sp("YAGE_REGISTRY_NETWORK", &c.RegistryNetwork),
+		sp("YAGE_REGISTRY_STORAGE", &c.RegistryStorage),
+		sp("YAGE_REGISTRY_FLAVOR", &c.RegistryFlavor),
+		sp("YAGE_TOFU_REF", &c.TofuRef),
 	}
 }
 

--- a/internal/config/snapshot_test.go
+++ b/internal/config/snapshot_test.go
@@ -97,3 +97,26 @@ func TestEmptyValueSkipped(t *testing.T) {
 		t.Errorf("empty value should be ignored: got %q", c.KindVersion)
 	}
 }
+
+// TestSnapshotExcludesRootCAFields asserts that root CA material never
+// appears in the snapshot emitted to kind Secrets. It also verifies that
+// the registry fields *are* included so the test cannot pass vacuously.
+func TestSnapshotExcludesRootCAFields(t *testing.T) {
+	c := Load()
+	c.IssuingCARootCert = "-----BEGIN CERTIFICATE-----\nMIIBtest\n-----END CERTIFICATE-----"
+	c.IssuingCARootKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIBtest\n-----END RSA PRIVATE KEY-----"
+	// Set a registry field so we can confirm the snapshot isn't empty.
+	c.RegistryNode = "pve-node-1"
+
+	yaml := c.SnapshotYAML()
+
+	if strings.Contains(yaml, "YAGE_ISSUING_CA_ROOT_CERT") {
+		t.Error("YAGE_ISSUING_CA_ROOT_CERT must not appear in SnapshotYAML output")
+	}
+	if strings.Contains(yaml, "YAGE_ISSUING_CA_ROOT_KEY") {
+		t.Error("YAGE_ISSUING_CA_ROOT_KEY must not appear in SnapshotYAML output")
+	}
+	if !strings.Contains(yaml, `YAGE_REGISTRY_NODE: "pve-node-1"`) {
+		t.Errorf("YAGE_REGISTRY_NODE should appear in SnapshotYAML output; got:\n%s", yaml)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds 8 new config fields under `// --- On-prem platform services (Phase H, ADR 0009) ---` in `internal/config/config.go`
- Five `YAGE_REGISTRY_*` fields (RegistryNode, RegistryVMFlavor, RegistryNetwork, RegistryStorage, RegistryFlavor) and `YAGE_TOFU_REF` are included in `Snapshot()` for persistence to kind Secrets
- `IssuingCARootCert` and `IssuingCARootKey` are loaded from env but **intentionally omitted** from `Snapshot()` so root CA material never appears in kind Secrets

Closes #124

## Acceptance Criteria Evidence

| Criterion | Status |
|---|---|
| All 8 fields load from env vars with correct defaults | ✅ verified in `Load()` |
| `Snapshot()` includes 5 registry fields and `TofuRef` | ✅ present in `snapshot.go` |
| `Snapshot()` excludes `IssuingCARootCert` and `IssuingCARootKey` | ✅ intentionally omitted from slice |
| `TestSnapshotExcludesRootCAFields` asserts exclusion | ✅ added to `snapshot_test.go` |
| `make build && make test` green | ✅ all 52 test packages pass |

## Audit Checks

| Check | Result |
|---|---|
| No new dependencies | ✅ no `go.mod` changes |
| No secrets in snapshot | ✅ root CA fields omitted by construction |
| Consistent field-loading pattern | ✅ uses `getenv()` helper matching all other YAGE_* fields |
| Snapshot stability (ordered slice) | ✅ new entries appended at end of Snapshot() |

## Breaking Changes

None. All fields are additive with backward-compatible empty/default values. Existing snapshots without the new keys continue to work — `ApplySnapshotKV` silently ignores unknown keys.

## Definition of Done

- [x] Issue assigned and status set to In Progress
- [x] Branch created from latest `main`
- [x] Implementation follows existing patterns (struct fields + `Load()` + `Snapshot()`)
- [x] Unit test added for security-critical exclusion behavior
- [x] `make build && make test` green (no regressions)
- [x] PR opened with Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)