### PR TITLE
feat(templates): add ADR 0012 §3 wrapper structs (follow-up to #136)

### DIFF
--- a/internal/capi/templates/argo_application_data_test.go
+++ b/internal/capi/templates/argo_application_data_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// TestArgoApplicationData_AllFieldsRendered exercises every ADR 0012 §3
+// field on ArgoApplicationData, including the embedded PostSyncBlock
+// reached through the .PostSync path. Fixture template references
+// every leaf field; missingkey=error turns any rename into a render
+// failure.
+func TestArgoApplicationData_AllFieldsRendered(t *testing.T) {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+
+	data := templates.ArgoApplicationData{
+		Cfg:         &config.Config{WorkloadClusterName: "wl-prod"},
+		Name:        "metrics-server",
+		DestNS:      "kube-system",
+		RepoURL:     "https://kubernetes-sigs.github.io/metrics-server/",
+		Chart:       "metrics-server",
+		Path:        "charts/metrics-server",
+		Ref:         "v0.7.2",
+		SyncWave:    "5",
+		ReleaseName: "metrics-server",
+		ValuesYAML:  "replicas: 2",
+		Annotations: map[string]string{
+			"argocd.argoproj.io/compare-options": "ServerSideDiff=true",
+		},
+		PostSync: templates.PostSyncBlock{
+			URL:              "https://github.com/lpasquali/workload-smoketests",
+			Path:             "kustomize/proxmox-csi",
+			Ref:              "main",
+			KustomizePartial: "  patches:\n    - path: image-override.yaml",
+		},
+	}
+
+	got, err := f.Render("argoapplication.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	wants := []string{
+		"cluster: wl-prod",
+		"name: metrics-server",
+		"destNS: kube-system",
+		"repoURL: https://kubernetes-sigs.github.io/metrics-server/",
+		"chart: metrics-server",
+		"path: charts/metrics-server",
+		"ref: v0.7.2",
+		"syncWave: 5",
+		"releaseName: metrics-server",
+		"valuesYAML: replicas: 2",
+		"annotation: ServerSideDiff=true",
+		"postSyncURL: https://github.com/lpasquali/workload-smoketests",
+		"postSyncPath: kustomize/proxmox-csi",
+		"postSyncRef: main",
+		"postSyncPartial:",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/capi/templates/helm_chart_proxy_data_test.go
+++ b/internal/capi/templates/helm_chart_proxy_data_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// TestHelmChartProxyData_AllFieldsRendered exercises every ADR 0012 §3
+// field on HelmChartProxyData. Fixture template references each field
+// exactly once; missingkey=error turns rename or removal into a hard
+// render error.
+func TestHelmChartProxyData_AllFieldsRendered(t *testing.T) {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+
+	data := templates.HelmChartProxyData{
+		Cfg:       &config.Config{WorkloadClusterName: "wl-prod"},
+		Name:      "cilium",
+		Namespace: "default",
+		ClusterSelector: map[string]string{
+			"cluster.x-k8s.io/cluster-name": "wl-prod",
+		},
+		ChartName:      "cilium",
+		RepoURL:        "https://helm.cilium.io/",
+		Version:        "1.16.4",
+		ChartNamespace: "kube-system",
+		ValuesTemplate: "kubeProxyReplacement: true",
+	}
+
+	got, err := f.Render("helmchartproxy.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	wants := []string{
+		"cluster: wl-prod",
+		"name: cilium",
+		"namespace: default",
+		"selector: wl-prod",
+		"chartName: cilium",
+		"repoURL: https://helm.cilium.io/",
+		"version: 1.16.4",
+		"chartNamespace: kube-system",
+		"valuesTemplate: kubeProxyReplacement: true",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/capi/templates/helmvalues_data_test.go
+++ b/internal/capi/templates/helmvalues_data_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// TestHelmValuesData_AllFieldsRendered exercises every ADR 0012 §3 field
+// on HelmValuesData against an in-package fixture template that
+// references each field. The Fetcher's missingkey=error policy turns
+// any field omission or rename into a hard render error, pinning the
+// struct shape against ADR 0012.
+func TestHelmValuesData_AllFieldsRendered(t *testing.T) {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+
+	data := templates.HelmValuesData{
+		Cfg: &config.Config{WorkloadClusterName: "wl-prod"},
+	}
+
+	got, err := f.Render("helmvalues.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	for _, want := range []string{"cluster: wl-prod"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/capi/templates/kustomize_partial_data_test.go
+++ b/internal/capi/templates/kustomize_partial_data_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// TestKustomizePartialData_AllFieldsRendered exercises every ADR 0012
+// §3 field on KustomizePartialData against an in-package fixture
+// template that references each field including a representative key
+// in the Extra map. missingkey=error pins the contract.
+func TestKustomizePartialData_AllFieldsRendered(t *testing.T) {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+
+	data := templates.KustomizePartialData{
+		Cfg:          &config.Config{WorkloadClusterName: "wl-prod"},
+		Namespace:    "argocd",
+		JobName:      "proxmox-csi-smoke",
+		KubectlImage: "registry.k8s.io/kubectl:v1.31.0",
+		Extra: map[string]string{
+			"TARGET_IMAGE": "registry.local/csi-driver:v1.2.3",
+		},
+	}
+
+	got, err := f.Render("kustomizepartial.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	wants := []string{
+		"cluster: wl-prod",
+		"namespace: argocd",
+		"jobName: proxmox-csi-smoke",
+		"kubectlImage: registry.k8s.io/kubectl:v1.31.0",
+		"extra: registry.local/csi-driver:v1.2.3",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/capi/templates/post_sync_block_test.go
+++ b/internal/capi/templates/post_sync_block_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// TestPostSyncBlock_AllFieldsRendered exercises PostSyncBlock as a
+// standalone payload. The struct is also reachable via
+// ArgoApplicationData.PostSync; the dedicated test pins the field
+// surface so renames break here even when no Application template is
+// wired up to use it yet.
+func TestPostSyncBlock_AllFieldsRendered(t *testing.T) {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+
+	data := templates.PostSyncBlock{
+		URL:              "https://github.com/lpasquali/workload-smoketests",
+		Path:             "kustomize/proxmox-csi",
+		Ref:              "main",
+		KustomizePartial: "  patches:\n    - path: image-override.yaml",
+	}
+
+	got, err := f.Render("postsyncblock.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	wants := []string{
+		"url: https://github.com/lpasquali/workload-smoketests",
+		"path: kustomize/proxmox-csi",
+		"ref: main",
+		"kustomizePartial:",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/capi/templates/post_sync_data_test.go
+++ b/internal/capi/templates/post_sync_data_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package templates_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// TestPostSyncData_AllFieldsRendered exercises every ADR 0012 §3 field
+// on PostSyncData against an in-package fixture template that
+// references each field. missingkey=error pins the contract.
+func TestPostSyncData_AllFieldsRendered(t *testing.T) {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+
+	data := templates.PostSyncData{
+		Cfg:           &config.Config{WorkloadClusterName: "wl-prod"},
+		Namespace:     "argocd",
+		StorageClass:  "proxmox-csi",
+		KubectlImage:  "registry.k8s.io/kubectl:v1.31.0",
+		K8sVersionTag: "v1.31.0",
+	}
+
+	got, err := f.Render("postsyncdata.yaml.tmpl", data)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	wants := []string{
+		"cluster: wl-prod",
+		"namespace: argocd",
+		"storageClass: proxmox-csi",
+		"kubectlImage: registry.k8s.io/kubectl:v1.31.0",
+		"k8sVersionTag: v1.31.0",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/capi/templates/templates.go
+++ b/internal/capi/templates/templates.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+// Package templates defines the six wrapper structs that
+// internal/platform/manifests.Fetcher passes to yage-manifests
+// templates (ADR 0012 §3).
+//
+// Templates do not receive *config.Config directly. Each template group
+// receives a purpose-built wrapper carrying the entire workload Config
+// alongside the per-call-site fields the renderer needs (release name,
+// sync wave, pre-rendered values blob, etc.). Field shapes are pinned
+// here so #137–#141 migrations land mechanically against a fixed
+// contract; reviewers reject ad-hoc per-renderer structs.
+//
+// Drift between this package and the templates is caught at render time
+// by Fetcher's Option("missingkey=error") policy (ADR 0012 §4): any
+// template that references a field absent from these structs fails the
+// orchestrator phase loudly rather than rendering "<no value>" into an
+// apiserver-acceptable manifest.
+package templates
+
+import "github.com/lpasquali/yage/internal/config"
+
+// HelmValuesData is passed to addons/<addon>/values.yaml.tmpl and
+// csi/<driver>/values.yaml.tmpl.
+type HelmValuesData struct {
+	Cfg *config.Config
+}
+
+// ArgoApplicationData is passed to addons/<addon>/application.yaml.tmpl.
+type ArgoApplicationData struct {
+	Cfg         *config.Config
+	Name        string
+	DestNS      string
+	RepoURL     string
+	Chart       string
+	Path        string
+	Ref         string
+	SyncWave    string
+	ReleaseName string
+	ValuesYAML  string
+	Annotations map[string]string
+	PostSync    PostSyncBlock
+}
+
+// PostSyncBlock is the second-source git+kustomize fields for an Argo
+// Application. Zero value means "single-source Application; no hook".
+type PostSyncBlock struct {
+	URL              string
+	Path             string
+	Ref              string
+	KustomizePartial string
+}
+
+// HelmChartProxyData is passed to addons/<addon>/helmchartproxy.yaml.tmpl.
+type HelmChartProxyData struct {
+	Cfg             *config.Config
+	Name            string
+	Namespace       string
+	ClusterSelector map[string]string
+	ChartName       string
+	RepoURL         string
+	Version         string
+	ChartNamespace  string
+	ValuesTemplate  string
+}
+
+// PostSyncData is passed to postsync/<hookname>.yaml.tmpl.
+type PostSyncData struct {
+	Cfg           *config.Config
+	Namespace     string
+	StorageClass  string
+	KubectlImage  string
+	K8sVersionTag string
+}
+
+// KustomizePartialData is passed to postsync/_partials/<name>.kustomize.tmpl.
+type KustomizePartialData struct {
+	Cfg          *config.Config
+	Namespace    string
+	JobName      string
+	KubectlImage string
+	Extra        map[string]string
+}

--- a/internal/capi/templates/testdata/yage-manifests/argoapplication.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/argoapplication.yaml.tmpl
@@ -1,0 +1,16 @@
+# yage-manifests/testdata/argoapplication.yaml.tmpl
+cluster: {{ .Cfg.WorkloadClusterName }}
+name: {{ .Name }}
+destNS: {{ .DestNS }}
+repoURL: {{ .RepoURL }}
+chart: {{ .Chart }}
+path: {{ .Path }}
+ref: {{ .Ref }}
+syncWave: {{ .SyncWave }}
+releaseName: {{ .ReleaseName }}
+valuesYAML: {{ .ValuesYAML }}
+annotation: {{ index .Annotations "argocd.argoproj.io/compare-options" }}
+postSyncURL: {{ .PostSync.URL }}
+postSyncPath: {{ .PostSync.Path }}
+postSyncRef: {{ .PostSync.Ref }}
+postSyncPartial: {{ .PostSync.KustomizePartial }}

--- a/internal/capi/templates/testdata/yage-manifests/helmchartproxy.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/helmchartproxy.yaml.tmpl
@@ -1,0 +1,10 @@
+# yage-manifests/testdata/helmchartproxy.yaml.tmpl
+cluster: {{ .Cfg.WorkloadClusterName }}
+name: {{ .Name }}
+namespace: {{ .Namespace }}
+selector: {{ index .ClusterSelector "cluster.x-k8s.io/cluster-name" }}
+chartName: {{ .ChartName }}
+repoURL: {{ .RepoURL }}
+version: {{ .Version }}
+chartNamespace: {{ .ChartNamespace }}
+valuesTemplate: {{ .ValuesTemplate }}

--- a/internal/capi/templates/testdata/yage-manifests/helmvalues.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/helmvalues.yaml.tmpl
@@ -1,0 +1,2 @@
+# yage-manifests/testdata/helmvalues.yaml.tmpl
+cluster: {{ .Cfg.WorkloadClusterName }}

--- a/internal/capi/templates/testdata/yage-manifests/kustomizepartial.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/kustomizepartial.yaml.tmpl
@@ -1,0 +1,6 @@
+# yage-manifests/testdata/kustomizepartial.yaml.tmpl
+cluster: {{ .Cfg.WorkloadClusterName }}
+namespace: {{ .Namespace }}
+jobName: {{ .JobName }}
+kubectlImage: {{ .KubectlImage }}
+extra: {{ index .Extra "TARGET_IMAGE" }}

--- a/internal/capi/templates/testdata/yage-manifests/postsyncblock.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/postsyncblock.yaml.tmpl
@@ -1,0 +1,5 @@
+# yage-manifests/testdata/postsyncblock.yaml.tmpl
+url: {{ .URL }}
+path: {{ .Path }}
+ref: {{ .Ref }}
+kustomizePartial: {{ .KustomizePartial }}

--- a/internal/capi/templates/testdata/yage-manifests/postsyncdata.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/postsyncdata.yaml.tmpl
@@ -1,0 +1,6 @@
+# yage-manifests/testdata/postsyncdata.yaml.tmpl
+cluster: {{ .Cfg.WorkloadClusterName }}
+namespace: {{ .Namespace }}
+storageClass: {{ .StorageClass }}
+kubectlImage: {{ .KubectlImage }}
+k8sVersionTag: {{ .K8sVersionTag }}


### PR DESCRIPTION
## Summary

Adds `internal/capi/templates/` with the six wrapper structs ADR 0012 §3 pins as the data contract for `yage-manifests` templates. Field shapes are transcribed verbatim from the ADR.

The six structs (HelmValuesData, ArgoApplicationData, PostSyncBlock, HelmChartProxyData, PostSyncData, KustomizePartialData) become the only legal payload types passed to `manifests.Fetcher.Render` for the migration PRs #137–#141. Reviewers reject ad-hoc per-renderer structs.

PR #167 (ADR 0012 + Fetcher; squash `ca3562f` on `main`) deferred this package on the argument that each struct should land per migration site to avoid speculative drift. This PR overrides that deferral at user direction so #137–#141 land mechanically against a pinned contract.

Closes #169
Refs #167 (deferred this package), ADR 0012 §3 (struct definitions), ADR 0012 §4 (missing-key=error).

## DoD Level

- [ ] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)
- [x] **Level 2 — Test / CI / Config** (test changes, CI config, linter — no runtime code)
- [ ] **Level 3 — Documentation** (yage-docs content, ADRs, runbooks — no Go code)

Level 2 selected: this PR adds new types and tests but no caller wires them up yet — that wiring is the explicit scope of #137–#141 (untouched per task hard requirement). No orchestrator phase, provider, or cluster-touching code path changes.

## Level 2 Checklist

- [x] Full test suite passes — `go test ./...` exit 0
- [x] Coverage not degraded — net-new package, six tests on six structs (one each, all fields exercised)
- [x] No unintended CI side effects — no workflow changes, no `go.mod` changes

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | go.mod unchanged; templates.go imports only `github.com/lpasquali/yage/internal/config` |
| PE review (Secret schema / CAPI YAML) | N/A | No Secret schema or CAPI YAML touched |
| Supply-chain (workflow change) | N/A | No `.github/workflows/` changes |

## Acceptance Criteria Evidence

- [x] Six struct definitions present in `internal/capi/templates/templates.go`, transcribed verbatim from ADR 0012 §3 (no field renames, no field shape edits, no fields invented).
- [x] One `*_test.go` per struct constructs the struct, sets every field, and renders an in-package fixture template that references every field through `manifests.Fetcher.Render` with `MountRoot: "testdata"`.
- [x] Missing-key strictness verified live: temporarily renaming `Cfg.WorkloadClusterName` in a fixture template to `Cfg.WorkloadClusterNameXXX` produced `manifests: execute template ...: can't evaluate field WorkloadClusterNameXXX in type *config.Config` — the contract fails loud as ADR 0012 §4 requires. Test passes again on revert.
- [x] `make build` green.
- [x] `go test ./...` exit 0 (full suite, all packages).
- [x] `go vet ./...` clean (no output).
- [x] No changes to `internal/capi/{helmvalues,wlargocd,postsync,caaph,cilium}/` (task hard requirement #4).
- [x] No changes to `CURRENT_STATE.md` (task hard requirement #5; PO domain).

## Test cases

- `TestHelmValuesData_AllFieldsRendered` — `Cfg`.
- `TestArgoApplicationData_AllFieldsRendered` — `Cfg`, `Name`, `DestNS`, `RepoURL`, `Chart`, `Path`, `Ref`, `SyncWave`, `ReleaseName`, `ValuesYAML`, `Annotations`, `PostSync.{URL,Path,Ref,KustomizePartial}` (embedded sub-struct exercised through the `.PostSync` path).
- `TestPostSyncBlock_AllFieldsRendered` — `URL`, `Path`, `Ref`, `KustomizePartial` (standalone payload; pins the surface even when no Application template wires it up yet).
- `TestHelmChartProxyData_AllFieldsRendered` — `Cfg`, `Name`, `Namespace`, `ClusterSelector`, `ChartName`, `RepoURL`, `Version`, `ChartNamespace`, `ValuesTemplate`.
- `TestPostSyncData_AllFieldsRendered` — `Cfg`, `Namespace`, `StorageClass`, `KubectlImage`, `K8sVersionTag`.
- `TestKustomizePartialData_AllFieldsRendered` — `Cfg`, `Namespace`, `JobName`, `KubectlImage`, `Extra`.

## Breaking Changes

None. Net-new package; no existing callers.

## Notes for Reviewer

- ADR 0012 §3 prose says "five wrapper structs" but the code block defines six and the Negative consequences block references "six structs and no behaviour"; `PostSyncBlock` is a sub-struct embedded in `ArgoApplicationData.PostSync`. Six total, transcribed verbatim.
- Map fields (`Annotations`, `ClusterSelector`, `Extra`) are exercised in fixtures via `index .Map "literal-key"`. This catches struct-side renames (the field becomes unreferenceable) but does not enumerate every possible map key — the ADR contract is field-name, not key-set.
- Fixture templates live in `internal/capi/templates/testdata/yage-manifests/` and reference `Cfg.WorkloadClusterName` (verified to exist in `internal/config/config.go:1107`) as the stable scalar from `*config.Config`. They are not real workload-cluster manifests; they exist solely to drive the field-coverage assertion.