### PR TITLE
feat(xapiri,plan): surface Phase H registry + issuing CA fields

### DIFF
--- a/internal/orchestrator/plan.go
+++ b/internal/orchestrator/plan.go
@@ -61,6 +61,7 @@ func PrintPlanTo(w io.Writer, cfg *config.Config) {
 	planPrePhase(w, cfg)
 	planPhase1(w, cfg)
 	describeIdentity(pw, cfg, prov, perr)
+	planPlatformServices(w, cfg)
 	planPhase2Clusterctl(w, cfg)
 	planPhase2Kind(w, cfg)
 	planPhase2CAPI(pw, w, cfg, prov, perr)
@@ -162,6 +163,37 @@ func describeIdentity(pw plan.Writer, cfg *config.Config, prov provider.Provider
 		return
 	}
 	prov.DescribeIdentity(pw, cfg)
+}
+
+// planPlatformServices prints Phase H — bootstrap registry and issuing CA.
+// If neither group is configured, prints a single skip line.
+func planPlatformServices(w io.Writer, cfg *config.Config) {
+	section(w, "Phase H — Platform Services")
+	hasRegistry := cfg.RegistryNode != ""
+	hasCA := cfg.IssuingCARootCert != ""
+	if !hasRegistry && !hasCA {
+		skip(w, "no YAGE_REGISTRY_NODE or YAGE_ISSUING_CA_ROOT_CERT set")
+		return
+	}
+	if hasRegistry {
+		bullet(w, "Registry node: %s", cfg.RegistryNode)
+		if cfg.RegistryVMFlavor != "" {
+			bullet(w, "  VM flavor: %s", cfg.RegistryVMFlavor)
+		}
+		if cfg.RegistryNetwork != "" {
+			bullet(w, "  network: %s", cfg.RegistryNetwork)
+		}
+		if cfg.RegistryStorage != "" {
+			bullet(w, "  storage: %s", cfg.RegistryStorage)
+		}
+		bullet(w, "  registry flavor: %s", firstNonEmptyStr(cfg.RegistryFlavor, "harbor"))
+	}
+	if hasCA {
+		bullet(w, "Issuing CA cert: (set via YAGE_ISSUING_CA_ROOT_CERT)")
+		if cfg.IssuingCARootKey != "" {
+			bullet(w, "Issuing CA key: (set via YAGE_ISSUING_CA_ROOT_KEY)")
+		}
+	}
 }
 
 func planPhase2Clusterctl(w io.Writer, cfg *config.Config) {

--- a/internal/orchestrator/testdata/plan/aws-default.golden
+++ b/internal/orchestrator/testdata/plan/aws-default.golden
@@ -22,6 +22,9 @@
     ◦ skip: AWS uses operator-supplied IAM (env: AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY / AWS_PROFILE)
     ◦ skip: CAPA bootstrap stack created out-of-band — `clusterawsadm bootstrap iam create-cloudformation-stack`
 
+▸ Phase H — Platform Services
+    ◦ skip: no YAGE_REGISTRY_NODE or YAGE_ISSUING_CA_ROOT_CERT set
+
 ▸ clusterctl credentials
     • synthesize ephemeral clusterctl config from provider env vars
 

--- a/internal/orchestrator/testdata/plan/aws-eks.golden
+++ b/internal/orchestrator/testdata/plan/aws-eks.golden
@@ -22,6 +22,9 @@
     ◦ skip: AWS uses operator-supplied IAM (env: AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY / AWS_PROFILE)
     ◦ skip: CAPA bootstrap stack created out-of-band — `clusterawsadm bootstrap iam create-cloudformation-stack`
 
+▸ Phase H — Platform Services
+    ◦ skip: no YAGE_REGISTRY_NODE or YAGE_ISSUING_CA_ROOT_CERT set
+
 ▸ clusterctl credentials
     • synthesize ephemeral clusterctl config from provider env vars
 

--- a/internal/orchestrator/testdata/plan/hetzner-default.golden
+++ b/internal/orchestrator/testdata/plan/hetzner-default.golden
@@ -21,6 +21,9 @@
 ▸ Identity bootstrap — Hetzner Cloud
     ◦ skip: HCLOUD_TOKEN supplied via env (operator-managed, not minted by yage)
 
+▸ Phase H — Platform Services
+    ◦ skip: no YAGE_REGISTRY_NODE or YAGE_ISSUING_CA_ROOT_CERT set
+
 ▸ clusterctl credentials
     • synthesize ephemeral clusterctl config from provider env vars
 

--- a/internal/orchestrator/testdata/plan/proxmox-default.golden
+++ b/internal/orchestrator/testdata/plan/proxmox-default.golden
@@ -24,6 +24,9 @@
     • tofu apply: create CSI user 'csi@pve' + token prefix 'csi-token'
     • outputs piped into clusterctl + CSI configs
 
+▸ Phase H — Platform Services
+    ◦ skip: no YAGE_REGISTRY_NODE or YAGE_ISSUING_CA_ROOT_CERT set
+
 ▸ clusterctl credentials
     • synthesize ephemeral clusterctl config from provider env vars
 

--- a/internal/orchestrator/testdata/plan/proxmox-pivot.golden
+++ b/internal/orchestrator/testdata/plan/proxmox-pivot.golden
@@ -24,6 +24,9 @@
     • tofu apply: create CSI user 'csi@pve' + token prefix 'csi-token'
     • outputs piped into clusterctl + CSI configs
 
+▸ Phase H — Platform Services
+    ◦ skip: no YAGE_REGISTRY_NODE or YAGE_ISSUING_CA_ROOT_CERT set
+
 ▸ clusterctl credentials
     • synthesize ephemeral clusterctl config from provider env vars
 

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -130,18 +130,26 @@ const (
 	tiDCLoc
 	tiBudget
 	tiHeadroom
+	// Phase H — Platform Services
+	tiRegistryNode    // YAGE_REGISTRY_NODE
+	tiRegistryVMFlav  // YAGE_REGISTRY_VM_FLAVOR
+	tiRegistryNetwork // YAGE_REGISTRY_NETWORK
+	tiRegistryStorage // YAGE_REGISTRY_STORAGE
+	tiIssuingCACert   // YAGE_ISSUING_CA_ROOT_CERT (PEM)
+	tiIssuingCAKey    // YAGE_ISSUING_CA_ROOT_KEY (PEM)
 	tiCount // must be last
 )
 
 // ─── select slot indices ─────────────────────────────────────────────────────
 
 const (
-	siMode      = 0 // cloud | on-prem
-	siEnv       = 1 // dev | staging | prod
-	siResil     = 2 // single-az | ha | ha-multi-region
-	siBootstrap = 3 // kubeadm | k3s  (on-prem only)
-	siProvider  = 4 // infra provider (auto | aws | gcp | …)
-	siCount     = 5
+	siMode         = 0 // cloud | on-prem
+	siEnv          = 1 // dev | staging | prod
+	siResil        = 2 // single-az | ha | ha-multi-region
+	siBootstrap    = 3 // kubeadm | k3s  (on-prem only)
+	siProvider     = 4 // infra provider (auto | aws | gcp | …)
+	siRegistryFlav = 5 // Phase H registry flavor: harbor | zot
+	siCount        = 6
 )
 
 // ─── toggle (bool) slot indices ──────────────────────────────────────────────
@@ -247,7 +255,15 @@ const (
 	focHWWatts                  // 69
 	focHWKWH                    // 70
 	focHWSupport                // 71
-	focCount                    // 72 — must be last
+	// Phase H — Platform Services (on-prem only)
+	focRegistryNode    // 72 — YAGE_REGISTRY_NODE (proxmox only)
+	focRegistryVMFlav  // 73
+	focRegistryNetwork // 74
+	focRegistryStorage // 75
+	focRegistryFlavor  // 76 — harbor | zot
+	focIssuingCACert   // 77 — YAGE_ISSUING_CA_ROOT_CERT
+	focIssuingCAKey    // 78 — YAGE_ISSUING_CA_ROOT_KEY
+	focCount           // 79 — must be last
 )
 
 // ─── per-field metadata ───────────────────────────────────────────────────────
@@ -362,6 +378,15 @@ var dashFields = []fieldMeta{
 	{fkText, tiHWWatts, "  HW watts", "", false},
 	{fkText, tiHWKWH, "  kWh rate USD", "", false},
 	{fkText, tiHWSupport, "  support USD/mo", "", false},
+	// ── Registry (proxmox only) ───────────────────────────────────────────
+	{fkText, tiRegistryNode, "registry node", "Registry", false},
+	{fkText, tiRegistryVMFlav, "  VM flavor", "", false},
+	{fkText, tiRegistryNetwork, "  network", "", false},
+	{fkText, tiRegistryStorage, "  storage", "", false},
+	{fkSelect, siRegistryFlav, "  flavor", "", false},
+	// ── Issuing CA (on-prem only) ─────────────────────────────────────────
+	{fkText, tiIssuingCACert, "issuing CA cert", "Issuing CA", false},
+	{fkText, tiIssuingCAKey, "issuing CA key", "", false},
 }
 
 // ─── tab IDs ─────────────────────────────────────────────────────────────────
@@ -768,6 +793,14 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 	m.textInputs[tiHWKWH].Validate = validateNonNegativeFloatOptional
 	m.textInputs[tiHWSupport].Validate = validateNonNegativeFloatOptional
 
+	// Phase H — Platform Services.
+	m.textInputs[tiRegistryNode].SetValue(cfg.RegistryNode)
+	m.textInputs[tiRegistryVMFlav].SetValue(cfg.RegistryVMFlavor)
+	m.textInputs[tiRegistryNetwork].SetValue(cfg.RegistryNetwork)
+	m.textInputs[tiRegistryStorage].SetValue(cfg.RegistryStorage)
+	m.textInputs[tiIssuingCACert].SetValue(cfg.IssuingCARootCert)
+	m.textInputs[tiIssuingCAKey].SetValue(cfg.IssuingCARootKey)
+
 	// Selects.
 	m.selects[siMode] = selectState{options: []string{"cloud", "on-prem"}, cur: 0}
 	if s.fork == forkOnPrem {
@@ -809,6 +842,12 @@ func newDashModel(cfg *config.Config, s *state) dashModel {
 		}
 	}
 	m.selects[siProvider] = selectState{options: provOptions, cur: provCur}
+
+	// Registry flavor: harbor (default) or zot.
+	m.selects[siRegistryFlav] = selectState{options: []string{"harbor", "zot"}, cur: 0}
+	if cfg.RegistryFlavor == "zot" {
+		m.selects[siRegistryFlav].cur = 1
+	}
 
 	// Toggles.
 	m.toggles[toiQueue] = s.workload.HasQueue
@@ -1053,6 +1092,12 @@ func (m *dashModel) isHidden(fid int) bool {
 		return isCloud
 	case focHWCost, focHWWatts, focHWKWH, focHWSupport:
 		return isCloud || !m.toggles[toiTCO]
+	// Registry: proxmox-only (bootstrap registry is an on-prem / bare-metal concern).
+	case focRegistryNode, focRegistryVMFlav, focRegistryNetwork, focRegistryStorage, focRegistryFlavor:
+		return m.selects[siProvider].value() != "proxmox"
+	// Issuing CA: on-prem only.
+	case focIssuingCACert, focIssuingCAKey:
+		return isCloud
 	}
 	return false
 }
