### PR TITLE
feat(kindsync+pivot): label-based yage-system handoff + extended VerifyParity (#148)

### DIFF
--- a/internal/capi/pivot/pivot.go
+++ b/internal/capi/pivot/pivot.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/kind/pkg/cluster"
 
 	"github.com/lpasquali/yage/internal/config"
@@ -20,6 +22,16 @@ import (
 	"github.com/lpasquali/yage/internal/platform/kubectl"
 	"github.com/lpasquali/yage/internal/provider"
 	"github.com/lpasquali/yage/internal/ui/logx"
+)
+
+// yageSystemNamespace / yageReposPVCName / yageManagedBySelector mirror
+// the constants used by internal/cluster/kindsync. Inlined (rather than
+// importing kindsync for three string constants) to keep this package's
+// dep graph minimal.
+const (
+	yageSystemNamespace   = "yage-system"
+	yageReposPVCName      = "yage-repos"
+	yageManagedBySelector = "app.kubernetes.io/managed-by=yage"
 )
 
 // EnsureManagementCluster provisions the management cluster on Proxmox
@@ -256,13 +268,88 @@ func VerifyParity(cfg *config.Config, mgmtKubeconfig string) error {
 			}
 		}
 
+		// (d) yage-system namespace present on mgmt (ADR 0011 §6.a).
 		if lastErr == nil {
-			logx.Log("Parity verified: workload Cluster + bootstrap Secrets + CAPI controllers all present on mgmt.")
+			if err := checkYageSystemNamespace(bg, cli.Typed); err != nil {
+				lastErr = err
+			}
+		}
+
+		// (e) Labeled yage-system Secrets present (ADR 0011 §6.b).
+		// Zero is a warning, not fatal — a first-run with no tofu modules
+		// executed yet has no tfstate Secrets to copy.
+		if lastErr == nil {
+			if err := checkLabeledYageSystemSecrets(bg, cli.Typed); err != nil {
+				lastErr = err
+			}
+		}
+
+		// (f) yage-repos PVC Bound (ADR 0011 §6.c).
+		if lastErr == nil {
+			if err := checkYageReposPVCBound(bg, cli.Typed); err != nil {
+				lastErr = err
+			}
+		}
+
+		if lastErr == nil {
+			logx.Log("Parity verified: workload Cluster + bootstrap Secrets + CAPI controllers + yage-system + yage-repos PVC all present on mgmt.")
 			return nil
 		}
 		time.Sleep(5 * time.Second)
 	}
 	return fmt.Errorf("parity not reached within %s: %v", timeout, lastErr)
+}
+
+// checkYageSystemNamespace verifies the yage-system namespace exists on
+// the management cluster (created by HandOff via EnsureNamespace, then
+// re-asserted by EnsureYageSystemOnCluster). Returns a typed error so
+// VerifyParity's poll loop can retry it transparently.
+func checkYageSystemNamespace(ctx context.Context, typed kubernetes.Interface) error {
+	if _, err := typed.CoreV1().Namespaces().Get(ctx, yageSystemNamespace, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("namespace %s not on mgmt yet", yageSystemNamespace)
+		}
+		return fmt.Errorf("get namespace %s on mgmt: %w", yageSystemNamespace, err)
+	}
+	return nil
+}
+
+// checkLabeledYageSystemSecrets lists Secrets in yage-system carrying
+// app.kubernetes.io/managed-by=yage on the management cluster. Per
+// ADR 0011 §6.b zero matches is a WARNING (handed-off cleanly but no
+// tofu state had been written when pivot ran) and one+ is the steady
+// state. Listing errors are reported so the poll loop can retry.
+func checkLabeledYageSystemSecrets(ctx context.Context, typed kubernetes.Interface) error {
+	list, err := typed.CoreV1().Secrets(yageSystemNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: yageManagedBySelector,
+	})
+	if err != nil {
+		return fmt.Errorf("list labeled %s Secrets on mgmt: %w", yageSystemNamespace, err)
+	}
+	if len(list.Items) == 0 {
+		logx.Warn("VerifyParity: zero Secrets in %s carry %s on mgmt — first-run with no tofu state yet?",
+			yageSystemNamespace, yageManagedBySelector)
+	}
+	return nil
+}
+
+// checkYageReposPVCBound verifies the yage-repos PVC in yage-system on
+// the management cluster is in the Bound phase. A Pending PVC here
+// indicates a StorageClass problem — surface it with a clear diagnostic
+// before the first post-pivot tofu Job runs (ADR 0011 §6.c).
+func checkYageReposPVCBound(ctx context.Context, typed kubernetes.Interface) error {
+	pvc, err := typed.CoreV1().PersistentVolumeClaims(yageSystemNamespace).Get(ctx, yageReposPVCName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("pvc %s/%s not on mgmt yet", yageSystemNamespace, yageReposPVCName)
+		}
+		return fmt.Errorf("get pvc %s/%s on mgmt: %w", yageSystemNamespace, yageReposPVCName, err)
+	}
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return fmt.Errorf("pvc %s/%s phase=%s, want Bound (StorageClass problem on mgmt?)",
+			yageSystemNamespace, yageReposPVCName, pvc.Status.Phase)
+	}
+	return nil
 }
 
 // TeardownKind deletes the kind cluster after a successful pivot. Honors

