### PR TITLE
feat(opentofux): implement EnsureRepoSync — yage-repos PVC + yage-repo-sync Job (ADR 0010, #144)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1162,14 +1162,27 @@ type Config struct {
 	// Env: YAGE_ISSUING_CA_ROOT_KEY.
 	IssuingCARootKey string
 
+	// TofuRepo is the Git URL of the yage-tofu repository.
+	// Defaults to "https://github.com/lpasquali/yage-tofu". Env: YAGE_TOFU_REPO.
+	TofuRepo string
+
 	// TofuRef is the Git ref of the lpasquali/yage-tofu repo to use.
 	// Defaults to main. Env: YAGE_TOFU_REF.
 	TofuRef string
+
+	// ManifestsRepo is the Git URL of the yage-manifests repository.
+	// Defaults to "https://github.com/lpasquali/yage-manifests". Env: YAGE_MANIFESTS_REPO.
+	ManifestsRepo string
 
 	// ManifestsRef is the git tag or branch of the lpasquali/yage-manifests
 	// repository that manifests.Fetcher clones/checks-out. Defaults to "v0.1.0"
 	// (ADR 0008 §5). Env: YAGE_MANIFESTS_REF.
 	ManifestsRef string
+
+	// ReposPVCSize is the size of the yage-repos PersistentVolumeClaim used
+	// by the yage-repo-sync Job to store cloned repositories. Defaults to "500Mi".
+	// Env: YAGE_REPOS_PVC_SIZE.
+	ReposPVCSize string
 }
 
 // Load reads environment variables and applies defaults to produce a
@@ -1252,8 +1265,11 @@ func Load() *Config {
 	c.HelmRepoMirror = strings.TrimRight(strings.TrimSpace(getenv("YAGE_HELM_REPO_MIRROR", "")), "/")
 	c.NodeImage = strings.TrimSpace(getenv("YAGE_NODE_IMAGE", ""))
 	c.TraceEndpoint = getenv("YAGE_TRACE_ENDPOINT", "")
+	c.TofuRepo = getenv("YAGE_TOFU_REPO", "https://github.com/lpasquali/yage-tofu")
 	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
+	c.ManifestsRepo = getenv("YAGE_MANIFESTS_REPO", "https://github.com/lpasquali/yage-manifests")
 	c.ManifestsRef = getenv("YAGE_MANIFESTS_REF", "v0.1.0")
+	c.ReposPVCSize = getenv("YAGE_REPOS_PVC_SIZE", "500Mi")
 
 	// --- On-prem platform services (Phase H, ADR 0009) ---
 	c.RegistryNode = getenv("YAGE_REGISTRY_NODE", "")

--- a/internal/config/snapshot.go
+++ b/internal/config/snapshot.go
@@ -331,8 +331,11 @@ func (c *Config) Snapshot() []SnapshotField {
 		sp("YAGE_REGISTRY_NETWORK", &c.RegistryNetwork),
 		sp("YAGE_REGISTRY_STORAGE", &c.RegistryStorage),
 		sp("YAGE_REGISTRY_FLAVOR", &c.RegistryFlavor),
+		sp("YAGE_TOFU_REPO", &c.TofuRepo),
 		sp("YAGE_TOFU_REF", &c.TofuRef),
+		sp("YAGE_MANIFESTS_REPO", &c.ManifestsRepo),
 		sp("YAGE_MANIFESTS_REF", &c.ManifestsRef),
+		sp("YAGE_REPOS_PVC_SIZE", &c.ReposPVCSize),
 	}
 }
 

--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -803,6 +803,19 @@ func Run(ctx context.Context, cfg *config.Config) int {
 	}
 	phGroup.End()
 
+	// --- Bootstrap yage-system RBAC + repo sync on kind ---
+	// EnsureYageSystemOnCluster creates the yage-job-runner ServiceAccount,
+	// Role, and RoleBinding in yage-system so that subsequent Job pods can
+	// run. EnsureRepoSync then clones yage-tofu and yage-manifests into the
+	// yage-repos PVC so OpenTofu Job runners can find their HCL modules.
+	// Both run against the kind cluster (mgmtCli points to kind at this stage).
+	if err := kindsync.EnsureYageSystemOnCluster(ctx, mgmtCli); err != nil {
+		logx.Die("EnsureYageSystemOnCluster: %v", err)
+	}
+	if err := opentofux.EnsureRepoSync(ctx, mgmtCli, cfg); err != nil {
+		logx.Die("EnsureRepoSync: %v", err)
+	}
+
 	// --- Pivot ---
 	// CAPI bootstrap-and-pivot pattern. With PivotEnabled (the
 	// default): kind provisions a single-node management cluster on
