### PR TITLE
feat(manifests): implement internal/platform/manifests Fetcher (ADR 0008/0010/0012)

### DIFF
--- a/internal/platform/manifests/fetcher.go
+++ b/internal/platform/manifests/fetcher.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package manifests resolves and renders YAML templates from the in-cluster
+// yage-repos PVC populated by opentofux.EnsureRepoSync (ADR 0010 §2).
+//
+// Templates live in the lpasquali/yage-manifests repository, cloned to
+// <MountRoot>/yage-manifests/ on the PVC. The Fetcher reads each .yaml.tmpl
+// from that path and executes it with text/template using the per-group
+// wrapper structs defined in internal/capi/templates/ (ADR 0012 §3).
+//
+// Templates are executed with Option("missingkey=error"): an undeclared
+// field on the data value is a hard error rather than the stdlib default
+// "<no value>" placeholder. This surfaces yage / yage-manifests version
+// skew at render time, before half-formed YAML reaches the apiserver
+// (ADR 0012 §4).
+package manifests
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+// defaultMountRoot is the in-pod path at which the yage-repos PVC is
+// mounted by yage-managed Jobs. yage-manifests content lives at
+// <defaultMountRoot>/yage-manifests/.
+const defaultMountRoot = "/repos"
+
+// manifestsSubdir is the per-repo subdirectory under MountRoot that holds
+// the yage-manifests checkout produced by EnsureRepoSync.
+const manifestsSubdir = "yage-manifests"
+
+// Fetcher resolves yage-manifests template paths from the in-cluster
+// yage-repos PVC and renders them via text/template.
+//
+// Production callers run inside a Job that mounts the PVC at /repos and
+// leave MountRoot zero; tests and dev tools may set MountRoot to a local
+// fixture directory that mirrors the PVC layout.
+type Fetcher struct {
+	// MountRoot is the path at which the yage-repos PVC is mounted in
+	// the current pod. Empty means defaultMountRoot ("/repos").
+	MountRoot string
+}
+
+// NewFetcher constructs a Fetcher with MountRoot left at its default
+// (resolved to /repos at render time). Callers that need a non-default
+// mount point may set MountRoot directly on the returned value.
+func NewFetcher() *Fetcher {
+	return &Fetcher{}
+}
+
+// Render reads the .yaml.tmpl at templatePath (relative to the
+// yage-manifests repository root on the PVC) and executes it with data
+// via text/template using Option("missingkey=error").
+//
+// Returned errors wrap the underlying cause (file read, parse, execute)
+// with the resolved on-disk path so log output points operators at the
+// exact PVC location.
+func (f *Fetcher) Render(templatePath string, data any) (string, error) {
+	fullPath := filepath.Join(f.mountRoot(), manifestsSubdir, templatePath)
+
+	raw, err := os.ReadFile(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("manifests: read template %s: %w", fullPath, err)
+	}
+
+	tmpl, err := template.New(filepath.Base(templatePath)).
+		Option("missingkey=error").
+		Parse(string(raw))
+	if err != nil {
+		return "", fmt.Errorf("manifests: parse template %s: %w", fullPath, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("manifests: execute template %s: %w", fullPath, err)
+	}
+	return buf.String(), nil
+}
+
+// mountRoot returns the effective PVC mount root, falling back to
+// defaultMountRoot when the field is empty.
+func (f *Fetcher) mountRoot() string {
+	if f.MountRoot == "" {
+		return defaultMountRoot
+	}
+	return f.MountRoot
+}

--- a/internal/platform/manifests/fetcher_test.go
+++ b/internal/platform/manifests/fetcher_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package manifests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type sampleData struct {
+	Name     string
+	Replicas int
+}
+
+func TestFetcher_Render_HappyPath(t *testing.T) {
+	f := &Fetcher{MountRoot: "testdata"}
+
+	got, err := f.Render("addons/sample/values.yaml.tmpl", sampleData{
+		Name:     "metrics-server",
+		Replicas: 2,
+	})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	want := "# yage-manifests/addons/sample/values.yaml.tmpl\nname: metrics-server\nreplicas: 2\n"
+	if got != want {
+		t.Errorf("Render output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestFetcher_Render_MissingTemplateFile(t *testing.T) {
+	f := &Fetcher{MountRoot: "testdata"}
+
+	_, err := f.Render("addons/sample/does-not-exist.yaml.tmpl", sampleData{})
+	if err == nil {
+		t.Fatal("expected error for missing template file, got nil")
+	}
+	if !strings.Contains(err.Error(), "read template") {
+		t.Errorf("error should mention read template stage; got: %v", err)
+	}
+	wantPath := filepath.Join("testdata", manifestsSubdir, "addons/sample/does-not-exist.yaml.tmpl")
+	if !strings.Contains(err.Error(), wantPath) {
+		t.Errorf("error should include resolved path %q; got: %v", wantPath, err)
+	}
+}
+
+func TestFetcher_Render_MissingKeyInData(t *testing.T) {
+	f := &Fetcher{MountRoot: "testdata"}
+
+	// map data missing the "Replicas" key referenced by the template.
+	// Per ADR 0012 §4, missingkey=error must hard-error rather than
+	// emit the stdlib default "<no value>" placeholder.
+	_, err := f.Render("addons/sample/values.yaml.tmpl", map[string]any{
+		"Name": "metrics-server",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing key, got nil")
+	}
+	if !strings.Contains(err.Error(), "execute template") {
+		t.Errorf("error should mention execute template stage; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Replicas") {
+		t.Errorf("error should mention the missing key Replicas; got: %v", err)
+	}
+}
+
+func TestFetcher_Render_MalformedTemplate(t *testing.T) {
+	f := &Fetcher{MountRoot: "testdata"}
+
+	_, err := f.Render("addons/sample/malformed.yaml.tmpl", sampleData{})
+	if err == nil {
+		t.Fatal("expected parse error for malformed template, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse template") {
+		t.Errorf("error should mention parse template stage; got: %v", err)
+	}
+}
+
+func TestFetcher_MountRoot_Default(t *testing.T) {
+	// Empty MountRoot must fall back to defaultMountRoot ("/repos").
+	// /repos does not exist in CI, so verify via the resolved path in
+	// the resulting "read template" error rather than executing a real
+	// template against the host filesystem.
+	f := &Fetcher{}
+
+	_, err := f.Render("addons/sample/values.yaml.tmpl", sampleData{})
+	if err == nil {
+		t.Fatal("expected error reading from default /repos mount, got nil")
+	}
+	wantPath := filepath.Join(defaultMountRoot, manifestsSubdir, "addons/sample/values.yaml.tmpl")
+	if !strings.Contains(err.Error(), wantPath) {
+		t.Errorf("default MountRoot should resolve to %q; got: %v", wantPath, err)
+	}
+}
+
+func TestNewFetcher_DefaultsMountRootEmpty(t *testing.T) {
+	f := NewFetcher()
+	if f.MountRoot != "" {
+		t.Errorf("NewFetcher MountRoot = %q; want empty string (resolved at render time)", f.MountRoot)
+	}
+}

--- a/internal/platform/manifests/testdata/yage-manifests/addons/sample/malformed.yaml.tmpl
+++ b/internal/platform/manifests/testdata/yage-manifests/addons/sample/malformed.yaml.tmpl
@@ -1,0 +1,2 @@
+# yage-manifests/addons/sample/malformed.yaml.tmpl
+name: {{ .Name

--- a/internal/platform/manifests/testdata/yage-manifests/addons/sample/values.yaml.tmpl
+++ b/internal/platform/manifests/testdata/yage-manifests/addons/sample/values.yaml.tmpl
@@ -1,0 +1,3 @@
+# yage-manifests/addons/sample/values.yaml.tmpl
+name: {{ .Name }}
+replicas: {{ .Replicas }}


### PR DESCRIPTION
## Summary

Adds `internal/platform/manifests` — the Fetcher package that resolves YAML templates from the in-cluster `yage-repos` PVC and renders them via `text/template`.

- `Render(templatePath, data)` reads `<MountRoot>/yage-manifests/<templatePath>` from the PVC and executes it with `Option("missingkey=error")` per ADR 0012 §4. Undeclared fields hard-error at render time so yage / yage-manifests version skew surfaces before half-formed YAML reaches the apiserver.
- `MountRoot` defaults to `/repos` (the path at which `EnsureRepoSync` mounts the PVC inside Job pods); tests override it to a `testdata/` fixture so CI runs without network or cluster access.
- No inline YAML, no wrapper-struct definitions. The six wrapper structs from ADR 0012 §3 land in `internal/capi/templates/` as part of the migration PRs (#137–#141), which this PR unblocks.

Closes #136
Epic: #133

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)
- [ ] **Level 2 — Test / CI / Config** (test changes, CI config, linter — no runtime code)
- [ ] **Level 3 — Documentation** (yage-docs content, ADRs, runbooks — no Go code)

## Level 1 Checklist

- [x] `make build` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` — no new findings (if `go.mod` changed; skip otherwise) — N/A: `go.mod` unchanged, only stdlib (`bytes`, `fmt`, `os`, `path/filepath`, `text/template`)
- [x] Manually walked affected flow **or** change fully covered by existing tests — covered by `internal/platform/manifests/fetcher_test.go` (6 cases)
- [x] Breaking-change audit: Secret schemas, env var renames, CAPI CRD fields, config namespacing — N/A; new package, no callers yet

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | go.mod unchanged |
| PE review (Secret schema / CAPI YAML) | N/A | No Secret schema or CAPI YAML touched |
| Supply-chain (workflow change) | N/A | No `.github/workflows/` changes |

## Acceptance Criteria Evidence

- [x] `Fetcher.Render` works with a local fixture directory (no network in test) — `TestFetcher_Render_HappyPath` passes against `testdata/yage-manifests/addons/sample/values.yaml.tmpl`
- [x] `MountRoot` defaults to `/repos` when empty; can be overridden in tests — `TestFetcher_MountRoot_Default` asserts default resolution to `/repos/yage-manifests/...`; happy-path test overrides to `testdata`
- [x] Full path resolution: `filepath.Join(mountRoot, "yage-manifests", templatePath)` — implemented in `Fetcher.Render`; verified by error-message path-substring assertions in `TestFetcher_Render_MissingTemplateFile` and `TestFetcher_MountRoot_Default`
- [x] `go test ./internal/platform/manifests/...` passes — six tests, all PASS
- [x] `make build` green
- [x] No `CacheDir` field; no local git clone; no `~/.yage/manifests-cache/` writes — Fetcher struct holds only `MountRoot`; package only imports stdlib

## Test cases

- `TestFetcher_Render_HappyPath` — renders a fixture template with a struct payload and asserts byte-exact output.
- `TestFetcher_Render_MissingTemplateFile` — asserts `read template` error stage and that the resolved on-disk path is included in the error.
- `TestFetcher_Render_MissingKeyInData` — passes a `map[string]any` missing a referenced key; asserts `execute template` stage and that the missing key name (`Replicas`) appears in the error. Pins the ADR 0012 §4 `missingkey=error` contract.
- `TestFetcher_Render_MalformedTemplate` — fixture template with an unclosed `{{ .Name`; asserts `parse template` error stage.
- `TestFetcher_MountRoot_Default` — empty `MountRoot` resolves under `/repos/yage-manifests/`; asserted via the resolved path in the read error (no host-filesystem dependency).
- `TestNewFetcher_DefaultsMountRootEmpty` — `NewFetcher().MountRoot == ""`; resolution happens at render time.

## Breaking Changes

None. Net-new package; no existing callers.

## Notes for Reviewer

- The wrapper-struct package `internal/capi/templates/` is intentionally out of scope per the issue brief: each migration PR (#137–#141) adds the wrapper struct it needs there, with the union pinned by ADR 0012 §3's six-struct table. Creating the structs speculatively here would either ship empty types or drift from the migrations' actual field shapes.
- The four existing renderers in `internal/capi/{helmvalues,wlargocd,postsync,caaph}/` are untouched per hard requirement #1 — their migration is the job of #137–#141.