--- a/internal/capi/pivot/verifyparity_test.go
+++ b/internal/capi/pivot/verifyparity_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package pivot
+
+// Tests for the three VerifyParity helpers added per ADR 0011 §6:
+//
+//   - checkYageSystemNamespace          (§6.a)
+//   - checkLabeledYageSystemSecrets     (§6.b — zero is a warning, not fatal)
+//   - checkYageReposPVCBound            (§6.c)
+//
+// Each helper takes a kubernetes.Interface so a fake clientset is enough
+// to drive the present/absent and bound/pending paths.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func newFake(objs ...interface{}) kubernetes.Interface {
+	cs := k8sfake.NewClientset()
+	ctx := context.Background()
+	for _, o := range objs {
+		switch v := o.(type) {
+		case *corev1.Namespace:
+			_, _ = cs.CoreV1().Namespaces().Create(ctx, v, metav1.CreateOptions{})
+		case *corev1.Secret:
+			_, _ = cs.CoreV1().Secrets(v.Namespace).Create(ctx, v, metav1.CreateOptions{})
+		case *corev1.PersistentVolumeClaim:
+			_, _ = cs.CoreV1().PersistentVolumeClaims(v.Namespace).Create(ctx, v, metav1.CreateOptions{})
+		}
+	}
+	return cs
+}
+
+func mkNS(name string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func mkLabeledSecret(ns, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{"app.kubernetes.io/managed-by": "yage"},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+func mkPVC(ns, name string, phase corev1.PersistentVolumeClaimPhase) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: phase},
+	}
+}
+
+// --- checkYageSystemNamespace ------------------------------------------------
+
+func TestCheckYageSystemNamespace_Present(t *testing.T) {
+	cs := newFake(mkNS(yageSystemNamespace))
+	if err := checkYageSystemNamespace(context.Background(), cs); err != nil {
+		t.Errorf("present case returned err: %v", err)
+	}
+}
+
+func TestCheckYageSystemNamespace_Missing(t *testing.T) {
+	cs := newFake()
+	err := checkYageSystemNamespace(context.Background(), cs)
+	if err == nil {
+		t.Fatalf("missing case returned nil err")
+	}
+	if !strings.Contains(err.Error(), yageSystemNamespace) {
+		t.Errorf("error %q does not mention namespace name", err)
+	}
+}
+
+// --- checkLabeledYageSystemSecrets ------------------------------------------
+
+func TestCheckLabeledYageSystemSecrets_OneOrMore(t *testing.T) {
+	cs := newFake(
+		mkNS(yageSystemNamespace),
+		mkLabeledSecret(yageSystemNamespace, "tfstate-default-proxmox"),
+	)
+	if err := checkLabeledYageSystemSecrets(context.Background(), cs); err != nil {
+		t.Errorf("one-or-more case returned err: %v", err)
+	}
+}
+
+func TestCheckLabeledYageSystemSecrets_ZeroIsWarning(t *testing.T) {
+	// ADR 0011 §6.b: zero labeled Secrets is a warning, not a fatal
+	// error — first-run with no tofu state yet. The helper must return
+	// nil so the caller's poll loop converges.
+	cs := newFake(mkNS(yageSystemNamespace))
+	if err := checkLabeledYageSystemSecrets(context.Background(), cs); err != nil {
+		t.Errorf("zero-secrets case returned err %v, want nil (ADR 0011 §6.b warn-don't-fail)", err)
+	}
+}
+
+func TestCheckLabeledYageSystemSecrets_IgnoresUnlabeled(t *testing.T) {
+	// Unlabeled Secrets must not satisfy the §6.b check on their own
+	// — the label is what makes a Secret part of the yage-managed set.
+	// (Steady-state still warns since we want zero matches → nil.)
+	cs := newFake(mkNS(yageSystemNamespace),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: yageSystemNamespace},
+			Type:       corev1.SecretTypeOpaque,
+		},
+	)
+	if err := checkLabeledYageSystemSecrets(context.Background(), cs); err != nil {
+		t.Errorf("unlabeled-only case returned err %v, want nil (warn path)", err)
+	}
+}
+
+// --- checkYageReposPVCBound -------------------------------------------------
+
+func TestCheckYageReposPVCBound_Bound(t *testing.T) {
+	cs := newFake(
+		mkNS(yageSystemNamespace),
+		mkPVC(yageSystemNamespace, yageReposPVCName, corev1.ClaimBound),
+	)
+	if err := checkYageReposPVCBound(context.Background(), cs); err != nil {
+		t.Errorf("Bound case returned err: %v", err)
+	}
+}
+
+func TestCheckYageReposPVCBound_Pending(t *testing.T) {
+	cs := newFake(
+		mkNS(yageSystemNamespace),
+		mkPVC(yageSystemNamespace, yageReposPVCName, corev1.ClaimPending),
+	)
+	err := checkYageReposPVCBound(context.Background(), cs)
+	if err == nil {
+		t.Fatalf("Pending case returned nil err")
+	}
+	if !strings.Contains(err.Error(), "Pending") {
+		t.Errorf("error %q does not mention the actual phase", err)
+	}
+}
+
+func TestCheckYageReposPVCBound_Missing(t *testing.T) {
+	cs := newFake(mkNS(yageSystemNamespace))
+	err := checkYageReposPVCBound(context.Background(), cs)
+	if err == nil {
+		t.Fatalf("missing case returned nil err")
+	}
+	if !strings.Contains(err.Error(), yageReposPVCName) {
+		t.Errorf("error %q does not name the missing PVC", err)
+	}
+}

