### PR TITLE
feat(kindsync): EnsureYageSystemOnCluster — SA + RBAC bootstrap from spec (#146)

### DIFF
--- a/internal/cluster/kindsync/yagesystem.go
+++ b/internal/cluster/kindsync/yagesystem.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package kindsync
+
+// yagesystem.go — idempotent RBAC bootstrap for the yage-job-runner
+// ServiceAccount on any Kubernetes cluster (kind or management).
+//
+// All objects are created via server-side apply (Force=true) using hardcoded
+// Go structs ("from spec"), so no template files are needed and re-runs are
+// always safe.
+//
+// Call order: EnsureNamespace → ServiceAccount → Role → RoleBinding.
+// Each step returns on the first error — this is bootstrap, not best-effort.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+)
+
+const (
+	yageJobRunnerName = "yage-job-runner"
+)
+
+// yageManagedLabel returns the standard managed-by label map.
+func yageManagedLabel() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "yage",
+	}
+}
+
+// EnsureYageSystemOnCluster creates or updates the yage-job-runner
+// ServiceAccount, Role, and RoleBinding in yage-system.
+// Idempotent — safe to call on any cluster.
+func EnsureYageSystemOnCluster(ctx context.Context, cli *k8sclient.Client) error {
+	ns := YageSystemNamespace
+
+	// Ensure the namespace exists before applying namespaced resources.
+	if err := cli.EnsureNamespace(ctx, ns); err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: ensure namespace %s: %w", ns, err)
+	}
+
+	if err := ensureJobRunnerServiceAccount(ctx, cli, ns); err != nil {
+		return err
+	}
+	if err := ensureJobRunnerRole(ctx, cli, ns); err != nil {
+		return err
+	}
+	if err := ensureJobRunnerRoleBinding(ctx, cli, ns); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureJobRunnerServiceAccount server-side-applies the yage-job-runner SA.
+func ensureJobRunnerServiceAccount(ctx context.Context, cli *k8sclient.Client, ns string) error {
+	sa := corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      yageJobRunnerName,
+			Namespace: ns,
+			Labels:    yageManagedLabel(),
+		},
+	}
+	body, err := json.Marshal(sa)
+	if err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: marshal ServiceAccount: %w", err)
+	}
+	_, err = cli.Typed.CoreV1().ServiceAccounts(ns).Patch(
+		ctx, yageJobRunnerName, types.ApplyPatchType, body,
+		metav1.PatchOptions{
+			FieldManager: k8sclient.FieldManager,
+			Force:        boolTrue(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: apply ServiceAccount: %w", err)
+	}
+	return nil
+}
+
+// ensureJobRunnerRole server-side-applies the yage-job-runner Role.
+func ensureJobRunnerRole(ctx context.Context, cli *k8sclient.Client, ns string) error {
+	role := rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      yageJobRunnerName,
+			Namespace: ns,
+			Labels:    yageManagedLabel(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumeclaims"},
+				Verbs:     []string{"get", "list", "watch", "create"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "pods/log"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"jobs"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
+			},
+		},
+	}
+	body, err := json.Marshal(role)
+	if err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: marshal Role: %w", err)
+	}
+	_, err = cli.Typed.RbacV1().Roles(ns).Patch(
+		ctx, yageJobRunnerName, types.ApplyPatchType, body,
+		metav1.PatchOptions{
+			FieldManager: k8sclient.FieldManager,
+			Force:        boolTrue(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: apply Role: %w", err)
+	}
+	return nil
+}
+
+// ensureJobRunnerRoleBinding server-side-applies the yage-job-runner RoleBinding.
+func ensureJobRunnerRoleBinding(ctx context.Context, cli *k8sclient.Client, ns string) error {
+	rb := rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      yageJobRunnerName,
+			Namespace: ns,
+			Labels:    yageManagedLabel(),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      yageJobRunnerName,
+				Namespace: ns,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     yageJobRunnerName,
+		},
+	}
+	body, err := json.Marshal(rb)
+	if err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: marshal RoleBinding: %w", err)
+	}
+	_, err = cli.Typed.RbacV1().RoleBindings(ns).Patch(
+		ctx, yageJobRunnerName, types.ApplyPatchType, body,
+		metav1.PatchOptions{
+			FieldManager: k8sclient.FieldManager,
+			Force:        boolTrue(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster: apply RoleBinding: %w", err)
+	}
+	return nil
+}

--- a/internal/cluster/kindsync/yagesystem_test.go
+++ b/internal/cluster/kindsync/yagesystem_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package kindsync
+
+// Tests for EnsureYageSystemOnCluster.
+//
+// We use k8s.io/client-go/kubernetes/fake.NewSimpleClientset() injected
+// into a k8sclient.Client to exercise the function without a real cluster.
+//
+// Assertions: after the call, the SA / Role / RoleBinding all exist in
+// yage-system with the expected names and managed-by label. On a second
+// call (idempotency) no error is returned.
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+)
+
+// fakeClient wraps a fake clientset inside a k8sclient.Client. The
+// yage-system namespace is pre-created so EnsureNamespace's Get call
+// succeeds without needing the REST mapper (which is nil in unit tests).
+// Only the Typed field is exercised by EnsureYageSystemOnCluster.
+func fakeClient(t *testing.T) *k8sclient.Client {
+	t.Helper()
+	cs := k8sfake.NewClientset()
+	// Pre-create yage-system so EnsureNamespace takes the early-return path.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: YageSystemNamespace},
+	}
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("pre-create yage-system namespace: %v", err)
+	}
+	return &k8sclient.Client{
+		Typed: cs,
+	}
+}
+
+func TestEnsureYageSystemOnCluster_CreatesResources(t *testing.T) {
+	cli := fakeClient(t)
+	ctx := context.Background()
+
+	if err := EnsureYageSystemOnCluster(ctx, cli); err != nil {
+		t.Fatalf("EnsureYageSystemOnCluster: unexpected error: %v", err)
+	}
+
+	ns := YageSystemNamespace
+
+	// Verify ServiceAccount.
+	sa, err := cli.Typed.CoreV1().ServiceAccounts(ns).Get(ctx, yageJobRunnerName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("ServiceAccount not found after EnsureYageSystemOnCluster: %v", err)
+	}
+	if sa.Labels["app.kubernetes.io/managed-by"] != "yage" {
+		t.Errorf("ServiceAccount missing managed-by=yage label, got: %v", sa.Labels)
+	}
+
+	// Verify Role.
+	role, err := cli.Typed.RbacV1().Roles(ns).Get(ctx, yageJobRunnerName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Role not found after EnsureYageSystemOnCluster: %v", err)
+	}
+	if role.Labels["app.kubernetes.io/managed-by"] != "yage" {
+		t.Errorf("Role missing managed-by=yage label, got: %v", role.Labels)
+	}
+	assertRoleRules(t, role)
+
+	// Verify RoleBinding.
+	rb, err := cli.Typed.RbacV1().RoleBindings(ns).Get(ctx, yageJobRunnerName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("RoleBinding not found after EnsureYageSystemOnCluster: %v", err)
+	}
+	if rb.Labels["app.kubernetes.io/managed-by"] != "yage" {
+		t.Errorf("RoleBinding missing managed-by=yage label, got: %v", rb.Labels)
+	}
+	if rb.RoleRef.Name != yageJobRunnerName {
+		t.Errorf("RoleBinding.RoleRef.Name = %q, want %q", rb.RoleRef.Name, yageJobRunnerName)
+	}
+	if rb.RoleRef.Kind != "Role" {
+		t.Errorf("RoleBinding.RoleRef.Kind = %q, want Role", rb.RoleRef.Kind)
+	}
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Name != yageJobRunnerName {
+		t.Errorf("RoleBinding.Subjects unexpected: %+v", rb.Subjects)
+	}
+	if rb.Subjects[0].Namespace != ns {
+		t.Errorf("RoleBinding.Subjects[0].Namespace = %q, want %q", rb.Subjects[0].Namespace, ns)
+	}
+}
+
+func TestEnsureYageSystemOnCluster_Idempotent(t *testing.T) {
+	cli := fakeClient(t)
+	ctx := context.Background()
+
+	if err := EnsureYageSystemOnCluster(ctx, cli); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := EnsureYageSystemOnCluster(ctx, cli); err != nil {
+		t.Fatalf("second call (idempotent): %v", err)
+	}
+}
+
+// assertRoleRules verifies the four required PolicyRules are present.
+func assertRoleRules(t *testing.T, role *rbacv1.Role) {
+	t.Helper()
+
+	type ruleCheck struct {
+		group    string
+		resource string
+		verb     string
+	}
+	required := []ruleCheck{
+		{"", "secrets", "create"},
+		{"", "secrets", "delete"},
+		{"", "persistentvolumeclaims", "create"},
+		{"", "pods", "get"},
+		{"", "pods/log", "watch"},
+		{"batch", "jobs", "create"},
+		{"batch", "jobs", "delete"},
+	}
+
+	for _, rc := range required {
+		found := false
+		for _, rule := range role.Rules {
+			if !containsString(rule.APIGroups, rc.group) {
+				continue
+			}
+			if !containsString(rule.Resources, rc.resource) {
+				continue
+			}
+			if !containsString(rule.Verbs, rc.verb) {
+				continue
+			}
+			found = true
+			break
+		}
+		if !found {
+			t.Errorf("Role missing rule: apiGroup=%q resource=%q verb=%q", rc.group, rc.resource, rc.verb)
+		}
+	}
+}
+
+// containsString reports whether slice contains s.
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds `EnsureYageSystemOnCluster(ctx, cli)` to `internal/cluster/kindsync/yagesystem.go` — idempotently server-side-applies the `yage-job-runner` ServiceAccount, Role, and RoleBinding in the `yage-system` namespace on any Kubernetes cluster (kind bootstrap or pivot management target).
- Role grants: `secrets` (full CRUD), `persistentvolumeclaims` (read/create), `pods`+`pods/log` (read-only), `batch/jobs` (read/create/delete). All objects carry `app.kubernetes.io/managed-by=yage`.
- Reuses existing package primitives: `YageSystemNamespace`, `boolTrue()`, `k8sclient.FieldManager`, `types.ApplyPatchType` — consistent with `handoff.go` and `config.go`.

Closes #146. Implements the SA/RBAC bootstrap step referenced in [ADR 0011 §3](https://lpasquali.github.io/yage-docs/architecture/adrs/abstraction-plan/).

## Test plan

- [x] `TestEnsureYageSystemOnCluster_CreatesResources` — verifies SA, Role (all four rule groups), and RoleBinding are present with correct labels and bindings after one call.
- [x] `TestEnsureYageSystemOnCluster_Idempotent` — calls twice, asserts no error on the second call.
- [x] Tests use `k8s.io/client-go/kubernetes/fake.NewClientset()` (ManagedFieldObjectTracker) so SSA create-on-apply works without a live cluster.
- [x] `make build` passes.
- [x] `go test ./internal/cluster/kindsync/...` — all 19 tests pass (1 skipped for TTY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)