### PR TITLE
fix(xapiri): remove duplicate profile selection prompt at startup (#151)

### DIFF
--- a/cmd/yage/main.go
+++ b/cmd/yage/main.go
@@ -111,6 +111,11 @@ func main() {
 	// Three branches correspond to the three supported modes:
 	//   • KindClusterName set + ConfigNameExplicit (--config-name passed)
 	//     → deterministic get: exactly one Secret targeted.
+	//   • --xapiri: skip the interactive picker here; the dashboard's
+	//     cfgListScreen is the canonical profile selection UI and runs
+	//     inside the TUI. Running a huh picker here would show the prompt
+	//     twice (#151). Case 1 above still applies when --config-name is
+	//     explicit (dashboard skips cfgListScreen in that case too).
 	//   • KindClusterName set, ConfigName defaulted from WorkloadClusterName
 	//     → huh picker across all Secrets on that kind cluster so the user
 	//       can choose among profiles / drafts for the same workload.
@@ -119,6 +124,8 @@ func main() {
 	switch {
 	case cfg.KindClusterName != "" && cfg.ConfigNameExplicit:
 		_ = kindsync.MergeBootstrapConfigFromKind(cfg)
+	case cfg.Xapiri:
+		// Dashboard cfgListScreen handles candidate discovery and selection.
 	case cfg.KindClusterName != "":
 		kindsync.MergeBootstrapConfigFromKindCluster(cfg)
 	default:


### PR DESCRIPTION
## Summary

- Adds a `cfg.Xapiri` guard in `cmd/yage/main.go` to skip the pre-dashboard `huh.Select` kindsync picker when running `--xapiri`
- The dashboard's own `cfgListScreen` is the canonical profile selection UI; the kindsync picker ran before the dashboard launched, causing the user to see profile selection twice
- The deterministic path (`--config-name` explicit) is preserved — it still silently merges from the exact Secret without prompting, and the dashboard correctly skips `cfgListScreen` for that case too

## Test plan

- [ ] `make build` passes
- [ ] `go test ./internal/ui/...` passes
- [ ] Manual: `yage --xapiri` shows profile selection exactly once (inside the dashboard `cfgListScreen`)
- [ ] Manual: `yage --xapiri --config-name <name>` goes directly to the provision tab, no selection screen

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)