--- a/internal/cluster/kindsync/handoff.go
+++ b/internal/cluster/kindsync/handoff.go
@@ -44,6 +44,30 @@ const (
 	capmoxLiveSecretName = "capmox-manager-credentials"
 )
 
+// yageManagedBySelector is the label selector used to discover Secrets
+// in yage-system that should be carried across to the management cluster
+// alongside the named-target list (ADR 0011 §2). Matches the label set
+// applied by EnsureYageSystemOnCluster and by the OpenTofu kubernetes
+// backend (ADR 0011 §1).
+const yageManagedBySelector = "app.kubernetes.io/managed-by=yage"
+
+// HandoffResult is the augmented return value of
+// HandOffBootstrapSecretsToManagement. NamedCopied counts Secrets carried
+// across from expectedHandoffTargets and the per-config bootstrap-config
+// pass; LabelCopied counts Secrets discovered in yage-system via the
+// app.kubernetes.io/managed-by=yage label (ADR 0011 §2). FirstErr is the
+// first per-Secret error seen — handoff is best-effort, the caller
+// chains a VerifyParity step after.
+type HandoffResult struct {
+	NamedCopied int
+	LabelCopied int
+	FirstErr    error
+}
+
+// Total returns NamedCopied + LabelCopied so callers that only care about
+// the gross volume can keep their existing log lines.
+func (r HandoffResult) Total() int { return r.NamedCopied + r.LabelCopied }
+
 // handoffTarget describes one Secret to copy from kind → mgmt.
 // Namespace is resolved at call-time so an empty config field
 // (e.g. an unset Providers.Proxmox.BootstrapSecretName) is