@@ -875,6 +888,18 @@ func Run(ctx context.Context, cfg *config.Config) int {
 		}
 		if err := pivot.VerifyParity(cfg, mgmtKubeconfig); err != nil {
 			logx.Die("pivot: VerifyParity: %v", err)
+		}
+		// Ensure yage-system RBAC and repo sync on the real management cluster
+		// (mirrors the kind-cluster step above, but targeting mgmt after pivot).
+		pivotMgmtCli, pivotCliErr := k8sclient.ForKubeconfigFile(mgmtKubeconfig)
+		if pivotCliErr != nil {
+			logx.Die("pivot: kube client for mgmt cluster: %v", pivotCliErr)
+		}
+		if err := kindsync.EnsureYageSystemOnCluster(ctx, pivotMgmtCli); err != nil {
+			logx.Die("pivot: EnsureYageSystemOnCluster on management cluster: %v", err)
+		}
+		if err := opentofux.EnsureRepoSync(ctx, pivotMgmtCli, cfg); err != nil {
+			logx.Die("pivot: EnsureRepoSync on management cluster: %v", err)
 		}
 		if err := rebindKindContextToMgmt(cfg, mgmtKubeconfig); err != nil {
 			logx.Die("pivot: rebind kind-%s context to mgmt kubeconfig: %v", cfg.KindClusterName, err)

--- a/internal/platform/opentofux/fetcher.go
+++ b/internal/platform/opentofux/fetcher.go
@@ -4,12 +4,23 @@
 package opentofux
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/logx"
 )
 
 // Fetcher resolves yage-tofu module paths from the in-cluster yage-repos PVC.
@@ -31,10 +42,305 @@ func (f *Fetcher) ModulePath(module string) string {
 	return filepath.Join(root, "yage-tofu", module)
 }
 
+const (
+	repoSyncJobName = "yage-repo-sync"
+	reposPVCName    = "yage-repos"
+)
+
+// repoSyncLabels returns labels for yage-repo-sync resources.
+func repoSyncLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "yage",
+		"app.kubernetes.io/component":  "repo-sync",
+	}
+}
+
+// repoSyncStorageClass returns the StorageClass to use for the yage-repos PVC,
+// using the same priority chain as JobRunner.storageClassName():
+//  1. cfg.CSI.DefaultClass
+//  2. cfg.Providers.Proxmox.CSIStorageClassName
+//  3. "standard" (kind's local-path provisioner default)
+func repoSyncStorageClass(cfg *config.Config) string {
+	if cfg.CSI.DefaultClass != "" {
+		return cfg.CSI.DefaultClass
+	}
+	if cfg.Providers.Proxmox.CSIStorageClassName != "" {
+		return cfg.Providers.Proxmox.CSIStorageClassName
+	}
+	return "standard"
+}
+
+// repoSyncImagePrefix prepends the mirror prefix to an image reference.
+// When cfg.ImageRegistryMirror is empty, the image is returned as-is.
+// When set, the mirror is prepended with "/": <mirror>/<image>.
+// Unlike tofuImageRef, Docker Hub images have no host prefix to strip.
+func repoSyncImageRef(cfg *config.Config, image string) string {
+	if cfg.ImageRegistryMirror != "" {
+		return cfg.ImageRegistryMirror + "/" + image
+	}
+	return image
+}
+
+// reposPVCSize returns the storage size for the yage-repos PVC.
+// Falls back to "500Mi" when the config field is empty.
+func reposPVCSize(cfg *config.Config) string {
+	if cfg.ReposPVCSize != "" {
+		return cfg.ReposPVCSize
+	}
+	return "500Mi"
+}
+
 // EnsureRepoSync creates the yage-repos PVC (if absent) and runs the
 // yage-repo-sync Job to clone/fetch yage-tofu and yage-manifests.
