### PR TITLE
feat(opentofux): switch JobRunner to OpenTofu kubernetes backend; eliminate tofu-state PVCs (#145)

### DIFF
--- a/internal/platform/opentofux/job_runner.go
+++ b/internal/platform/opentofux/job_runner.go
@@ -303,6 +303,14 @@ func (j *JobRunner) buildJob(ns, jobName, cmName, secretName, module, operation 
 									Name:  "KUBE_NAMESPACE",
 									Value: yageNamespace,
 								},
+								{
+									// Redirect tofu's plugin cache and lock file to
+									// a writable path. The module ConfigMap is mounted
+									// read-only, so tofu init cannot write .terraform/
+									// into -chdir=/workspace/module.
+									Name:  "TF_DATA_DIR",
+									Value: "/tmp/.terraform",
+								},
 							},
 							EnvFrom: []corev1.EnvFromSource{
 								{

--- a/internal/platform/opentofux/job_runner.go
+++ b/internal/platform/opentofux/job_runner.go
@@ -17,7 +17,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/lpasquali/yage/internal/config"
@@ -31,7 +30,12 @@ const (
 )
 
 // JobRunner implements Runner by creating Kubernetes resources (ConfigMap,
-// PVC, Secret, Job) on the management cluster and streaming pod logs.
+// Secret, Job) on the management cluster and streaming pod logs.
+//
+// State is stored in Kubernetes Secrets via the OpenTofu kubernetes backend
+// (one Secret per module, named tfstate-default-<module> in yage-system).
+// No PVCs are created for tofu state; the yage-repos PVC (EnsureRepoSync,
+// issue #144) is a separate concern for HCL module content.
 //
 // TODO(#125): pre-kind ordering conflict — JobRunner requires a reachable
 // management cluster and a yage-system namespace. The Fetcher (and thus the
@@ -88,25 +92,11 @@ func (j *JobRunner) tofuImageRef() string {
 	return tofuImage
 }
 
-// storageClassName returns the StorageClass to use for the PVC. Priority:
-//
-//  1. cfg.CSI.DefaultClass (provider-agnostic; set by --csi-default-class)
-//  2. cfg.Providers.Proxmox.CSIStorageClassName (Proxmox-specific fallback)
-//  3. "standard" (kind's local-path provisioner default)
-func (j *JobRunner) storageClassName() string {
-	if j.cfg.CSI.DefaultClass != "" {
-		return j.cfg.CSI.DefaultClass
-	}
-	if j.cfg.Providers.Proxmox.CSIStorageClassName != "" {
-		return j.cfg.Providers.Proxmox.CSIStorageClassName
-	}
-	return "standard"
-}
-
 // Apply implements Runner. Creates (or updates) a ConfigMap with the HCL
-// module files, a PVC for state, a Secret for credentials, and a Job that
-// runs `tofu init && tofu apply`. Streams pod logs in real time and waits
-// for the Job to complete.
+// module files, a Secret for credentials, and a Job that runs
+// `tofu init && tofu apply`. State is kept in a Kubernetes Secret via the
+// OpenTofu kubernetes backend; no PVC is created for tofu state.
+// Streams pod logs in real time and waits for the Job to complete.
 func (j *JobRunner) Apply(ctx context.Context, module string, vars map[string]string) error {
 	return j.runJob(ctx, module, "apply", vars)
 }
@@ -145,13 +135,9 @@ func (j *JobRunner) runJob(ctx context.Context, module, operation string, vars m
 		return fmt.Errorf("job runner: module configmap (%s): %w", module, err)
 	}
 
-	// 2. Ensure PVC for state.
-	pvcName := "tofu-state-" + module
-	if err := j.ensureStatePVC(ctx, ns, pvcName); err != nil {
-		return fmt.Errorf("job runner: state pvc (%s): %w", module, err)
-	}
-
-	// 3. Create (or replace) credentials Secret.
+	// 2. Create (or replace) credentials Secret.
+	// State is stored in a Kubernetes Secret via the OpenTofu kubernetes
+	// backend (tfstate-default-<module> in yage-system); no state PVC needed.
 	secretName := "tofu-creds-" + module
 	if vars == nil {
 		vars = map[string]string{}
@@ -160,9 +146,9 @@ func (j *JobRunner) runJob(ctx context.Context, module, operation string, vars m
 		return fmt.Errorf("job runner: creds secret (%s): %w", module, err)
 	}
 
-	// 4. Create and run the Job.
+	// 3. Create and run the Job.
 	jobName := fmt.Sprintf("tofu-%s-%s", module, operation)
-	if err := j.createAndWaitJob(ctx, ns, jobName, cmName, pvcName, secretName, module, operation); err != nil {
+	if err := j.createAndWaitJob(ctx, ns, jobName, cmName, secretName, module, operation); err != nil {
 		return fmt.Errorf("job runner: job %s: %w", jobName, err)
 	}
 
@@ -220,37 +206,6 @@ func (j *JobRunner) ensureModuleConfigMap(ctx context.Context, ns, cmName, modul
 	return err
 }
 
-// ensureStatePVC creates the PVC if it does not already exist.
-func (j *JobRunner) ensureStatePVC(ctx context.Context, ns, pvcName string) error {
-	_, err := j.client.Typed.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
-	if err == nil {
-		return nil // already exists
-	}
-	if !apierrors.IsNotFound(err) {
-		return err
-	}
-	sc := j.storageClassName()
-	pvc := &corev1.PersistentVolumeClaim{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PersistentVolumeClaim"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvcName,
-			Namespace: ns,
-			Labels:    yageLabels(),
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse("1Gi"),
-				},
-			},
-			StorageClassName: &sc,
-		},
-	}
-	_, err = j.client.Typed.CoreV1().PersistentVolumeClaims(ns).Create(ctx, pvc, metav1.CreateOptions{})
-	return err
-}
-
 // ensureCredsSecret creates (or updates) the credentials Secret. The vars map
 // is encoded as TF_VAR_<key> environment variables so OpenTofu picks them up
 // without extra -var flags. The Secret is never logged.
@@ -284,14 +239,14 @@ func (j *JobRunner) ensureCredsSecret(ctx context.Context, ns, secretName string
 
 // createAndWaitJob creates the Job, waits for a pod to start running, streams
 // logs, then waits for the Job to complete or fail.
-func (j *JobRunner) createAndWaitJob(ctx context.Context, ns, jobName, cmName, pvcName, secretName, module, operation string) error {
+func (j *JobRunner) createAndWaitJob(ctx context.Context, ns, jobName, cmName, secretName, module, operation string) error {
 	// Delete pre-existing job with the same name (from a previous run).
 	background := metav1.DeletePropagationBackground
 	_ = j.client.Typed.BatchV1().Jobs(ns).Delete(ctx, jobName, metav1.DeleteOptions{
 		PropagationPolicy: &background,
 	})
 
-	job := j.buildJob(ns, jobName, cmName, pvcName, secretName, module, operation)
+	job := j.buildJob(ns, jobName, cmName, secretName, module, operation)
 	if _, err := j.client.Typed.BatchV1().Jobs(ns).Create(ctx, job, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("create job: %w", err)
 	}
@@ -313,7 +268,12 @@ func (j *JobRunner) createAndWaitJob(ctx context.Context, ns, jobName, cmName, p
 }
 
 // buildJob constructs the Job spec.
-func (j *JobRunner) buildJob(ns, jobName, cmName, pvcName, secretName, module, operation string) *batchv1.Job {
+//
+// The pod runs as the yage-job-runner ServiceAccount, which has RBAC to
+// read and write Secrets in yage-system. This is required by the OpenTofu
+// kubernetes backend to store state as a Secret (tfstate-default-<module>).
+// KUBE_NAMESPACE instructs the backend client which namespace to target.
+func (j *JobRunner) buildJob(ns, jobName, cmName, secretName, module, operation string) *batchv1.Job {
 	cmd := j.buildCommand(module, operation)
 	backoffLimit := int32(0) // no retries — fail fast so the caller can react
 
@@ -329,12 +289,21 @@ func (j *JobRunner) buildJob(ns, jobName, cmName, pvcName, secretName, module, o
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: yageLabels()},
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					ServiceAccountName: "yage-job-runner",
 					Containers: []corev1.Container{
 						{
 							Name:    "tofu",
 							Image:   j.tofuImageRef(),
 							Command: []string{"/bin/sh", "-c", cmd},
+							Env: []corev1.EnvVar{
+								{
+									// Tells the OpenTofu kubernetes backend which
+									// namespace to store state Secrets in.
+									Name:  "KUBE_NAMESPACE",
+									Value: yageNamespace,
+								},
+							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									SecretRef: &corev1.SecretEnvSource{
@@ -348,10 +317,6 @@ func (j *JobRunner) buildJob(ns, jobName, cmName, pvcName, secretName, module, o
 									MountPath: "/workspace/module",
 									ReadOnly:  true,
 								},
-								{
-									Name:      "state",
-									MountPath: "/workspace/state",
-								},
 							},
 						},
 					},
@@ -364,14 +329,6 @@ func (j *JobRunner) buildJob(ns, jobName, cmName, pvcName, secretName, module, o
 								},
 							},
 						},
-						{
-							Name: "state",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: pvcName,
-								},
-							},
-						},
 					},
 				},
 			},