@@ -83,24 +107,37 @@ func expectedHandoffTargets(cfg *config.Config) []handoffTarget {
 //   - <Providers.Proxmox.BootstrapSecretName>                (single-Secret form)
 //   - capmox-system/capmox-manager-credentials    (the live capmox copy)
 //
+// After the named-target pass, every Secret in yage-system carrying
+// label app.kubernetes.io/managed-by=yage is discovered and applied to
+// the management cluster (ADR 0011 §2 — label-scoped pass; covers
+// tofu-state Secrets and any future yage-managed Secrets that opt into
+// the label).
+//
 // Both kindCtx and mgmtKubeconfig identify the source / destination. The
-// destination namespace is created when missing. Returns the count of
-// Secrets copied + any error encountered (we keep going on per-Secret
-// failures to maximise data-arrival; the caller chains a VerifyParity
-// step after).
-func HandOffBootstrapSecretsToManagement(cfg *config.Config, kindCtx, mgmtKubeconfig string) (copied int, err error) {
+// destination namespace is created when missing. Returns the per-pass
+// counts plus the first error encountered — handoff is best-effort, the
+// caller chains a VerifyParity step after.
+func HandOffBootstrapSecretsToManagement(cfg *config.Config, kindCtx, mgmtKubeconfig string) (HandoffResult, error) {
 	if cfg == nil {
-		return 0, fmt.Errorf("handoff: nil config")
+		return HandoffResult{}, fmt.Errorf("handoff: nil config")
 	}
 	srcCli, srcErr := k8sclient.ForContext(kindCtx)
 	if srcErr != nil {
-		return 0, fmt.Errorf("handoff: load kind context %q: %w", kindCtx, srcErr)
+		return HandoffResult{}, fmt.Errorf("handoff: load kind context %q: %w", kindCtx, srcErr)
 	}
 	dstCli, dstErr := k8sclient.ForKubeconfigFile(mgmtKubeconfig)
 	if dstErr != nil {
-		return 0, fmt.Errorf("handoff: load management kubeconfig %q: %w", mgmtKubeconfig, dstErr)
+		return HandoffResult{}, fmt.Errorf("handoff: load management kubeconfig %q: %w", mgmtKubeconfig, dstErr)
 	}
 	bg := context.Background()
+	// Tracks (namespace, name) of Secrets already applied via the named
+	// pass so the subsequent label pass cannot double-apply them.
+	copiedKey := func(ns, name string) string { return ns + "/" + name }
+	alreadyCopied := map[string]bool{}
+	var (
+		namedCopied int
+		labelCopied int
+	)
 
 	// Track which destination namespaces we have ensured to avoid duplicate
 	// EnsureNamespace calls (typically only the bootstrap NS + capmox-system).
@@ -196,7 +233,8 @@ func HandOffBootstrapSecretsToManagement(cfg *config.Config, kindCtx, mgmtKubeco
 			continue
 		}
 
-		copied++
+		namedCopied++
+		alreadyCopied[copiedKey(tgt.Namespace, tgt.Name)] = true
 		logx.Log("Hand-off: copied %s/%s (%s) from %s to management cluster.",
 			tgt.Namespace, tgt.Name, tgt.Description, kindCtx)
 	}
@@ -258,13 +296,120 @@ func HandOffBootstrapSecretsToManagement(cfg *config.Config, kindCtx, mgmtKubeco
 				}
 				continue
 			}
-			copied++
+			namedCopied++
+			alreadyCopied[copiedKey(nsName, "bootstrap-config")] = true
 			logx.Log("Hand-off: copied %s/bootstrap-config (config %s) from %s to management cluster.",
 				nsName, src.Labels["yage.io/config-name"], kindCtx)
 		}
 	}
 