-// Full implementation is in issue #144; stub here to establish the
-// function signature in this package.
+// Cluster-agnostic: takes a *k8sclient.Client so it can be called on
+// both the kind bootstrap cluster and the management cluster after pivot.
 func EnsureRepoSync(ctx context.Context, cli *k8sclient.Client, cfg *config.Config) error {
-	return fmt.Errorf("EnsureRepoSync: not yet implemented (see issue #144)")
+	ns := yageNamespace
+
+	// Ensure the namespace exists (defensive; may already be present).
+	if err := cli.EnsureNamespace(ctx, ns); err != nil {
+		return fmt.Errorf("EnsureRepoSync: ensure namespace: %w", err)
+	}
+
+	// Step 1: Create yage-repos PVC (idempotent via SSA).
+	if err := ensureReposPVC(ctx, cli, cfg, ns); err != nil {
+		return fmt.Errorf("EnsureRepoSync: PVC: %w", err)
+	}
+
+	// Step 2: Delete any pre-existing job and submit a fresh one.
+	if err := submitRepoSyncJob(ctx, cli, cfg, ns); err != nil {
+		return fmt.Errorf("EnsureRepoSync: submit job: %w", err)
+	}
+
+	// Step 3: Wait for a pod, stream logs, wait for completion.
+	podName, err := waitForRepoSyncPod(ctx, cli, ns)
+	if err != nil {
+		return fmt.Errorf("EnsureRepoSync: wait for pod: %w", err)
+	}
+	if err := streamRepoSyncLogs(ctx, cli, ns, podName); err != nil {
+		logx.Warn("EnsureRepoSync: log streaming interrupted for pod %s: %v", podName, err)
+	}
+	if err := waitForRepoSyncJob(ctx, cli, ns); err != nil {
+		return fmt.Errorf("EnsureRepoSync: %w", err)
+	}
+
+	// Step 4: Clean up the Job after success.
+	background := metav1.DeletePropagationBackground
+	_ = cli.Typed.BatchV1().Jobs(ns).Delete(ctx, repoSyncJobName, metav1.DeleteOptions{
+		PropagationPolicy: &background,
+	})
+
+	logx.Log("EnsureRepoSync: yage-repos PVC populated (yage-tofu@%s, yage-manifests@%s).",
+		cfg.TofuRef, cfg.ManifestsRef)
+	return nil
 }
