### PR TITLE
fix(kindsync+xapiri): config profile system bug fixes (#153)

### DIFF
--- a/internal/cluster/kindsync/bootstrap_config.go
+++ b/internal/cluster/kindsync/bootstrap_config.go
@@ -69,6 +69,7 @@ const YageSystemNamespace = "yage-system"
 // separately via an error return).
 func BootstrapConfigNamespace(cfg *config.Config) string {
 	if cfg == nil || cfg.ConfigName == "" {
+		logx.Warn("kindsync: BootstrapConfigNamespace called with empty ConfigName; falling back to yage-default")
 		return "yage-default"
 	}
 	return "yage-" + sanitizeLabelValue(cfg.ConfigName)
@@ -251,13 +252,13 @@ func WriteBootstrapConfigSecret(cfg *config.Config) error {
 //   - universal keys (cluster_name, cluster_id, kubernetes_version)
 //     are filled when empty.
 func MergeBootstrapConfigFromKind(cfg *config.Config) error {
+	if cfg.ConfigName == "" {
+		return fmt.Errorf("kindsync: MergeBootstrapConfigFromKind: ConfigName is required; set --config-name or YAGE_CONFIG_NAME")
+	}
 	kctx := "kind-" + cfg.KindClusterName
 	cli, err := k8sclient.ForContext(kctx)
 	if err != nil {
 		return nil // best-effort; caller continues
-	}
-	if cfg.ConfigName == "" {
-		return nil // no discriminator; caller must populate ConfigName first
 	}
 	bg := context.Background()
 	sec, err := cli.Typed.CoreV1().Secrets(BootstrapConfigNamespace(cfg)).Get(bg, BootstrapConfigSecretName(cfg), metav1.GetOptions{})
@@ -334,6 +335,7 @@ func MergeBootstrapConfigFromKind(cfg *config.Config) error {
 // is verified.
 func PromoteBootstrapConfigToRealized(cfg *config.Config) {
 	if cfg == nil || cfg.KindClusterName == "" || cfg.ConfigName == "" {
+		logx.Warn("kindsync: PromoteBootstrapConfigToRealized: skipped — KindClusterName or ConfigName is empty")
 		return
 	}
 	kctx := "kind-" + cfg.KindClusterName
@@ -376,18 +378,20 @@ func (c BootstrapCandidate) Label() string {
 // kind cluster by looking for namespaces labeled
 // infra.yage-deployment.bucaniere.us=true, then fetches the
 // "bootstrap-config" Secret from each to read the rich label metadata.
-func ListBootstrapCandidates(kindClusterName string) []BootstrapCandidate {
+// Returns an error when the kind cluster is not reachable or the namespace
+// list fails, so callers can surface a user-visible message.
+func ListBootstrapCandidates(kindClusterName string) ([]BootstrapCandidate, error) {
 	kctx := "kind-" + kindClusterName
 	cli, err := k8sclient.ForContext(kctx)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("connect to kind cluster %q: %w", kindClusterName, err)
 	}
 	bg := context.Background()
 	nsList, err := cli.Typed.CoreV1().Namespaces().List(bg, metav1.ListOptions{
 		LabelSelector: "infra.yage-deployment.bucaniere.us=true",
 	})
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("list namespaces on kind cluster %q: %w", kindClusterName, err)
 	}
 	out := make([]BootstrapCandidate, 0, len(nsList.Items))
 	for _, ns := range nsList.Items {
@@ -396,7 +400,12 @@ func ListBootstrapCandidates(kindClusterName string) []BootstrapCandidate {
 			// Namespace exists but secret not yet written — skip.
 			continue
 		}
+		// Validate that this Secret is managed by yage and is a bootstrap-config
+		// Secret; skip non-yage Secrets that happen to share the name.
 		lbl := sec.Labels
+		if lbl["app.kubernetes.io/managed-by"] != "yage" || lbl["app.kubernetes.io/component"] != "bootstrap-config" {
+			continue
+		}
 		out = append(out, BootstrapCandidate{
 			KindCluster: kindClusterName,
 			ConfigName:  lbl["yage.io/config-name"],
@@ -406,7 +415,7 @@ func ListBootstrapCandidates(kindClusterName string) []BootstrapCandidate {
 			Region:      lbl["yage.io/region"],
 		})
 	}
-	return out
+	return out, nil
 }
 
 // pickBootstrapConfig presents a huh.Select form to pick one candidate.
@@ -473,7 +482,12 @@ func MergeBootstrapConfigFromFirstKindCluster(cfg *config.Config) {
 		if name == "" {
 			continue
 		}
-		candidates = append(candidates, ListBootstrapCandidates(name)...)
+		found, err := ListBootstrapCandidates(name)
+		if err != nil {
+			logx.Warn("kindsync: MergeBootstrapConfigFromFirstKindCluster: skipping cluster %q: %v", name, err)
+			continue
+		}
+		candidates = append(candidates, found...)
 	}
 	switch len(candidates) {
 	case 0:
@@ -493,7 +507,11 @@ func MergeBootstrapConfigFromFirstKindCluster(cfg *config.Config) {
 // It lists all bootstrap-config Secrets on that kind cluster and applies
 // the same 0/1/N huh-picker logic as MergeBootstrapConfigFromFirstKindCluster.
 func MergeBootstrapConfigFromKindCluster(cfg *config.Config) {
-	candidates := ListBootstrapCandidates(cfg.KindClusterName)
+	candidates, err := ListBootstrapCandidates(cfg.KindClusterName)
+	if err != nil {
+		logx.Warn("kindsync: MergeBootstrapConfigFromKindCluster: %v", err)
+		return
+	}
 	switch len(candidates) {
 	case 0:
 		// No configs on this cluster yet — leave ConfigName at its default.

--- a/internal/provider/proxmox/state.go
+++ b/internal/provider/proxmox/state.go
@@ -48,7 +48,8 @@ func (p *Provider) KindSyncFields(cfg *config.Config) map[string]string {
 	add("pool", cfg.Providers.Proxmox.Pool)
 	add("identity_suffix", cfg.Providers.Proxmox.IdentitySuffix)
 	add("admin_username", cfg.Providers.Proxmox.AdminUsername)
-	add("admin_token", cfg.Providers.Proxmox.AdminToken)
+	// admin_token is intentionally excluded — it is a sensitive credential that
+	// should not be persisted to the orchestrator-state Secret (see issue #152/#153).
 	if cfg.Providers.Proxmox.AdminInsecure != "" {
 		add("admin_insecure", cfg.Providers.Proxmox.AdminInsecure)
 	}

--- a/internal/ui/xapiri/dashboard.go
+++ b/internal/ui/xapiri/dashboard.go
@@ -1772,6 +1772,11 @@ func (m dashModel) updateCfgNewNameScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // updateCfgEditScreen handles key events in the full config edit form.
 func (m dashModel) updateCfgEditScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Discard keystrokes while a config entry is loading to prevent input
+	// from being silently lost when cfgEntryLoadMsg rebuilds all inputs.
+	if m.cfgLoading {
+		return m, nil
+	}
 	key := msg.Type
 	keyStr := msg.String()
 
@@ -2054,7 +2059,11 @@ func (m dashModel) cfgReady() bool { return m.cfgSelected }
 func (m dashModel) loadCfgListCmd() tea.Cmd {
 	kindName := m.cfg.KindClusterName
 	return func() tea.Msg {
-		return cfgListMsg{candidates: kindsync.ListBootstrapCandidates(kindName)}
+		candidates, err := kindsync.ListBootstrapCandidates(kindName)
+		if err != nil {
+			return cfgListMsg{err: fmt.Errorf("⚠ Could not reach kind cluster: %w", err)}
+		}
+		return cfgListMsg{candidates: candidates}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes all 6 bugs identified in the PE audit (issue #153):

- **Bug 1 — `ListBootstrapCandidates` error blindness**: Changed signature to `([]BootstrapCandidate, error)`; `loadCfgListCmd` now propagates the error to `cfgListMsg.err`, so the config-list screen renders `⚠ Could not reach kind cluster: <err>` instead of a silent empty list.
- **Bug 2 — Missing Secret label validation**: After fetching the `bootstrap-config` Secret, validate `app.kubernetes.io/managed-by=yage` and `app.kubernetes.io/component=bootstrap-config`; non-yage Secrets sharing the name are skipped.
- **Bug 3 — Inconsistent empty `ConfigName` handling**: `MergeBootstrapConfigFromKind` now returns an error when `ConfigName` is empty (matching `WriteBootstrapConfigSecret`); `BootstrapConfigNamespace` emits `logx.Warn` when falling back to `"yage-default"`.
- **Bug 4 — `PromoteBootstrapConfigToRealized` silent skip**: Added `logx.Warn` before the early return when `KindClusterName` or `ConfigName` is empty.
- **Bug 5 — `loadCfgEntryCmd` race in dashboard**: Added `if m.cfgLoading { return m, nil }` guard at the top of `updateCfgEditScreen` to discard keystrokes while a config entry is loading.
- **Bug 6 — `AdminToken` leak via `KindSyncFields`**: Removed `admin_token` from `KindSyncFields` with an explanatory comment. `AbsorbConfigYAML` retains its `admin_token` alias for backward compat with older Secrets.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/cluster/kindsync/...` — all PASS
- [x] `go test ./internal/ui/...` — all PASS
- [x] `make build` — clean binary produced

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)