@@ -380,24 +337,29 @@ func (j *JobRunner) buildJob(ns, jobName, cmName, pvcName, secretName, module, o
 }
 
 // buildCommand returns the shell command string for the given operation.
+//
+// tofu init receives -backend-config=in_cluster_config=true so the
+// kubernetes backend authenticates via the pod's ServiceAccount token rather
+// than looking for ~/.kube/config (which does not exist inside a container).
+// State is stored in a Kubernetes Secret; no -state= flag is used.
 func (j *JobRunner) buildCommand(module, operation string) string {
-	statePath := "/workspace/state/terraform.tfstate"
 	chdir := "-chdir=/workspace/module"
+	initFlags := `-upgrade -backend-config=in_cluster_config=true`
 	switch operation {
 	case "destroy":
 		return fmt.Sprintf(
-			`tofu %s init -upgrade && tofu %s destroy -auto-approve -state=%s`,
-			chdir, chdir, statePath,
+			`tofu %s init %s && tofu %s destroy -auto-approve`,
+			chdir, initFlags, chdir,
 		)
 	case "output":
 		return fmt.Sprintf(
-			`tofu %s output -json -state=%s`,
-			chdir, statePath,
+			`tofu %s output -json`,
+			chdir,
 		)
 	default: // "apply"
 		return fmt.Sprintf(
-			`tofu %s init -upgrade && tofu %s apply -auto-approve -state=%s`,
-			chdir, chdir, statePath,
+			`tofu %s init %s && tofu %s apply -auto-approve`,
+			chdir, initFlags, chdir,
 		)
 	}
 }