+
+// ensureReposPVC server-side-applies the yage-repos PVC.
+func ensureReposPVC(ctx context.Context, cli *k8sclient.Client, cfg *config.Config, ns string) error {
+	sc := repoSyncStorageClass(cfg)
+	pvc := corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reposPVCName,
+			Namespace: ns,
+			Labels:    repoSyncLabels(),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(reposPVCSize(cfg)),
+				},
+			},
+			StorageClassName: &sc,
+		},
+	}
+	body, err := json.Marshal(pvc)
+	if err != nil {
+		return fmt.Errorf("marshal PVC: %w", err)
+	}
+	_, err = cli.Typed.CoreV1().PersistentVolumeClaims(ns).Patch(
+		ctx, reposPVCName, types.ApplyPatchType, body,
+		metav1.PatchOptions{
+			FieldManager: k8sclient.FieldManager,
+			Force:        boolPtrFetcher(true),
+		},
+	)
+	return err
+}
+
+// gitSyncCommand builds the shell command for an init container that
+// clones (or fast-forwards) a git repository at a specific ref.
+func gitSyncCommand(targetDir string) string {
+	return fmt.Sprintf(
+		`if [ -d %s/.git ]; then`+
+			` git -C %s fetch --depth=1 origin "$REF" && git -C %s checkout FETCH_HEAD;`+
+			` else git clone --depth=1 --branch "$REF" "$REPO" %s; fi`,
+		targetDir, targetDir, targetDir, targetDir,
+	)
+}
+
+// submitRepoSyncJob deletes any pre-existing yage-repo-sync Job and creates a fresh one.
+func submitRepoSyncJob(ctx context.Context, cli *k8sclient.Client, cfg *config.Config, ns string) error {
+	// Delete pre-existing job (background propagation to avoid blocking).
+	background := metav1.DeletePropagationBackground
+	_ = cli.Typed.BatchV1().Jobs(ns).Delete(ctx, repoSyncJobName, metav1.DeleteOptions{
+		PropagationPolicy: &background,
+	})
+
+	gitImage := repoSyncImageRef(cfg, "alpine/git:2")
+	busyboxImage := repoSyncImageRef(cfg, "busybox:stable")
+
+	ttl := int32(0)
+	backoffLimit := int32(0)
+
+	job := &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      repoSyncJobName,
+			Namespace: ns,
+			Labels:    repoSyncLabels(),
+		},
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttl,
+			BackoffLimit:            &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: repoSyncLabels(),
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "yage-job-runner",
+					RestartPolicy:      corev1.RestartPolicyNever,
+					InitContainers: []corev1.Container{
+						{
+							Name:  "sync-yage-tofu",
+							Image: gitImage,
+							Env: []corev1.EnvVar{
+								{Name: "REPO", Value: cfg.TofuRepo},
+								{Name: "REF", Value: cfg.TofuRef},
+							},
+							Command: []string{"sh", "-c", gitSyncCommand("/repos/yage-tofu")},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "repos", MountPath: "/repos"},
+							},
+						},
+						{
+							Name:  "sync-yage-manifests",
+							Image: gitImage,
+							Env: []corev1.EnvVar{
+								{Name: "REPO", Value: cfg.ManifestsRepo},
+								{Name: "REF", Value: cfg.ManifestsRef},
+							},
+							Command: []string{"sh", "-c", gitSyncCommand("/repos/yage-manifests")},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "repos", MountPath: "/repos"},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:    "done",
+							Image:   busyboxImage,
+							Command: []string{"true"},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "repos",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: reposPVCName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := cli.Typed.BatchV1().Jobs(ns).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("create job %s: %w", repoSyncJobName, err)
+	}
+	logx.Log("EnsureRepoSync: job %s/%s created; waiting for pod ...", ns, repoSyncJobName)
+	return nil
+}
+
+// waitForRepoSyncPod polls until the yage-repo-sync Job has a pod in
+// Running, Succeeded, or Failed phase. Returns the pod name.
+func waitForRepoSyncPod(ctx context.Context, cli *k8sclient.Client, ns string) (string, error) {
+	var podName string
+	err := k8sclient.PollUntil(ctx, 3*time.Second, 5*time.Minute, func(c context.Context) (bool, error) {
+		pods, err := cli.Typed.CoreV1().Pods(ns).List(c, metav1.ListOptions{
+			LabelSelector: "job-name=" + repoSyncJobName,
+		})
+		if err != nil {
+			return false, nil // transient API error — retry
+		}
+		for i := range pods.Items {
+			p := &pods.Items[i]
+			switch p.Status.Phase {
+			case corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed:
+				podName = p.Name
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("timed out waiting for pod (job %s/%s)", ns, repoSyncJobName)
+	}
+	return podName, nil
+}
+
+// streamRepoSyncLogs streams the pod logs to logx.Log in real time.
+func streamRepoSyncLogs(ctx context.Context, cli *k8sclient.Client, ns, podName string) error {
+	req := cli.Typed.CoreV1().Pods(ns).GetLogs(podName, &corev1.PodLogOptions{
+		Follow: true,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("open log stream for pod %s: %w", podName, err)
+	}
+	defer stream.Close()
+
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		logx.Log("[repo-sync] %s", scanner.Text())
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+// waitForRepoSyncJob polls until the yage-repo-sync Job reaches Complete or Failed.
+func waitForRepoSyncJob(ctx context.Context, cli *k8sclient.Client, ns string) error {
+	return k8sclient.PollUntil(ctx, 5*time.Second, 10*time.Minute, func(c context.Context) (bool, error) {
+		job, err := cli.Typed.BatchV1().Jobs(ns).Get(c, repoSyncJobName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil // transient — retry
+		}
+		for _, cond := range job.Status.Conditions {
+			if cond.Type == batchv1.JobComplete && cond.Status == corev1.ConditionTrue {
+				logx.Log("EnsureRepoSync: job %s/%s completed successfully.", ns, repoSyncJobName)
+				return true, nil
+			}
+			if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+				return true, fmt.Errorf("repo-sync job %s/%s failed: %s", ns, repoSyncJobName, cond.Message)
+			}
+		}
+		return false, nil
+	})
+}
+
+// boolPtrFetcher is a local bool pointer helper (mirrors boolPtr in job_runner.go
+// without introducing a shared unexported name).
+func boolPtrFetcher(b bool) *bool { return &b }

--- a/internal/platform/opentofux/fetcher_test.go
+++ b/internal/platform/opentofux/fetcher_test.go
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package opentofux
+
+// Unit tests for EnsureRepoSync helpers (ADR 0010 §1–2, issue #144).
+//
+// All tests use a fake k8s clientset (no real cluster required).
+// We verify:
+//   - PVC is created with the correct spec (size, storage class, labels)
+//   - Job is created with the correct init containers (images, env vars, order)
+//   - Image mirror prefix is applied correctly when cfg.ImageRegistryMirror is set
+//   - reposPVCSize falls back to "500Mi" when the config field is empty
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// fakeCli returns a k8sclient.Client backed by a fake clientset with the
+// yage-system namespace pre-created (so EnsureNamespace is a no-op).
+func fakeCli(t *testing.T) *k8sclient.Client {
+	t.Helper()
+	cs := k8sfake.NewClientset()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: yageNamespace},
+	}
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("pre-create %s namespace: %v", yageNamespace, err)
+	}
+	return &k8sclient.Client{Typed: cs}
+}
+
+// minCfg returns a minimal config with required repo fields populated.
+// Storage-class and image-mirror fields are zeroed so tests that check
+// defaults are not polluted by environment variables on the test host.
+func minCfg() *config.Config {
+	cfg := config.Load()
+	// Override repo fields to known values for assertions.
+	cfg.TofuRepo = "https://github.com/lpasquali/yage-tofu"
+	cfg.TofuRef = "v1.2.3"
+	cfg.ManifestsRepo = "https://github.com/lpasquali/yage-manifests"
+	cfg.ManifestsRef = "v0.5.0"
+	cfg.ReposPVCSize = "500Mi"
+	cfg.ImageRegistryMirror = ""
+	// Clear storage-class overrides so repoSyncStorageClass returns "standard".
+	cfg.CSI.DefaultClass = ""
+	cfg.Providers.Proxmox.CSIStorageClassName = ""
+	return cfg
+}
+
+// --- reposPVCSize tests ---
+
+func TestReposPVCSizeDefault(t *testing.T) {
+	cfg := config.Load()
+	cfg.ReposPVCSize = ""
+	if got := reposPVCSize(cfg); got != "500Mi" {
+		t.Errorf("reposPVCSize: got %q, want %q", got, "500Mi")
+	}
+}
+
+func TestReposPVCSizeFromConfig(t *testing.T) {
+	cfg := config.Load()
+	cfg.ReposPVCSize = "2Gi"
+	if got := reposPVCSize(cfg); got != "2Gi" {
+		t.Errorf("reposPVCSize: got %q, want %q", got, "2Gi")
+	}
+}
+
+// --- repoSyncStorageClass tests ---
+
+func TestRepoSyncStorageClassDefault(t *testing.T) {
+	cfg := config.Load()
+	cfg.CSI.DefaultClass = ""
+	cfg.Providers.Proxmox.CSIStorageClassName = ""
+	if got := repoSyncStorageClass(cfg); got != "standard" {
+		t.Errorf("repoSyncStorageClass: got %q, want %q", got, "standard")
+	}
+}
+
+func TestRepoSyncStorageClassCSIDefault(t *testing.T) {
+	cfg := config.Load()
+	cfg.CSI.DefaultClass = "fast-ssd"
+	cfg.Providers.Proxmox.CSIStorageClassName = "proxmox-csi"
+	if got := repoSyncStorageClass(cfg); got != "fast-ssd" {
+		t.Errorf("repoSyncStorageClass: CSI default should win, got %q", got)
+	}
+}
+
+func TestRepoSyncStorageClassProxmoxFallback(t *testing.T) {
+	cfg := config.Load()
+	cfg.CSI.DefaultClass = ""
+	cfg.Providers.Proxmox.CSIStorageClassName = "proxmox-csi"
+	if got := repoSyncStorageClass(cfg); got != "proxmox-csi" {
+		t.Errorf("repoSyncStorageClass: Proxmox fallback, got %q, want %q", got, "proxmox-csi")
+	}
+}
+
+// --- repoSyncImageRef tests ---
+
+func TestRepoSyncImageRefNoMirror(t *testing.T) {
+	cfg := config.Load()
+	cfg.ImageRegistryMirror = ""
+	if got := repoSyncImageRef(cfg, "alpine/git:2"); got != "alpine/git:2" {
+		t.Errorf("repoSyncImageRef (no mirror): got %q, want %q", got, "alpine/git:2")
+	}
+}
+
+func TestRepoSyncImageRefWithMirror(t *testing.T) {
+	cfg := config.Load()
+	cfg.ImageRegistryMirror = "harbor.internal/mirror"
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"alpine/git:2", "harbor.internal/mirror/alpine/git:2"},
+		{"busybox:stable", "harbor.internal/mirror/busybox:stable"},
+	}
+	for _, tt := range tests {
+		got := repoSyncImageRef(cfg, tt.image)
+		if got != tt.want {
+			t.Errorf("repoSyncImageRef(%q): got %q, want %q", tt.image, got, tt.want)
+		}
+	}
+}
+
+// --- ensureReposPVC tests ---
+
+func TestEnsureReposPVCCreated(t *testing.T) {
+	cli := fakeCli(t)
+	cfg := minCfg()
+	ctx := context.Background()
+
+	if err := ensureReposPVC(ctx, cli, cfg, yageNamespace); err != nil {
+		t.Fatalf("ensureReposPVC: %v", err)
+	}
+
+	pvc, err := cli.Typed.CoreV1().PersistentVolumeClaims(yageNamespace).
+		Get(ctx, reposPVCName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get PVC: %v", err)
+	}
+
+	// Check name and namespace.
+	if pvc.Name != reposPVCName {
+		t.Errorf("PVC name: got %q, want %q", pvc.Name, reposPVCName)
+	}
+
+	// Check managed-by label.
+	if pvc.Labels["app.kubernetes.io/managed-by"] != "yage" {
+		t.Errorf("PVC label managed-by: %v", pvc.Labels)
+	}
+
+	// Check access mode.
+	if len(pvc.Spec.AccessModes) != 1 || pvc.Spec.AccessModes[0] != corev1.ReadWriteOnce {
+		t.Errorf("PVC access mode: %v", pvc.Spec.AccessModes)
+	}
+
+	// Check storage size.
+	storage := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if storage.String() != "500Mi" {
+		t.Errorf("PVC storage: got %q, want %q", storage.String(), "500Mi")
+	}
+
+	// Check storage class (default = "standard").
+	if pvc.Spec.StorageClassName == nil {
+		t.Errorf("PVC storageClassName: got nil, want standard")
+	} else if *pvc.Spec.StorageClassName != "standard" {
+		t.Errorf("PVC storageClassName: got %q, want standard", *pvc.Spec.StorageClassName)
+	}
+}
+
+func TestEnsureReposPVCCustomSize(t *testing.T) {
+	cli := fakeCli(t)
+	cfg := minCfg()
+	cfg.ReposPVCSize = "2Gi"
+	ctx := context.Background()
+
+	if err := ensureReposPVC(ctx, cli, cfg, yageNamespace); err != nil {
+		t.Fatalf("ensureReposPVC: %v", err)
+	}
+	pvc, err := cli.Typed.CoreV1().PersistentVolumeClaims(yageNamespace).
+		Get(ctx, reposPVCName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get PVC: %v", err)
+	}
+	storage := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if storage.String() != "2Gi" {
+		t.Errorf("PVC storage: got %q, want %q", storage.String(), "2Gi")
+	}
+}
+
+// --- submitRepoSyncJob tests ---
+
+func TestSubmitRepoSyncJobCreated(t *testing.T) {
+	cli := fakeCli(t)
+	cfg := minCfg()
+	ctx := context.Background()
+
+	if err := submitRepoSyncJob(ctx, cli, cfg, yageNamespace); err != nil {
+		t.Fatalf("submitRepoSyncJob: %v", err)
+	}
+
+	job, err := cli.Typed.BatchV1().Jobs(yageNamespace).
+		Get(ctx, repoSyncJobName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get Job: %v", err)
+	}
+
+	// Check job name.
+	if job.Name != repoSyncJobName {
+		t.Errorf("Job name: got %q, want %q", job.Name, repoSyncJobName)
+	}
+
+	// Check service account.
+	if job.Spec.Template.Spec.ServiceAccountName != "yage-job-runner" {
+		t.Errorf("ServiceAccountName: got %q, want yage-job-runner",
+			job.Spec.Template.Spec.ServiceAccountName)
+	}
+
+	// Check restart policy.
+	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("RestartPolicy: got %q, want Never", job.Spec.Template.Spec.RestartPolicy)
+	}
+
+	// Check exactly 2 init containers.
+	initContainers := job.Spec.Template.Spec.InitContainers
+	if len(initContainers) != 2 {
+		t.Fatalf("InitContainers count: got %d, want 2", len(initContainers))
+	}
+
+	// First init container: sync-yage-tofu.
+	ic0 := initContainers[0]
+	if ic0.Name != "sync-yage-tofu" {
+		t.Errorf("InitContainer[0].Name: got %q, want sync-yage-tofu", ic0.Name)
+	}
+	if ic0.Image != "alpine/git:2" {
+		t.Errorf("InitContainer[0].Image: got %q, want alpine/git:2", ic0.Image)
+	}
+	assertEnvVar(t, ic0.Env, "REPO", cfg.TofuRepo)
+	assertEnvVar(t, ic0.Env, "REF", cfg.TofuRef)
+
+	// Second init container: sync-yage-manifests.
+	ic1 := initContainers[1]
+	if ic1.Name != "sync-yage-manifests" {
+		t.Errorf("InitContainer[1].Name: got %q, want sync-yage-manifests", ic1.Name)
+	}
+	if ic1.Image != "alpine/git:2" {
+		t.Errorf("InitContainer[1].Image: got %q, want alpine/git:2", ic1.Image)
+	}
+	assertEnvVar(t, ic1.Env, "REPO", cfg.ManifestsRepo)
+	assertEnvVar(t, ic1.Env, "REF", cfg.ManifestsRef)
+
+	// Check the main "done" container.
+	containers := job.Spec.Template.Spec.Containers
+	if len(containers) != 1 {
+		t.Fatalf("Containers count: got %d, want 1", len(containers))
+	}
+	if containers[0].Name != "done" {
+		t.Errorf("Container[0].Name: got %q, want done", containers[0].Name)
+	}
+	if containers[0].Image != "busybox:stable" {
+		t.Errorf("Container[0].Image: got %q, want busybox:stable", containers[0].Image)
+	}
+
+	// Check the repos volume references the correct PVC.
+	volumes := job.Spec.Template.Spec.Volumes
+	if len(volumes) != 1 || volumes[0].Name != "repos" {
+		t.Fatalf("Volumes: got %+v, want single repos volume", volumes)
+	}
+	if volumes[0].PersistentVolumeClaim == nil ||
+		volumes[0].PersistentVolumeClaim.ClaimName != reposPVCName {
+		t.Errorf("Volume repos PVC claim: got %v, want %q",
+			volumes[0].PersistentVolumeClaim, reposPVCName)
+	}
+
+	// Check TTL is set to 0.
+	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 0 {
+		t.Errorf("TTLSecondsAfterFinished: got %v, want 0", job.Spec.TTLSecondsAfterFinished)
+	}
+}
+
+func TestSubmitRepoSyncJobWithMirror(t *testing.T) {
+	cli := fakeCli(t)
+	cfg := minCfg()
+	cfg.ImageRegistryMirror = "registry.internal"
+	ctx := context.Background()
+
+	if err := submitRepoSyncJob(ctx, cli, cfg, yageNamespace); err != nil {
+		t.Fatalf("submitRepoSyncJob: %v", err)
+	}
+
+	job, err := cli.Typed.BatchV1().Jobs(yageNamespace).
+		Get(ctx, repoSyncJobName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get Job: %v", err)
+	}
+
+	initContainers := job.Spec.Template.Spec.InitContainers
+	if len(initContainers) < 2 {
+		t.Fatalf("expected 2 init containers, got %d", len(initContainers))
+	}
+
+	wantGitImage := "registry.internal/alpine/git:2"
+	for i, ic := range initContainers {
+		if ic.Image != wantGitImage {
+			t.Errorf("InitContainer[%d].Image: got %q, want %q", i, ic.Image, wantGitImage)
+		}
+	}
+
+	wantBusybox := "registry.internal/busybox:stable"
+	containers := job.Spec.Template.Spec.Containers
+	if len(containers) > 0 && containers[0].Image != wantBusybox {
+		t.Errorf("Container[0].Image: got %q, want %q", containers[0].Image, wantBusybox)
+	}
+}
+
+func TestSubmitRepoSyncJobNoMirror(t *testing.T) {
+	cli := fakeCli(t)
+	cfg := minCfg()
+	cfg.ImageRegistryMirror = ""
+	ctx := context.Background()
+
+	if err := submitRepoSyncJob(ctx, cli, cfg, yageNamespace); err != nil {
+		t.Fatalf("submitRepoSyncJob: %v", err)
+	}
+	job, err := cli.Typed.BatchV1().Jobs(yageNamespace).
+		Get(ctx, repoSyncJobName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get Job: %v", err)
+	}
+	// Without mirror, images should be plain Docker Hub references.
+	for i, ic := range job.Spec.Template.Spec.InitContainers {
+		if ic.Image != "alpine/git:2" {
+			t.Errorf("InitContainer[%d].Image (no mirror): got %q, want alpine/git:2", i, ic.Image)
+		}
+	}
+	if len(job.Spec.Template.Spec.Containers) > 0 {
+		if job.Spec.Template.Spec.Containers[0].Image != "busybox:stable" {
+			t.Errorf("Container[0].Image (no mirror): got %q, want busybox:stable",
+				job.Spec.Template.Spec.Containers[0].Image)
+		}
+	}
+}
+
+// assertEnvVar asserts that the named env var exists with the expected value.
+func assertEnvVar(t *testing.T, envVars []corev1.EnvVar, name, want string) {
+	t.Helper()
+	for _, ev := range envVars {
+		if ev.Name == name {
+			if ev.Value != want {
+				t.Errorf("env var %q: got %q, want %q", name, ev.Value, want)
+			}
+			return
+		}
+	}
+	t.Errorf("env var %q not found in %+v", name, envVars)
+}