-	logx.Log("Hand-off summary: %d Secret(s) copied from kind context %s to management cluster.", copied, kindCtx)
+	// Label-scoped second pass per ADR 0011 §2: every Secret in
+	// yage-system carrying app.kubernetes.io/managed-by=yage that wasn't
+	// already applied above is server-side-applied to the destination.
+	// This is what carries OpenTofu kubernetes-backend state Secrets
+	// (tfstate-default-<module>) and any future yage-managed Secrets that
+	// opt into the label across to mgmt without code changes here.
+	yageNS := YageSystemNamespace
+	if !ensuredNS[yageNS] {
+		if nsErr := dstCli.EnsureNamespace(bg, yageNS); nsErr != nil {
+			logx.Warn("Hand-off: failed to ensure namespace %s on management: %v", yageNS, nsErr)
+			if firstErr == nil {
+				firstErr = nsErr
+			}
+		} else {
+			ensuredNS[yageNS] = true
+		}
+	}
+	if ensuredNS[yageNS] {
+		labelN, labelErr := copyYageSystemSecrets(bg, srcCli, dstCli, yageNS, alreadyCopied, kindCtx)
+		labelCopied = labelN
+		if labelErr != nil && firstErr == nil {
+			firstErr = labelErr
+		}
+	}
+
+	logx.Log("Hand-off summary: %d named + %d labeled = %d Secret(s) copied from kind context %s to management cluster.",
+		namedCopied, labelCopied, namedCopied+labelCopied, kindCtx)
+	return HandoffResult{
+		NamedCopied: namedCopied,
+		LabelCopied: labelCopied,
+		FirstErr:    firstErr,
+	}, firstErr
+}
+
+// copyYageSystemSecrets lists every Secret in namespace ns on srcCli that
+// carries label app.kubernetes.io/managed-by=yage and server-side-applies
+// it to dstCli (Force=true). Secrets whose (namespace, name) appears in
+// skip are not re-applied; the caller passes the keys handled by the
+// named pass to avoid double-counting.
+//
+// Returns the count of Secrets actually applied and the first per-Secret
+// error encountered. Per-Secret failures are warnings — handoff is
+// best-effort, the caller chains a VerifyParity step after.
+func copyYageSystemSecrets(
+	ctx context.Context,
+	srcCli, dstCli *k8sclient.Client,
+	ns string,
+	skip map[string]bool,
+	kindCtx string,
+) (int, error) {
+	list, listErr := srcCli.Typed.CoreV1().Secrets(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: yageManagedBySelector,
+	})
+	if listErr != nil {
+		logx.Warn("Hand-off: failed to list labeled Secrets in %s on kind: %v", ns, listErr)
+		return 0, listErr
+	}
+
+	var (
+		copied   int
+		firstErr error
+	)
+	for i := range list.Items {
+		src := &list.Items[i]
+		key := ns + "/" + src.Name
+		if skip != nil && skip[key] {
+			continue
+		}
+
+		clean := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        src.Name,
+				Namespace:   src.Namespace,
+				Labels:      src.Labels,
+				Annotations: stripServerAnnotations(src.Annotations),
+			},
+			Type:       src.Type,
+			Data:       src.Data,
+			StringData: src.StringData,
+			Immutable:  src.Immutable,
+		}
+		if clean.Type == "" {
+			clean.Type = corev1.SecretTypeOpaque
+		}
+		body, marshalErr := json.Marshal(clean)
+		if marshalErr != nil {
+			logx.Warn("Hand-off: failed to marshal %s/%s: %v", ns, src.Name, marshalErr)
+			if firstErr == nil {
+				firstErr = marshalErr
+			}
+			continue
+		}
+		_, patchErr := dstCli.Typed.CoreV1().Secrets(ns).Patch(
+			ctx, src.Name, types.ApplyPatchType, body,
+			metav1.PatchOptions{FieldManager: k8sclient.FieldManager, Force: boolTrue()},
+		)
+		if patchErr != nil {
+			logx.Warn("Hand-off: failed to apply %s/%s on management: %v", ns, src.Name, patchErr)
+			if firstErr == nil {
+				firstErr = patchErr
+			}
+			continue
+		}
+		copied++
+		logx.Log("Hand-off (label): copied %s/%s from %s to management cluster.", ns, src.Name, kindCtx)
+	}
 	return copied, firstErr
 }
 