--- a/internal/platform/opentofux/runner.go
+++ b/internal/platform/opentofux/runner.go
@@ -12,8 +12,9 @@ import "context"
 // Two implementations are provided:
 //   - LocalRunner: runs `tofu` as a local subprocess (dev/test; used before
 //     a management cluster exists).
-//   - JobRunner: creates Kubernetes resources (ConfigMap, PVC, Secret, Job)
-//     on the management cluster and streams pod logs.
+//   - JobRunner: creates Kubernetes resources (ConfigMap, Secret, Job)
+//     on the management cluster and streams pod logs. State is stored in
+//     Kubernetes Secrets via the OpenTofu kubernetes backend (no PVCs).
 type Runner interface {
 	// Apply runs `tofu init && tofu apply -auto-approve` with the given
 	// variable map, creating or updating resources.

--- a/internal/platform/opentofux/runner_test.go
+++ b/internal/platform/opentofux/runner_test.go
@@ -275,14 +275,16 @@ func TestBuildJobSpec(t *testing.T) {
 		t.Errorf("envFrom: %+v", containers[0].EnvFrom)
 	}
 	// KUBE_NAMESPACE must be set so the kubernetes backend targets yage-system.
-	kubeNsFound := false
-	for _, e := range containers[0].Env {
-		if e.Name == "KUBE_NAMESPACE" && e.Value == "yage-system" {
-			kubeNsFound = true
-		}
+	// TF_DATA_DIR must redirect tofu's plugin cache off the read-only ConfigMap mount.
+	wantEnvs := map[string]string{
+		"KUBE_NAMESPACE": "yage-system",
+		"TF_DATA_DIR":    "/tmp/.terraform",
 	}
-	if !kubeNsFound {
-		t.Errorf("container missing KUBE_NAMESPACE=yage-system env var; got: %+v", containers[0].Env)
+	for _, e := range containers[0].Env {
+		delete(wantEnvs, e.Name)
+	}
+	if len(wantEnvs) > 0 {
+		t.Errorf("container missing required env vars: %v; got: %+v", wantEnvs, containers[0].Env)
 	}
 	// No state volume — state lives in a Kubernetes Secret via the backend.
 	for _, vol := range podSpec.Volumes {

--- a/internal/platform/opentofux/runner_test.go
+++ b/internal/platform/opentofux/runner_test.go
@@ -101,29 +101,6 @@ func TestJobRunnerTofuImageRef(t *testing.T) {
 	}
 }
 
-func TestJobRunnerStorageClassName(t *testing.T) {
-	tests := []struct {
-		name            string
-		csiDefaultClass string
-		proxmoxClass    string
-		want            string
-	}{
-		{"all-empty", "", "", "standard"},
-		{"proxmox-only", "", "proxmox-csi", "proxmox-csi"},
-		{"csi-default-wins", "fast-ssd", "proxmox-csi", "fast-ssd"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := config.Load()
-			cfg.CSI.DefaultClass = tt.csiDefaultClass
-			cfg.Providers.Proxmox.CSIStorageClassName = tt.proxmoxClass
-			j := &JobRunner{cfg: cfg, client: fakeClient()}
-			if got := j.storageClassName(); got != tt.want {
-				t.Errorf("storageClassName: got %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestJobRunnerBuildCommand(t *testing.T) {
 	j := &JobRunner{cfg: config.Load(), client: fakeClient()}
@@ -143,48 +120,27 @@ func TestJobRunnerBuildCommand(t *testing.T) {
 	}
 }
 
-func TestJobRunnerBuildCommandStateFlag(t *testing.T) {
+func TestJobRunnerBuildCommandNoStateFlag(t *testing.T) {
 	j := &JobRunner{cfg: config.Load(), client: fakeClient()}
-	cmd := j.buildCommand("proxmox", "apply")
-	if !containsStr(cmd, "-state=/workspace/state/terraform.tfstate") {
-		t.Errorf("buildCommand did not include -state flag: %q", cmd)
+	for _, op := range []string{"apply", "destroy", "output"} {
+		cmd := j.buildCommand("proxmox", op)
+		if containsStr(cmd, "-state=") {
+			t.Errorf("buildCommand(%q): unexpected -state= flag in %q (state is kept in kubernetes backend)", op, cmd)
+		}
 	}
 }
 
-func TestEnsureStatePVCCreatesWhenAbsent(t *testing.T) {
-	cfg := config.Load()
-	cfg.CSI.DefaultClass = "test-class"
-	cl := fakeClient()
-	j := &JobRunner{cfg: cfg, client: cl}
-	ctx := context.Background()
-
-	if err := j.ensureStatePVC(ctx, "yage-system", "tofu-state-mymodule"); err != nil {
-		t.Fatalf("ensureStatePVC: %v", err)
-	}
-	pvc, err := cl.Typed.CoreV1().PersistentVolumeClaims("yage-system").Get(ctx, "tofu-state-mymodule", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get pvc: %v", err)
-	}
-	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "test-class" {
-		t.Errorf("storageClassName: got %v, want test-class", pvc.Spec.StorageClassName)
+func TestJobRunnerBuildCommandInClusterBackend(t *testing.T) {
+	j := &JobRunner{cfg: config.Load(), client: fakeClient()}
+	// apply and destroy must pass in_cluster_config to tofu init.
+	for _, op := range []string{"apply", "destroy"} {
+		cmd := j.buildCommand("proxmox", op)
+		if !containsStr(cmd, "in_cluster_config=true") {
+			t.Errorf("buildCommand(%q): -backend-config=in_cluster_config=true not found in %q", op, cmd)
+		}
 	}
 }
 
-func TestEnsureStatePVCIdempotent(t *testing.T) {
-	cfg := config.Load()
-	cl := fakeClient()
-	j := &JobRunner{cfg: cfg, client: cl}
-	ctx := context.Background()
-
-	// Create once.
-	if err := j.ensureStatePVC(ctx, "yage-system", "tofu-state-idempotent"); err != nil {
-		t.Fatalf("first ensureStatePVC: %v", err)
-	}
-	// Call again — must not error.
-	if err := j.ensureStatePVC(ctx, "yage-system", "tofu-state-idempotent"); err != nil {
-		t.Fatalf("second ensureStatePVC: %v", err)
-	}
-}
 
 func TestEnsureCredsSecretEncodesTFVars(t *testing.T) {
 	cfg := config.Load()
@@ -294,7 +250,7 @@ func TestBuildJobSpec(t *testing.T) {
 	cfg.ImageRegistryMirror = ""
 	j := &JobRunner{cfg: cfg, client: fakeClient()}
 
-	job := j.buildJob("yage-system", "tofu-proxmox-apply", "tofu-module-proxmox", "tofu-state-proxmox", "tofu-creds-proxmox", "proxmox", "apply")
+	job := j.buildJob("yage-system", "tofu-proxmox-apply", "tofu-module-proxmox", "tofu-creds-proxmox", "proxmox", "apply")
 
 	if job.Name != "tofu-proxmox-apply" {
 		t.Errorf("job name: %q", job.Name)
@@ -302,7 +258,12 @@ func TestBuildJobSpec(t *testing.T) {
 	if job.Namespace != "yage-system" {
 		t.Errorf("job namespace: %q", job.Namespace)
 	}
-	containers := job.Spec.Template.Spec.Containers
+	podSpec := job.Spec.Template.Spec
+	// ServiceAccountName must be yage-job-runner for kubernetes backend RBAC.
+	if podSpec.ServiceAccountName != "yage-job-runner" {
+		t.Errorf("ServiceAccountName: got %q, want %q", podSpec.ServiceAccountName, "yage-job-runner")
+	}
+	containers := podSpec.Containers
 	if len(containers) != 1 {
 		t.Fatalf("expected 1 container, got %d", len(containers))
 	}
@@ -313,9 +274,30 @@ func TestBuildJobSpec(t *testing.T) {
 	if len(containers[0].EnvFrom) != 1 || containers[0].EnvFrom[0].SecretRef.Name != "tofu-creds-proxmox" {
 		t.Errorf("envFrom: %+v", containers[0].EnvFrom)
 	}
+	// KUBE_NAMESPACE must be set so the kubernetes backend targets yage-system.
+	kubeNsFound := false
+	for _, e := range containers[0].Env {
+		if e.Name == "KUBE_NAMESPACE" && e.Value == "yage-system" {
+			kubeNsFound = true
+		}
+	}
+	if !kubeNsFound {
+		t.Errorf("container missing KUBE_NAMESPACE=yage-system env var; got: %+v", containers[0].Env)
+	}
+	// No state volume — state lives in a Kubernetes Secret via the backend.
+	for _, vol := range podSpec.Volumes {
+		if vol.Name == "state" {
+			t.Errorf("unexpected 'state' volume in pod spec (state is in kubernetes backend Secret)")
+		}
+	}
+	for _, mount := range containers[0].VolumeMounts {
+		if mount.Name == "state" {
+			t.Errorf("unexpected 'state' volume mount in container")
+		}
+	}
 }
 
-func TestJobRunnerEnsureNamespaceBeforeJob(t *testing.T) {
+func TestJobRunnerEnsureCredsSecretWithNamespace(t *testing.T) {
 	cfg := config.Load()
 
 	// Pre-create the namespace so EnsureNamespace won't fail with the fake client.
@@ -324,10 +306,10 @@ func TestJobRunnerEnsureNamespaceBeforeJob(t *testing.T) {
 	})
 	j := &JobRunner{cfg: cfg, client: cl}
 
-	// ensureStatePVC requires the namespace; using it as a lightweight integration.
+	// Verify that ensureCredsSecret works when the namespace already exists.
 	ctx := context.Background()
-	if err := j.ensureStatePVC(ctx, "yage-system", "tofu-state-nstest"); err != nil {
-		t.Fatalf("ensureStatePVC with existing namespace: %v", err)
+	if err := j.ensureCredsSecret(ctx, "yage-system", "tofu-creds-nstest", map[string]string{"key": "val"}); err != nil {
+		t.Fatalf("ensureCredsSecret with existing namespace: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove `ensureStatePVC` / `storageClassName` from `JobRunner` — tofu state PVCs (`tofu-state-<module>`) are eliminated; state is now stored as Kubernetes Secrets via the OpenTofu `kubernetes` backend (`tfstate-default-<module>` in `yage-system`)
- Add `ServiceAccountName: "yage-job-runner"` to the Job pod spec — the SA (provisioned by `EnsureYageSystemOnCluster`, PR #150) has RBAC to read/write Secrets in `yage-system`
- Add `KUBE_NAMESPACE=yage-system` env var so the backend writes to the correct namespace
- Pass `-backend-config=in_cluster_config=true` to `tofu init` so the backend authenticates via the pod's ServiceAccount token (no kubeconfig inside containers); this flag is kept out of the HCL `backend.tf` files so modules remain usable from a local workstation

Companion PR: https://github.com/lpasquali/yage-tofu/pull/2 (adds `backend.tf` to all 8 provider modules)

Closes #145

## Test plan

- [x] `make build` clean
- [x] `go test ./internal/platform/opentofux/...` — 17 tests pass
- [ ] After `tofu apply` in-cluster, verify Secret `tfstate-default-<module>` exists in `yage-system` with both `app.kubernetes.io/managed-by=yage` and `app.kubernetes.io/component=tofu-state` labels
- [ ] Verify no `tofu-state-<module>` PVCs are created during bootstrap
- [ ] `tofu destroy` (--purge) reads state from Secret correctly
- [ ] Re-run (apply → apply) is idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)