### PR DESCRIPTION
## Summary

- Replaces the `EnsureRepoSync` stub in `internal/platform/opentofux/fetcher.go` with a full implementation (ADR 0010 §1–2, closes #144)
- Creates the `yage-repos` PVC idempotently via server-side apply (SSA); honours storage-class priority chain: `CSI.DefaultClass` → `Providers.Proxmox.CSIStorageClassName` → `"standard"`
- Runs the `yage-repo-sync` batch Job (two init containers: `sync-yage-tofu` and `sync-yage-manifests`, both `alpine/git:2`; `done` main container with `busybox:stable`); streams logs, waits for completion, then deletes the Job
- Image registry mirror support: when `YAGE_IMAGE_REGISTRY_MIRROR` is set, both init and main container images are prefixed accordingly
- Wires `EnsureYageSystemOnCluster` + `EnsureRepoSync` in `internal/orchestrator/bootstrap.go` on **both** the kind-cluster path (after `phGroup.End()`, cluster is running) and the post-pivot management cluster path (after `pivot.VerifyParity`)
- Adds three new config fields surfaced as env vars:
  - `YAGE_TOFU_REPO` (default `https://github.com/lpasquali/yage-tofu`)
  - `YAGE_MANIFESTS_REPO` (default `https://github.com/lpasquali/yage-manifests`)
  - `YAGE_REPOS_PVC_SIZE` (default `500Mi`)
- All three fields are included in `config.Snapshot()` for persistence to the kind bootstrap-config Secret
- Adds unit tests in `internal/platform/opentofux/fetcher_test.go` (fake clientset, no real cluster required): PVC creation (name, labels, access mode, storage size, storage class), Job creation (ServiceAccountName, RestartPolicy, init containers count/names/images/env vars, done container, volume PVC claim, TTL), image mirror on both init and main containers

## Test plan

- [ ] `make build` passes
- [ ] `go test ./internal/platform/opentofux/...` — all 11 new tests pass
- [ ] `go test ./...` — no regressions
- [ ] Integration: run `yage bootstrap` against a kind cluster, verify `yage-repos` PVC and `yage-repo-sync` Job lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)