@@ -2815,6 +2860,15 @@ func (m dashModel) buildSnapshotCfg() config.Config {
 		snap.HardwareSupportUSDMonth = v
 	}
 
+	// Phase H — Platform Services.
+	snap.RegistryNode = strings.TrimSpace(m.textInputs[tiRegistryNode].Value())
+	snap.RegistryVMFlavor = strings.TrimSpace(m.textInputs[tiRegistryVMFlav].Value())
+	snap.RegistryNetwork = strings.TrimSpace(m.textInputs[tiRegistryNetwork].Value())
+	snap.RegistryStorage = strings.TrimSpace(m.textInputs[tiRegistryStorage].Value())
+	snap.RegistryFlavor = m.selects[siRegistryFlav].value()
+	snap.IssuingCARootCert = strings.TrimSpace(m.textInputs[tiIssuingCACert].Value())
+	snap.IssuingCARootKey = strings.TrimSpace(m.textInputs[tiIssuingCAKey].Value())
+
 	mode := m.selects[siMode].value()
 	fork := forkCloud
 	if mode == "on-prem" {
@@ -2994,6 +3048,13 @@ func (m *dashModel) flushToCfg() {
 	m.cfg.HardwareWatts = snap.HardwareWatts
 	m.cfg.HardwareKWHRateUSD = snap.HardwareKWHRateUSD
 	m.cfg.HardwareSupportUSDMonth = snap.HardwareSupportUSDMonth
+	m.cfg.RegistryNode = snap.RegistryNode
+	m.cfg.RegistryVMFlavor = snap.RegistryVMFlavor
+	m.cfg.RegistryNetwork = snap.RegistryNetwork
+	m.cfg.RegistryStorage = snap.RegistryStorage
+	m.cfg.RegistryFlavor = snap.RegistryFlavor
+	m.cfg.IssuingCARootCert = snap.IssuingCARootCert
+	m.cfg.IssuingCARootKey = snap.IssuingCARootKey
 
 	// Derive s.fork / s.env / s.resil for the rest of the walkthrough.
 	if m.selects[siMode].value() == "on-prem" {


### PR DESCRIPTION
## Summary

- Adds `planPlatformServices()` to `--dry-run` plan output (Phase H section after Identity bootstrap): prints registry node/VM flavor/network/storage/flavor and issuing CA cert/key when set, or a single skip line when neither `YAGE_REGISTRY_NODE` nor `YAGE_ISSUING_CA_ROOT_CERT` is configured
- Adds **Registry** section to the xapiri TUI provision tab (proxmox-only, gated by `siProvider == "proxmox"`): text inputs for node, VM flavor, network, storage; `harbor | zot` select for flavor
- Adds **Issuing CA** section (on-prem-only): text inputs for PEM cert and PEM key, both round-tripped to `cfg.IssuingCARootCert` / `cfg.IssuingCARootKey`
- Regenerates all five plan golden fixtures to include the new Phase H skip line

Note: the issue description references `IssuingCAPath`/`YAGE_ISSUING_CA_PATH` but PR #132 merged the fields as `IssuingCARootCert`/`YAGE_ISSUING_CA_ROOT_CERT` (PEM content, not file paths). This PR uses the actual field names from `config.go`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/ui/...` — xapiri tests pass
- [x] `go test ./internal/orchestrator/...` — plan golden tests pass after regeneration with `UPDATE_GOLDENS=1`
- [ ] Manual smoke-test: `yage --dry-run` shows `Phase H — Platform Services` section (skip line when neither env var is set)
- [ ] Manual smoke-test: `yage --xapiri` shows Registry section when provider=proxmox; Issuing CA section when on-prem

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)