### PR TITLE
feat(config): add YAGE_MANIFESTS_REF field (ADR 0008, #135)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1165,6 +1165,11 @@ type Config struct {
 	// Defaults to main. Env: YAGE_TOFU_REF.
 	TofuRef string
 
+	// ManifestsRef is the git tag or branch of the lpasquali/yage-manifests
+	// repository that manifests.Fetcher clones/checks-out. Defaults to "v0.1.0"
+	// (ADR 0008 §5). Env: YAGE_MANIFESTS_REF.
+	ManifestsRef string
+
 }
 
 // Load reads environment variables and applies defaults to produce a
@@ -1248,6 +1253,7 @@ func Load() *Config {
 	c.NodeImage = strings.TrimSpace(getenv("YAGE_NODE_IMAGE", ""))
 	c.TraceEndpoint = getenv("YAGE_TRACE_ENDPOINT", "")
 	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
+	c.ManifestsRef = getenv("YAGE_MANIFESTS_REF", "v0.1.0")
 
 	// --- On-prem platform services (Phase H, ADR 0009) ---
 	c.RegistryNode = getenv("YAGE_REGISTRY_NODE", "")

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -331,6 +331,7 @@ func (c *Config) Snapshot() []SnapshotField {
 		sp("YAGE_REGISTRY_STORAGE", &c.RegistryStorage),
 		sp("YAGE_REGISTRY_FLAVOR", &c.RegistryFlavor),
 		sp("YAGE_TOFU_REF", &c.TofuRef),
+		sp("YAGE_MANIFESTS_REF", &c.ManifestsRef),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `ManifestsRef string` to `Config` struct, immediately after `TofuRef`, loaded from `YAGE_MANIFESTS_REF` env var with default `"v0.1.0"` (ADR 0008 §5).
- Registers the field in `Snapshot()` so the value round-trips through kind Secrets alongside `TofuRef`.

## Motivation

Closes #135. ADR 0008 §5 specifies `YAGE_MANIFESTS_REF` as the config knob for selecting which git tag/branch of `lpasquali/yage-manifests` the upcoming `manifests.Fetcher` (issue #136) will clone. This PR lands the config field as a prerequisite so #136 can reference `cfg.ManifestsRef` without touching the config layer itself.

## Test plan

- [x] `make build` passes
- [x] `go test ./internal/config/...` passes (snapshot roundtrip test covers the new field via the generic `SnapshotYAML → ApplySnapshotKV` cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)