--- a/internal/cluster/kindsync/handoff_test.go
+++ b/internal/cluster/kindsync/handoff_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package kindsync
+
+// Tests for the label-scoped second pass of HandOffBootstrapSecretsToManagement
+// (ADR 0011 §2): copyYageSystemSecrets discovers every Secret in yage-system
+// carrying app.kubernetes.io/managed-by=yage on the source (kind) side and
+// server-side-applies it to the destination (mgmt). The named pass already
+// applied some Secrets — those must NOT be re-applied (per-key skip set).
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+)
+
+// makeKindsyncClient builds a Client backed by a fake clientset and
+// pre-creates the yage-system namespace so EnsureNamespace short-circuits.
+func makeKindsyncClient(t *testing.T, objs ...interface{}) *k8sclient.Client {
+	t.Helper()
+	cs := k8sfake.NewClientset()
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: YageSystemNamespace}},
+		metav1.CreateOptions{}); err != nil {
+		t.Fatalf("pre-create %s: %v", YageSystemNamespace, err)
+	}
+	for _, o := range objs {
+		switch v := o.(type) {
+		case *corev1.Secret:
+			if _, err := cs.CoreV1().Secrets(v.Namespace).Create(context.Background(), v, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("seed Secret %s/%s: %v", v.Namespace, v.Name, err)
+			}
+		default:
+			t.Fatalf("unsupported seed type %T", o)
+		}
+	}
+	return &k8sclient.Client{Typed: cs}
+}
+
+func labeledSecret(name string, extra map[string]string) *corev1.Secret {
+	labels := map[string]string{"app.kubernetes.io/managed-by": "yage"}
+	for k, v := range extra {
+		labels[k] = v
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: YageSystemNamespace,
+			Labels:    labels,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"k": []byte("v-" + name)},
+	}
+}
+
+func TestCopyYageSystemSecrets_AppliesAllLabeled(t *testing.T) {
+	src := makeKindsyncClient(t,
+		labeledSecret("tfstate-default-proxmox", nil),
+		labeledSecret("tfstate-default-aws", nil),
+	)
+	// Add an unlabeled Secret that must be ignored.
+	if _, err := src.Typed.CoreV1().Secrets(YageSystemNamespace).Create(context.Background(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: YageSystemNamespace},
+			Type:       corev1.SecretTypeOpaque,
+		}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed unrelated: %v", err)
+	}
+
+	dst := makeKindsyncClient(t)
+
+	n, err := copyYageSystemSecrets(context.Background(), src, dst, YageSystemNamespace, nil, "kind-test")
+	if err != nil {
+		t.Fatalf("copyYageSystemSecrets: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("copied count = %d, want 2", n)
+	}
+	for _, name := range []string{"tfstate-default-proxmox", "tfstate-default-aws"} {
+		if _, err := dst.Typed.CoreV1().Secrets(YageSystemNamespace).Get(context.Background(), name, metav1.GetOptions{}); err != nil {
+			t.Errorf("destination missing %s: %v", name, err)
+		}
+	}
+	if _, err := dst.Typed.CoreV1().Secrets(YageSystemNamespace).Get(context.Background(), "unrelated", metav1.GetOptions{}); err == nil {
+		t.Errorf("unlabeled Secret leaked to destination — label selector ignored")
+	}
+}
+
+func TestCopyYageSystemSecrets_RespectsSkipSet(t *testing.T) {
+	src := makeKindsyncClient(t,
+		labeledSecret("already-handled", nil),
+		labeledSecret("new-one", nil),
+	)
+	dst := makeKindsyncClient(t)
+
+	skip := map[string]bool{
+		YageSystemNamespace + "/already-handled": true,
+	}
+	n, err := copyYageSystemSecrets(context.Background(), src, dst, YageSystemNamespace, skip, "kind-test")
+	if err != nil {
+		t.Fatalf("copyYageSystemSecrets: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("copied count = %d, want 1 (skip set should suppress duplicate)", n)
+	}
+	if _, err := dst.Typed.CoreV1().Secrets(YageSystemNamespace).Get(context.Background(), "already-handled", metav1.GetOptions{}); err == nil {
+		t.Errorf("already-handled Secret was re-applied despite skip set")
+	}
+	if _, err := dst.Typed.CoreV1().Secrets(YageSystemNamespace).Get(context.Background(), "new-one", metav1.GetOptions{}); err != nil {
+		t.Errorf("new-one Secret missing on destination: %v", err)
+	}
+}
+
+func TestCopyYageSystemSecrets_EmptyListReturnsZero(t *testing.T) {
+	src := makeKindsyncClient(t)
+	dst := makeKindsyncClient(t)
+
+	n, err := copyYageSystemSecrets(context.Background(), src, dst, YageSystemNamespace, nil, "kind-test")
+	if err != nil {
+		t.Errorf("expected nil error on empty list, got: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("copied count = %d, want 0", n)
+	}
+}
+
+func TestHandoffResult_TotalSumsCounts(t *testing.T) {
+	cases := []struct {
+		name  string
+		named int
+		label int
+		want  int
+	}{
+		{"both zero", 0, 0, 0},
+		{"only named", 4, 0, 4},
+		{"only label", 0, 7, 7},
+		{"mixed", 3, 5, 8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := HandoffResult{NamedCopied: tc.named, LabelCopied: tc.label}
+			if got := r.Total(); got != tc.want {
+				t.Errorf("Total() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -866,12 +866,33 @@ func Run(ctx context.Context, cfg *config.Config) int {
 			phPivot.End()
 			return 0
 		}
-		copied, err := kindsync.HandOffBootstrapSecretsToManagement(cfg, "kind-"+cfg.KindClusterName, mgmtKubeconfig)
+		// Post-pivot sequence per ADR 0011 §7:
+		//   MoveCAPIState (above) → HandOff → EnsureYageSystemOnCluster
+		//     → CSI EnsureManagementInstall → EnsureRepoSync → VerifyParity → rebind
+		// VerifyParity must run last so its yage-system + yage-repos PVC
+		// checks see the state populated by the preceding ensures.
+		hr, err := kindsync.HandOffBootstrapSecretsToManagement(cfg, "kind-"+cfg.KindClusterName, mgmtKubeconfig)
 		if err != nil {
-			logx.Warn("pivot: handoff Secrets returned error after %d copies: %v", copied, err)
+			logx.Warn("pivot: handoff Secrets returned error after %d named + %d labeled copies: %v",
+				hr.NamedCopied, hr.LabelCopied, err)
 		} else {
-			logx.Log("pivot: handoff complete (%d Secrets copied to mgmt cluster).", copied)
+			logx.Log("pivot: handoff complete (%d named + %d labeled Secrets copied to mgmt cluster).",
+				hr.NamedCopied, hr.LabelCopied)
 		}
+
+		// Single mgmt-cluster client reused by every post-handoff step.
+		pivotMgmtCli, pivotCliErr := k8sclient.ForKubeconfigFile(mgmtKubeconfig)
+		if pivotCliErr != nil {
+			logx.Die("pivot: kube client for mgmt cluster: %v", pivotCliErr)
+		}
+
+		// EnsureYageSystemOnCluster re-creates the yage-job-runner SA + RBAC
+		// from spec on the real mgmt cluster (these are not Secrets, so the
+		// handoff did not carry them across).
+		if err := kindsync.EnsureYageSystemOnCluster(ctx, pivotMgmtCli); err != nil {
+			logx.Die("pivot: EnsureYageSystemOnCluster on management cluster: %v", err)
+		}
+
 		// Install CSI driver on management cluster (needed for
 		// yage-repos PVC). Load file-based credentials first so
 		// operators that supply PROXMOX_CSI_CONFIG see them here, then
@@ -886,21 +907,20 @@ func Run(ctx context.Context, cfg *config.Config) int {
 				logx.Die("pivot: EnsureManagementInstall (%s): %v", d.Name(), merr)
 			}
 		}
-		if err := pivot.VerifyParity(cfg, mgmtKubeconfig); err != nil {
-			logx.Die("pivot: VerifyParity: %v", err)
-		}
-		// Ensure yage-system RBAC and repo sync on the real management cluster
-		// (mirrors the kind-cluster step above, but targeting mgmt after pivot).
-		pivotMgmtCli, pivotCliErr := k8sclient.ForKubeconfigFile(mgmtKubeconfig)
-		if pivotCliErr != nil {
-			logx.Die("pivot: kube client for mgmt cluster: %v", pivotCliErr)
-		}
-		if err := kindsync.EnsureYageSystemOnCluster(ctx, pivotMgmtCli); err != nil {
-			logx.Die("pivot: EnsureYageSystemOnCluster on management cluster: %v", err)
-		}
+
+		// EnsureRepoSync creates the yage-repos PVC + repo-sync Job on the
+		// management cluster, using the StorageClass installed above.
 		if err := opentofux.EnsureRepoSync(ctx, pivotMgmtCli, cfg); err != nil {
 			logx.Die("pivot: EnsureRepoSync on management cluster: %v", err)
 		}
+
+		// VerifyParity is last: its ADR 0011 §6 checks (yage-system ns,
+		// labeled Secrets, yage-repos PVC bound) require the preceding
+		// ensures to have run.
+		if err := pivot.VerifyParity(cfg, mgmtKubeconfig); err != nil {
+			logx.Die("pivot: VerifyParity: %v", err)
+		}
+
 		if err := rebindKindContextToMgmt(cfg, mgmtKubeconfig); err != nil {
 			logx.Die("pivot: rebind kind-%s context to mgmt kubeconfig: %v", cfg.KindClusterName, err)
 		}


### PR DESCRIPTION
## Summary

Implements ADR 0011 §2, §6, §7 — the last open item from issue #148:

- `kindsync.HandOffBootstrapSecretsToManagement` gains a label-scoped second pass: every Secret in `yage-system` carrying `app.kubernetes.io/managed-by=yage` is server-side-applied to the mgmt cluster after the named-target list. Return type changes from `(int, error)` to `(HandoffResult{NamedCopied, LabelCopied, FirstErr}, error)`.
- `pivot.VerifyParity` gains three checks (yage-system ns, labeled Secrets — zero is a warning per §6.b, `yage-repos` PVC Bound).
- `bootstrap.go` post-pivot phases reordered per §7 — `VerifyParity` now runs **after** `EnsureYageSystemOnCluster` + CSI + `EnsureRepoSync`, so the new §6 checks see populated state instead of always failing.

Closes #148
Epic: #120

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, kindsync, pivot)
- [ ] **Level 2 — Test / CI / Config**
- [ ] **Level 3 — Documentation**

## Level 1 Checklist

- [x] `make build` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` — no new findings (`go.mod` unchanged → N/A)
- [x] Manually walked affected flow **or** change fully covered by existing tests (cite test name) — covered by `internal/cluster/kindsync/handoff_test.go` (`TestCopyYageSystemSecrets_*`, `TestHandoffResult_TotalSumsCounts`) and `internal/capi/pivot/verifyparity_test.go` (`TestCheckYageSystemNamespace_*`, `TestCheckLabeledYageSystemSecrets_*` including the §6.b warn-don't-fail edge, `TestCheckYageReposPVCBound_*`).
- [x] Breaking-change audit — see Breaking Changes section.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | `go.mod` / `go.sum` unchanged |
| PE review (Secret schema / CAPI YAML) | N/A | no new Secret schemas; label `app.kubernetes.io/managed-by=yage` already in use by `EnsureYageSystemOnCluster` and the OpenTofu kubernetes backend (ADR 0011 §1) |
| Supply-chain (workflow change) | N/A | no `.github/workflows/` changes |

## Acceptance Criteria Evidence

- [x] **§2 label-based handoff** — `copyYageSystemSecrets` lists `app.kubernetes.io/managed-by=yage` Secrets in `yage-system` and SSA-applies them; per-(ns, name) dedupe skip-set prevents double-apply with the named pass. Test: `TestCopyYageSystemSecrets_AppliesAllLabeled`, `TestCopyYageSystemSecrets_RespectsSkipSet`.
- [x] **`HandoffResult{NamedCopied, LabelCopied, FirstErr}`** added; orchestrator logs both counts (`bootstrap.go` handoff log line).
- [x] **§6.a yage-system ns check** — `TestCheckYageSystemNamespace_Present/Missing`.
- [x] **§6.b labeled Secrets check, zero = warning** — `TestCheckLabeledYageSystemSecrets_ZeroIsWarning` asserts nil error when no labeled Secrets are present (matches ADR text "Zero is a warning (not fatal) — a first-run with no tofu modules executed yet has no tfstate Secrets to copy"); `TestCheckLabeledYageSystemSecrets_OneOrMore` covers steady state.
- [x] **§6.c `yage-repos` PVC Bound** — `TestCheckYageReposPVCBound_Bound/Pending/Missing`.
- [x] **§7 phase reorder** — `bootstrap.go` now executes `MoveCAPIState → HandOff → EnsureYageSystemOnCluster → CSI EnsureManagementInstall → EnsureRepoSync → VerifyParity → rebind`. Single mgmt-cluster client is created after handoff and reused by every post-handoff step.

## Breaking Changes

`kindsync.HandOffBootstrapSecretsToManagement` now returns `(HandoffResult, error)` instead of `(int, error)`. The sole in-tree caller in `internal/orchestrator/bootstrap.go` is updated. `HandoffResult.Total()` provides the prior gross count for any external caller that wants to keep its previous log shape.

## Notes for Reviewer

- The three pivot constants (`yageSystemNamespace`, `yageReposPVCName`, `yageManagedBySelector`) are inlined in `pivot.go` rather than imported from `kindsync` to keep this package's dep graph minimal — three string constants vs. a new package edge.
- `EnsureYageSystemOnCluster` already runs on the kind cluster pre-pivot at `bootstrap.go:812`; the post-pivot call now runs on the mgmt cluster *between* HandOff and CSI install, exactly where ADR 0011 §7 places it. The kind-side call is untouched.
- `checkLabeledYageSystemSecrets` deliberately returns nil on empty list (with a `logx.Warn`) — the alternative (treating zero as fatal) would block first-run pivots where no tofu module has executed yet, contradicting ADR §6.b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)