### PR TITLE
feat(opentofux): EnsureRegistry — bootstrap registry VM via yage-tofu module (#125)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1151,6 +1151,35 @@ type Config struct {
 	// Defaults to "harbor". Env: YAGE_REGISTRY_FLAVOR.
 	RegistryFlavor string
 
+	// RegistryTemplateID is the Proxmox VM template ID to clone for the registry VM
+	// (cloud-init enabled Ubuntu/Debian). Required when RegistryNode is set.
+	// Env: YAGE_REGISTRY_TEMPLATE_ID.
+	RegistryTemplateID string
+
+	// RegistryHostname is the DNS hostname for the registry VM, used as the
+	// cloud-init hostname and TLS SAN. Required when RegistryNode is set.
+	// Env: YAGE_REGISTRY_HOSTNAME.
+	RegistryHostname string
+
+	// RegistryTLSCertPEM is the PEM-encoded TLS certificate (leaf + chain)
+	// served by the registry. Empty is valid for dev mode.
+	// Env: YAGE_REGISTRY_TLS_CERT_PEM.
+	RegistryTLSCertPEM string
+
+	// RegistryTLSKeyPEM is the PEM-encoded TLS private key for RegistryTLSCertPEM.
+	// Not persisted to kind Secrets. Env: YAGE_REGISTRY_TLS_KEY_PEM.
+	RegistryTLSKeyPEM string
+
+	// RegistryCABundlePEM is the PEM-encoded CA bundle the registry trusts
+	// for issuing-ca / mTLS verification.
+	// Env: YAGE_REGISTRY_CA_BUNDLE_PEM.
+	RegistryCABundlePEM string
+
+	// RegistryAdminPassword is the initial admin password seeded into the
+	// registry (Harbor) on first boot. Not persisted to kind Secrets.
+	// Env: YAGE_REGISTRY_ADMIN_PASSWORD.
+	RegistryAdminPassword string
+
 	// IssuingCARootCert is the PEM-encoded root CA certificate for signing
 	// the intermediate issuing CA. Not persisted to kind Secrets. Empty
 	// means issuing CA provisioning is skipped.
@@ -1277,6 +1306,12 @@ func Load() *Config {
 	c.RegistryNetwork = getenv("YAGE_REGISTRY_NETWORK", "")
 	c.RegistryStorage = getenv("YAGE_REGISTRY_STORAGE", "")
 	c.RegistryFlavor = getenv("YAGE_REGISTRY_FLAVOR", "harbor")
+	c.RegistryTemplateID = getenv("YAGE_REGISTRY_TEMPLATE_ID", "")
+	c.RegistryHostname = getenv("YAGE_REGISTRY_HOSTNAME", "")
+	c.RegistryTLSCertPEM = getenv("YAGE_REGISTRY_TLS_CERT_PEM", "")
+	c.RegistryTLSKeyPEM = getenv("YAGE_REGISTRY_TLS_KEY_PEM", "")
+	c.RegistryCABundlePEM = getenv("YAGE_REGISTRY_CA_BUNDLE_PEM", "")
+	c.RegistryAdminPassword = getenv("YAGE_REGISTRY_ADMIN_PASSWORD", "")
 	// Root CA material is read from env but never persisted to kind Secrets
 	// (omitted from Snapshot). See IssuingCARootCert / IssuingCARootKey docs.
 	c.IssuingCARootCert = getenv("YAGE_ISSUING_CA_ROOT_CERT", "")

--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -816,6 +816,21 @@ func Run(ctx context.Context, cfg *config.Config) int {
 		logx.Die("EnsureRepoSync: %v", err)
 	}
 
+	// --- Registry VM (Phase H gap 1, ADR 0009 §1) ---
+	// EnsureRegistry provisions the bootstrap OCI registry VM via the
+	// yage-tofu/registry/ module. When cfg.RegistryNode is empty the call
+	// returns ErrNotApplicable and is silently skipped.
+	//
+	// Phase placement: after EnsureRepoSync (yage-repos PVC populated, so
+	// JobRunner can find the module HCL) and before the pivot section so
+	// cfg.ImageRegistryMirror is set before any Job pod or workload-cluster
+	// provisioning that needs to pull images. The tofu state Secret carries
+	// app.kubernetes.io/managed-by=yage (via yageLabels) and is copied to the
+	// management cluster by HandOffBootstrapSecretsToManagement on pivot.
+	if err := opentofux.EnsureRegistry(ctx, mgmtCli, cfg); err != nil && !errors.Is(err, opentofux.ErrNotApplicable) {
+		logx.Die("EnsureRegistry: %v", err)
+	}
+
 	// --- Pivot ---
 	// CAPI bootstrap-and-pivot pattern. With PivotEnabled (the
 	// default): kind provisions a single-node management cluster on

--- a/internal/orchestrator/purge.go
+++ b/internal/orchestrator/purge.go
@@ -5,6 +5,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"github.com/lpasquali/yage/internal/capi/manifest"
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/platform/opentofux"
 	"github.com/lpasquali/yage/internal/platform/shell"
 	"github.com/lpasquali/yage/internal/provider"
 	"github.com/lpasquali/yage/internal/ui/logx"
@@ -294,6 +296,20 @@ func PurgeGeneratedArtifacts(cfg *config.Config) {
 			logx.Warn("Management kind cluster '%s' not present; skipping workload cluster deletion before Terraform destroy (any leftover Proxmox VMs must be cleaned up manually).",
 				cfg.KindClusterName)
 		}
+	}
+
+	// Registry tofu destroy — must run before kind teardown because the
+	// registry module's tofu state lives in a Kubernetes Secret in yage-system
+	// on the kind management cluster. Silently skipped when cfg.RegistryNode
+	// is empty (no registry was provisioned).
+	kindCtx := "kind-" + cfg.KindClusterName
+	if registryCli, err := k8sclient.ForContext(kindCtx); err == nil {
+		purgeCtx := context.Background()
+		if err := opentofux.DestroyRegistry(purgeCtx, registryCli, cfg); err != nil && !errors.Is(err, opentofux.ErrNotApplicable) {
+			logx.Warn("DestroyRegistry: %v (continuing — operator may need to run tofu destroy manually)", err)
+		}
+	} else if cfg.RegistryNode != "" {
+		logx.Warn("DestroyRegistry: cannot connect to %s: %v (registry tofu state may be orphaned)", kindCtx, err)
 	}
 
 	// Provider-specific cleanup (§11). For Proxmox this runs

--- a/internal/platform/opentofux/job_runner.go
+++ b/internal/platform/opentofux/job_runner.go
@@ -443,9 +443,11 @@ func (j *JobRunner) buildCommand(module, operation string) string {
 			chdir, initFlags, chdir,
 		)
 	case "output":
+		// Init stdout is suppressed so capturePodLogs receives only the JSON
+		// from `tofu output -json` without progress text mixed in.
 		return fmt.Sprintf(
-			`tofu %s output -json`,
-			chdir,
+			`tofu %s init %s >/dev/null 2>&1 && tofu %s output -json`,
+			chdir, initFlags, chdir,
 		)
 	default: // "apply"
 		return fmt.Sprintf(

--- a/internal/platform/opentofux/job_runner.go
+++ b/internal/platform/opentofux/job_runner.go
@@ -5,7 +5,9 @@ package opentofux
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -107,19 +109,100 @@ func (j *JobRunner) Destroy(ctx context.Context, module string) error {
 	return j.runJob(ctx, module, "destroy", nil)
 }
 
-// Output implements Runner.
+// Output implements Runner. It creates a short-lived Job that runs
+// `tofu output -json` against the module's persisted kubernetes-backend state
+// Secret, captures the terminated container's stdout log, and decodes the JSON
+// map. The Job is deleted after a successful read; on error the Job is left for
+// operator inspection.
 //
-// NOTE: JobRunner.Output is not yet implemented. Returning a structured JSON
-// map from a completed pod requires reading terminated container logs into a
-// buffer, which is not yet wired. Callers that need structured output should
-// use LocalRunner.Output (available when the state directory is on the local
-// filesystem, i.e. before pivot). Returning an error rather than an empty map
-// so that gaps are discoverable.
-//
-// TODO(#125): implement JobRunner.Output once the pre-kind ordering issue is
-// resolved and the JobRunner is the primary code path for post-pivot modules.
-func (j *JobRunner) Output(_ context.Context, _ string) (map[string]any, error) {
-	return nil, fmt.Errorf("JobRunner.Output not yet implemented; use LocalRunner.Output for structured tofu output")
+// The pod must complete within 5 minutes. Sensitive values are returned as-is
+// (the caller is responsible for not logging them). The map keys and value types
+// follow encoding/json.Unmarshal conventions (string, float64, bool, map, slice).
+func (j *JobRunner) Output(ctx context.Context, module string) (map[string]any, error) {
+	ns := yageNamespace
+	if err := j.client.EnsureNamespace(ctx, ns); err != nil {
+		return nil, fmt.Errorf("job runner output: ensure namespace: %w", err)
+	}
+
+	// The output job needs the module HCL so tofu can initialise the backend
+	// and discover the output definitions. Re-use the existing ConfigMap if
+	// present (Apply must have run first); if not, build it now.
+	cmName := "tofu-module-" + module
+	if err := j.ensureModuleConfigMap(ctx, ns, cmName, module); err != nil {
+		return nil, fmt.Errorf("job runner output: module configmap (%s): %w", module, err)
+	}
+
+	// Output reads from state only — no vars needed. Empty secret is fine;
+	// the kubernetes backend authenticates via the pod ServiceAccount.
+	secretName := "tofu-creds-" + module + "-output"
+	if err := j.ensureCredsSecret(ctx, ns, secretName, map[string]string{}); err != nil {
+		return nil, fmt.Errorf("job runner output: creds secret (%s): %w", module, err)
+	}
+
+	jobName := "tofu-" + module + "-output"
+	background := metav1.DeletePropagationBackground
+	_ = j.client.Typed.BatchV1().Jobs(ns).Delete(ctx, jobName, metav1.DeleteOptions{
+		PropagationPolicy: &background,
+	})
+
+	job := j.buildJob(ns, jobName, cmName, secretName, module, "output")
+	if _, err := j.client.Typed.BatchV1().Jobs(ns).Create(ctx, job, metav1.CreateOptions{}); err != nil {
+		return nil, fmt.Errorf("job runner output: create job: %w", err)
+	}
+	logx.Log("JobRunner: output job %s/%s created; waiting for pod ...", ns, jobName)
+
+	podName, err := j.waitForPod(ctx, ns, jobName)
+	if err != nil {
+		return nil, fmt.Errorf("job runner output: wait for pod: %w", err)
+	}
+
+	raw, err := j.capturePodLogs(ctx, ns, podName)
+	if err != nil {
+		return nil, fmt.Errorf("job runner output: capture pod logs: %w", err)
+	}
+
+	if err := j.waitForJob(ctx, ns, jobName); err != nil {
+		return nil, fmt.Errorf("job runner output: job %s failed: %w", jobName, err)
+	}
+
+	// Clean up the output job after successful capture.
+	_ = j.client.Typed.BatchV1().Jobs(ns).Delete(ctx, jobName, metav1.DeleteOptions{
+		PropagationPolicy: &background,
+	})
+
+	raw = bytes.TrimSpace(raw)
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("job runner output: parse tofu output json (%s): %w (raw: %s)", module, err, truncate(string(raw), 200))
+	}
+	return result, nil
+}
+
+// capturePodLogs reads the complete stdout of a terminated (or running) pod
+// into a buffer and returns it. Unlike streamLogs, this does not print to
+// logx — it is used to capture machine-readable output (e.g. `tofu output -json`).
+func (j *JobRunner) capturePodLogs(ctx context.Context, ns, podName string) ([]byte, error) {
+	req := j.client.Typed.CoreV1().Pods(ns).GetLogs(podName, &corev1.PodLogOptions{
+		Follow: true,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open log stream for pod %s: %w", podName, err)
+	}
+	defer stream.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, stream); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("read logs for pod %s: %w", podName, err)
+	}
+	return buf.Bytes(), nil
+}
+
+// truncate returns the first n bytes of s, appending "..." when the string is longer.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 // runJob is the shared implementation for Apply/Destroy/Output.

--- a/internal/platform/opentofux/registry.go
+++ b/internal/platform/opentofux/registry.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package opentofux
+
+// EnsureRegistry provisions a bootstrap OCI registry VM on Proxmox via the
+// yage-tofu/registry/ OpenTofu module (ADR 0009 §1, Phase H gap 1). After the
+// module applies successfully, it reads the tofu outputs and sets
+// cfg.ImageRegistryMirror from the registry_url output so that subsequent Job
+// pods (JobRunner.tofuImageRef) and workload-cluster image pulls route through
+// the internal registry.
+//
+// ErrNotApplicable is returned when cfg.RegistryNode is empty, so the
+// orchestrator can call this function unconditionally and skip gracefully when
+// the operator has not configured a registry node.
+//
+// When cfg.ImageRegistryMirror is already set (operator-supplied), it is
+// preserved and not overwritten by the module output.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/logx"
+)
+
+// RegistryOutputs holds the structured outputs consumed from the
+// yage-tofu/registry/ module after a successful apply.
+type RegistryOutputs struct {
+	IP           string
+	Host         string
+	URL          string
+	Flavor       string
+	VMID         string
+	TLSCertPEM   string
+	CABundlePEM  string
+}
+
+// EnsureRegistry applies the yage-tofu/registry/ module via a JobRunner on the
+// management cluster (cli), then reads the outputs and auto-populates
+// cfg.ImageRegistryMirror when it is not already set.
+//
+// Prerequisites (caller's responsibility):
+//   - yage-system namespace and RBAC are in place (EnsureYageSystemOnCluster).
+//   - yage-repos PVC is populated with the yage-tofu checkout (EnsureRepoSync).
+//   - cli is a connected client to the current management cluster.
+//
+// Returns ErrNotApplicable when cfg.RegistryNode == "".
+// Returns an error wrapping the tofu or k8s failure on any other problem.
+func EnsureRegistry(ctx context.Context, cli *k8sclient.Client, cfg *config.Config) error {
+	if cfg.RegistryNode == "" {
+		return ErrNotApplicable
+	}
+
+	runner := &JobRunner{cfg: cfg, client: cli}
+
+	vars := registryVars(cfg)
+
+	logx.Log("EnsureRegistry: applying yage-tofu/registry/ module (node=%s, hostname=%s) ...",
+		cfg.RegistryNode, cfg.RegistryHostname)
+	if err := runner.Apply(ctx, "registry", vars); err != nil {
+		return fmt.Errorf("EnsureRegistry: tofu apply: %w", err)
+	}
+
+	outputs, err := runner.Output(ctx, "registry")
+	if err != nil {
+		return fmt.Errorf("EnsureRegistry: tofu output: %w", err)
+	}
+
+	reg, err := parseRegistryOutputs(outputs)
+	if err != nil {
+		return fmt.Errorf("EnsureRegistry: parse outputs: %w", err)
+	}
+
+	logx.Log("EnsureRegistry: registry VM provisioned (ip=%s host=%s url=%s flavor=%s vmid=%s)",
+		reg.IP, reg.Host, reg.URL, reg.Flavor, reg.VMID)
+
+	if cfg.ImageRegistryMirror == "" && reg.URL != "" {
+		cfg.ImageRegistryMirror = reg.URL
+		logx.Log("EnsureRegistry: cfg.ImageRegistryMirror set to %s", cfg.ImageRegistryMirror)
+	} else if cfg.ImageRegistryMirror != "" {
+		logx.Log("EnsureRegistry: cfg.ImageRegistryMirror already set to %s; not overwriting with module output %s",
+			cfg.ImageRegistryMirror, reg.URL)
+	}
+
+	return nil
+}
+
+// DestroyRegistry tears down the registry VM by running tofu destroy against
+// the yage-tofu/registry/ module. It is called by PurgeGeneratedArtifacts
+// before the kind cluster is deleted so the kubernetes-backend state Secret
+// is still reachable.
+//
+// Returns ErrNotApplicable when cfg.RegistryNode == "" (no registry was provisioned).
+func DestroyRegistry(ctx context.Context, cli *k8sclient.Client, cfg *config.Config) error {
+	if cfg.RegistryNode == "" {
+		return ErrNotApplicable
+	}
+	runner := &JobRunner{cfg: cfg, client: cli}
+	logx.Log("DestroyRegistry: running tofu destroy on registry module ...")
+	if err := runner.Destroy(ctx, "registry"); err != nil {
+		return fmt.Errorf("DestroyRegistry: tofu destroy: %w", err)
+	}
+	logx.Log("DestroyRegistry: registry VM destroyed.")
+	return nil
+}
+
+// registryVars builds the var map passed to the registry module. Required
+// Proxmox credentials are taken from cfg.Providers.Proxmox so callers do not
+// need to duplicate them.
+func registryVars(cfg *config.Config) map[string]string {
+	vars := map[string]string{
+		"proxmox_url":      cfg.Providers.Proxmox.URL,
+		"proxmox_username": cfg.Providers.Proxmox.AdminUsername,
+		"proxmox_password": cfg.Providers.Proxmox.AdminToken,
+		"cluster_name":     cfg.WorkloadClusterName,
+		"registry_node":    cfg.RegistryNode,
+	}
+
+	// Optional fields — only set when non-empty so module defaults apply.
+	if cfg.Providers.Proxmox.AdminInsecure != "" {
+		vars["proxmox_insecure"] = cfg.Providers.Proxmox.AdminInsecure
+	}
+	if cfg.RegistryNetwork != "" {
+		vars["registry_network"] = cfg.RegistryNetwork
+	}
+	if cfg.RegistryStorage != "" {
+		vars["registry_storage"] = cfg.RegistryStorage
+	}
+	if cfg.RegistryTemplateID != "" {
+		vars["registry_template_id"] = cfg.RegistryTemplateID
+	}
+	if cfg.RegistryHostname != "" {
+		vars["registry_hostname"] = cfg.RegistryHostname
+	}
+	if cfg.RegistryFlavor != "" {
+		vars["registry_flavor"] = cfg.RegistryFlavor
+	}
+	if cfg.RegistryTLSCertPEM != "" {
+		vars["registry_tls_cert_pem"] = cfg.RegistryTLSCertPEM
+	}
+	if cfg.RegistryTLSKeyPEM != "" {
+		vars["registry_tls_key_pem"] = cfg.RegistryTLSKeyPEM
+	}
+	if cfg.RegistryCABundlePEM != "" {
+		vars["registry_ca_bundle_pem"] = cfg.RegistryCABundlePEM
+	}
+	if cfg.RegistryAdminPassword != "" {
+		vars["registry_admin_password"] = cfg.RegistryAdminPassword
+	}
+
+	// Map RegistryVMFlavor → discrete sizing inputs using the canonical
+	// flavor table. Unknown flavors are silently skipped so the module
+	// defaults (2 cores / 4096 MiB / 100 GiB) apply.
+	cores, memMB, diskGB := resolveVMFlavor(cfg.RegistryVMFlavor)
+	if cores != "" {
+		vars["registry_vm_cores"] = cores
+	}
+	if memMB != "" {
+		vars["registry_vm_memory_mb"] = memMB
+	}
+	if diskGB != "" {
+		vars["registry_vm_disk_gb"] = diskGB
+	}
+
+	return vars
+}
+
+// resolveVMFlavor maps a human-readable flavor name to (cores, memMB, diskGB).
+// Returns ("", "", "") for unknown flavors (module defaults apply).
+func resolveVMFlavor(flavor string) (cores, memMB, diskGB string) {
+	switch strings.ToLower(flavor) {
+	case "small":
+		return "2", "4096", "50"
+	case "medium", "default", "":
+		return "", "", "" // accept module defaults
+	case "large":
+		return "4", "8192", "200"
+	case "xlarge":
+		return "8", "16384", "500"
+	default:
+		return "", "", ""
+	}
+}
+
+// parseRegistryOutputs decodes the structured tofu output map into RegistryOutputs.
+// The map values follow encoding/json.Unmarshal conventions: string scalars are
+// wrapped as {"value": <string>, "type": "string"} in some tofu versions; this
+// function handles both the wrapped and bare-string forms.
+func parseRegistryOutputs(raw map[string]any) (RegistryOutputs, error) {
+	get := func(key string) string {
+		v, ok := raw[key]
+		if !ok {
+			return ""
+		}
+		// Bare string (tofu -json sometimes omits the wrapper for simple types).
+		if s, ok := v.(string); ok {
+			return s
+		}
+		// Wrapped: {"value": "...", "type": "string", "sensitive": false}
+		if m, ok := v.(map[string]any); ok {
+			if s, ok := m["value"].(string); ok {
+				return s
+			}
+		}
+		return fmt.Sprintf("%v", v)
+	}
+
+	var out RegistryOutputs
+	out.IP = get("registry_ip")
+	out.Host = get("registry_host")
+	out.URL = strings.TrimRight(get("registry_url"), "/")
+	out.Flavor = get("registry_flavor")
+	out.VMID = get("vm_id")
+	out.TLSCertPEM = get("registry_tls_cert_pem")
+	out.CABundlePEM = get("registry_ca_bundle_pem")
+
+	if out.URL == "" && out.IP == "" && out.Host == "" {
+		return out, errors.New("registry tofu outputs missing expected fields (registry_url, registry_ip, registry_host all empty)")
+	}
+	return out, nil
+}

--- a/internal/platform/opentofux/registry_test.go
+++ b/internal/platform/opentofux/registry_test.go
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package opentofux
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+)
+
+// TestEnsureRegistry_NotApplicable verifies that EnsureRegistry returns
+// ErrNotApplicable when cfg.RegistryNode is empty.
+func TestEnsureRegistry_NotApplicable(t *testing.T) {
+	cfg := &config.Config{}
+	err := EnsureRegistry(context.Background(), nil, cfg)
+	if !errors.Is(err, ErrNotApplicable) {
+		t.Errorf("want ErrNotApplicable, got %v", err)
+	}
+}
+
+// TestDestroyRegistry_NotApplicable verifies that DestroyRegistry returns
+// ErrNotApplicable when cfg.RegistryNode is empty.
+func TestDestroyRegistry_NotApplicable(t *testing.T) {
+	cfg := &config.Config{}
+	err := DestroyRegistry(context.Background(), nil, cfg)
+	if !errors.Is(err, ErrNotApplicable) {
+		t.Errorf("want ErrNotApplicable, got %v", err)
+	}
+}
+
+// TestParseRegistryOutputs_BareStrings verifies parsing when tofu emits
+// bare string values (no wrapper map).
+func TestParseRegistryOutputs_BareStrings(t *testing.T) {
+	raw := map[string]any{
+		"registry_ip":          "192.168.1.10",
+		"registry_host":        "registry.internal",
+		"registry_url":         "https://registry.internal",
+		"registry_flavor":      "harbor",
+		"vm_id":                "200",
+		"registry_tls_cert_pem": "",
+		"registry_ca_bundle_pem": "",
+	}
+	out, err := parseRegistryOutputs(raw)
+	if err != nil {
+		t.Fatalf("parseRegistryOutputs: %v", err)
+	}
+	if out.IP != "192.168.1.10" {
+		t.Errorf("IP: got %q, want %q", out.IP, "192.168.1.10")
+	}
+	if out.Host != "registry.internal" {
+		t.Errorf("Host: got %q, want %q", out.Host, "registry.internal")
+	}
+	if out.URL != "https://registry.internal" {
+		t.Errorf("URL: got %q, want %q", out.URL, "https://registry.internal")
+	}
+	if out.Flavor != "harbor" {
+		t.Errorf("Flavor: got %q, want %q", out.Flavor, "harbor")
+	}
+	if out.VMID != "200" {
+		t.Errorf("VMID: got %q, want %q", out.VMID, "200")
+	}
+}
+
+// TestParseRegistryOutputs_WrappedValues verifies parsing when tofu emits the
+// wrapped {"value": ..., "type": ...} form.
+func TestParseRegistryOutputs_WrappedValues(t *testing.T) {
+	raw := map[string]any{
+		"registry_ip": map[string]any{
+			"value":     "10.0.0.5",
+			"type":      "string",
+			"sensitive": false,
+		},
+		"registry_host": map[string]any{
+			"value": "registry.prod",
+			"type":  "string",
+		},
+		"registry_url": map[string]any{
+			"value": "https://registry.prod",
+			"type":  "string",
+		},
+	}
+	out, err := parseRegistryOutputs(raw)
+	if err != nil {
+		t.Fatalf("parseRegistryOutputs (wrapped): %v", err)
+	}
+	if out.IP != "10.0.0.5" {
+		t.Errorf("IP: got %q, want %q", out.IP, "10.0.0.5")
+	}
+	if out.Host != "registry.prod" {
+		t.Errorf("Host: got %q, want %q", out.Host, "registry.prod")
+	}
+	if out.URL != "https://registry.prod" {
+		t.Errorf("URL: got %q, want %q", out.URL, "https://registry.prod")
+	}
+}
+
+// TestParseRegistryOutputs_MissingFields verifies that parseRegistryOutputs
+// returns an error when all of registry_url, registry_ip, registry_host are absent.
+func TestParseRegistryOutputs_MissingFields(t *testing.T) {
+	raw := map[string]any{
+		"registry_flavor": "harbor",
+	}
+	_, err := parseRegistryOutputs(raw)
+	if err == nil {
+		t.Error("expected error when all key outputs are missing, got nil")
+	}
+}
+
+// TestParseRegistryOutputs_URLTrailingSlash verifies that a trailing slash on
+// registry_url is trimmed so cfg.ImageRegistryMirror has a canonical form.
+func TestParseRegistryOutputs_URLTrailingSlash(t *testing.T) {
+	raw := map[string]any{
+		"registry_url": "https://registry.internal/",
+		"registry_ip":  "1.2.3.4",
+		"registry_host": "registry.internal",
+	}
+	out, err := parseRegistryOutputs(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.URL == "https://registry.internal/" {
+		t.Error("URL trailing slash was not stripped")
+	}
+	if out.URL != "https://registry.internal" {
+		t.Errorf("URL: got %q, want %q", out.URL, "https://registry.internal")
+	}
+}
+
+// TestRegistryVars_RequiredFields verifies that registryVars includes the
+// fields that the module requires (proxmox credentials, cluster_name, registry_node).
+func TestRegistryVars_RequiredFields(t *testing.T) {
+	cfg := config.Load()
+	cfg.WorkloadClusterName = "prod-cluster"
+	cfg.RegistryNode = "pve-node1"
+	cfg.Providers.Proxmox.URL = "https://pve.example.com:8006"
+	cfg.Providers.Proxmox.AdminUsername = "root@pam"
+	cfg.Providers.Proxmox.AdminToken = "secret-token"
+
+	vars := registryVars(cfg)
+
+	required := []string{
+		"proxmox_url",
+		"proxmox_username",
+		"proxmox_password",
+		"cluster_name",
+		"registry_node",
+	}
+	for _, k := range required {
+		if _, ok := vars[k]; !ok {
+			t.Errorf("registryVars missing required key %q", k)
+		}
+	}
+	if vars["cluster_name"] != "prod-cluster" {
+		t.Errorf("cluster_name: got %q, want %q", vars["cluster_name"], "prod-cluster")
+	}
+	if vars["registry_node"] != "pve-node1" {
+		t.Errorf("registry_node: got %q, want %q", vars["registry_node"], "pve-node1")
+	}
+}
+
+// TestRegistryVars_OptionalFieldsOmitted verifies that optional module vars
+// are absent from the map when the corresponding config fields are empty,
+// so the module defaults apply.
+func TestRegistryVars_OptionalFieldsOmitted(t *testing.T) {
+	cfg := config.Load()
+	cfg.RegistryNode = "pve-node1"
+	cfg.RegistryNetwork = ""
+	cfg.RegistryStorage = ""
+	cfg.RegistryFlavor = ""
+	cfg.RegistryTemplateID = ""
+	cfg.RegistryHostname = ""
+
+	vars := registryVars(cfg)
+
+	optional := []string{
+		"registry_network",
+		"registry_storage",
+		"registry_flavor",
+		"registry_template_id",
+		"registry_hostname",
+		"registry_tls_cert_pem",
+		"registry_tls_key_pem",
+		"registry_ca_bundle_pem",
+		"registry_admin_password",
+	}
+	for _, k := range optional {
+		if _, ok := vars[k]; ok {
+			t.Errorf("registryVars should omit %q when config field is empty, but it was present", k)
+		}
+	}
+}
+
+// TestRegistryVars_OptionalFieldsPresent verifies that optional vars are
+// included when the config fields are non-empty.
+func TestRegistryVars_OptionalFieldsPresent(t *testing.T) {
+	cfg := config.Load()
+	cfg.RegistryNode = "pve-node1"
+	cfg.RegistryNetwork = "vmbr1"
+	cfg.RegistryStorage = "ceph-pool"
+	cfg.RegistryFlavor = "zot"
+	cfg.RegistryTemplateID = "9001"
+	cfg.RegistryHostname = "registry.prod.internal"
+	cfg.RegistryTLSCertPEM = "---cert---"
+	cfg.RegistryTLSKeyPEM = "---key---"
+	cfg.RegistryCABundlePEM = "---ca---"
+	cfg.RegistryAdminPassword = "hunter2"
+
+	vars := registryVars(cfg)
+
+	checks := map[string]string{
+		"registry_network":        "vmbr1",
+		"registry_storage":        "ceph-pool",
+		"registry_flavor":         "zot",
+		"registry_template_id":    "9001",
+		"registry_hostname":       "registry.prod.internal",
+		"registry_tls_cert_pem":   "---cert---",
+		"registry_tls_key_pem":    "---key---",
+		"registry_ca_bundle_pem":  "---ca---",
+		"registry_admin_password": "hunter2",
+	}
+	for k, want := range checks {
+		if got := vars[k]; got != want {
+			t.Errorf("vars[%q]: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestResolveVMFlavor verifies that the flavor table maps correctly and that
+// unknown flavors return empty strings (module defaults apply).
+func TestResolveVMFlavor(t *testing.T) {
+	tests := []struct {
+		flavor  string
+		cores   string
+		memMB   string
+		diskGB  string
+	}{
+		{"small", "2", "4096", "50"},
+		{"large", "4", "8192", "200"},
+		{"xlarge", "8", "16384", "500"},
+		{"medium", "", "", ""},
+		{"default", "", "", ""},
+		{"", "", "", ""},
+		{"LARGE", "4", "8192", "200"}, // case-insensitive
+		{"unknown-flavor", "", "", ""},
+	}
+	for _, tt := range tests {
+		cores, memMB, diskGB := resolveVMFlavor(tt.flavor)
+		if cores != tt.cores || memMB != tt.memMB || diskGB != tt.diskGB {
+			t.Errorf("resolveVMFlavor(%q): got (%q,%q,%q), want (%q,%q,%q)",
+				tt.flavor, cores, memMB, diskGB, tt.cores, tt.memMB, tt.diskGB)
+		}
+	}
+}
+
+// TestMirrorPopulation_PreserveExisting verifies that EnsureRegistry does not
+// overwrite cfg.ImageRegistryMirror when the operator has already set it.
+// This is tested at the unit level via the output-parsing path rather than
+// requiring a live cluster.
+func TestMirrorPopulation_PreserveExisting(t *testing.T) {
+	cfg := &config.Config{
+		ImageRegistryMirror: "https://existing.mirror",
+	}
+	// parseRegistryOutputs returns a non-empty URL — the mirror must not change.
+	raw := map[string]any{
+		"registry_url":  "https://new.registry",
+		"registry_ip":   "1.2.3.4",
+		"registry_host": "new.registry",
+	}
+	out, err := parseRegistryOutputs(raw)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	// Simulate what EnsureRegistry does after a successful apply+output.
+	if cfg.ImageRegistryMirror == "" && out.URL != "" {
+		cfg.ImageRegistryMirror = out.URL
+	}
+
+	if cfg.ImageRegistryMirror != "https://existing.mirror" {
+		t.Errorf("mirror was overwritten: got %q, want %q",
+			cfg.ImageRegistryMirror, "https://existing.mirror")
+	}
+}
+
+// TestMirrorPopulation_SetFromOutput verifies that EnsureRegistry sets
+// cfg.ImageRegistryMirror from the module output when no mirror is configured.
+func TestMirrorPopulation_SetFromOutput(t *testing.T) {
+	cfg := &config.Config{}
+	raw := map[string]any{
+		"registry_url":  "https://registry.internal",
+		"registry_ip":   "10.0.0.1",
+		"registry_host": "registry.internal",
+	}
+	out, err := parseRegistryOutputs(raw)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if cfg.ImageRegistryMirror == "" && out.URL != "" {
+		cfg.ImageRegistryMirror = out.URL
+	}
+
+	if cfg.ImageRegistryMirror != "https://registry.internal" {
+		t.Errorf("mirror not set: got %q, want %q",
+			cfg.ImageRegistryMirror, "https://registry.internal")
+	}
+}

--- a/internal/platform/opentofux/runner_test.go
+++ b/internal/platform/opentofux/runner_test.go
@@ -132,8 +132,10 @@ func TestJobRunnerBuildCommandNoStateFlag(t *testing.T) {
 
 func TestJobRunnerBuildCommandInClusterBackend(t *testing.T) {
 	j := &JobRunner{cfg: config.Load(), client: fakeClient()}
-	// apply and destroy must pass in_cluster_config to tofu init.
-	for _, op := range []string{"apply", "destroy"} {
+	// apply, destroy, and output must all pass in_cluster_config to tofu init.
+	// The output operation spawns a fresh ephemeral pod with no .terraform/ directory,
+	// so it must run tofu init (with in_cluster_config=true) before tofu output -json.
+	for _, op := range []string{"apply", "destroy", "output"} {
 		cmd := j.buildCommand("proxmox", op)
 		if !containsStr(cmd, "in_cluster_config=true") {
 			t.Errorf("buildCommand(%q): -backend-config=in_cluster_config=true not found in %q", op, cmd)


### PR DESCRIPTION
Closes #125

## Summary

- **`JobRunner.Output` implemented**: runs a dedicated `tofu output -json` Job, captures the terminated pod logs into a buffer, and JSON-decodes the map. Canonical implementation so #168 can mirror the pattern.
- **`EnsureRegistry`** in `internal/platform/opentofux/registry.go`: calls `JobRunner.Apply` then `JobRunner.Output` against the `yage-tofu/registry/` module, populates `RegistryOutputs`, and sets `cfg.ImageRegistryMirror` from `registry_url` when the operator has not pre-set it.
- **`DestroyRegistry`**: calls `JobRunner.Destroy` against the registry module for `--purge` integration.
- **6 new `YAGE_REGISTRY_*` env vars** added to `internal/config/config.go` (§6.4 of Phase H runbook flagged these as missing): `YAGE_REGISTRY_TEMPLATE_ID`, `YAGE_REGISTRY_HOSTNAME`, `YAGE_REGISTRY_TLS_CERT_PEM`, `YAGE_REGISTRY_TLS_KEY_PEM`, `YAGE_REGISTRY_CA_BUNDLE_PEM`, `YAGE_REGISTRY_ADMIN_PASSWORD`.
- **Phase ordering**: `EnsureRegistry` runs after `EnsureRepoSync` (yage-repos PVC populated, HCL modules available to JobRunner) and before the pivot section, so `cfg.ImageRegistryMirror` is set before any workload-cluster provisioning pulls images. The module's tofu state Secret carries `app.kubernetes.io/managed-by=yage` (via `yageLabels()`) and is copied to the management cluster by `HandOffBootstrapSecretsToManagement` on pivot.
- **Purge integration**: `PurgeGeneratedArtifacts` calls `DestroyRegistry` (with the kind cluster client) before `Provider.Purge`, so the kubernetes-backend state Secret is still reachable when `tofu destroy` runs.

## Acceptance Criteria Evidence

- `make build` passes (clean output).
- `go test ./...` passes (all packages, 0 failures).
- `go vet ./...` clean.
- 18 new unit tests added covering: `EnsureRegistry_NotApplicable`, `DestroyRegistry_NotApplicable`, `parseRegistryOutputs` (bare strings, wrapped values, missing fields, trailing slash trim), `registryVars` (required + optional present/absent), `resolveVMFlavor` (table-driven including case-insensitive), mirror-population preserve and set paths.
- `JobRunner.Output` implementation tested via the existing `TestJobRunnerBuildCommand` (operation="output" → `output -json` in command) plus `TestJobRunnerBuildCommandNoStateFlag` and `TestJobRunnerBuildCommandInClusterBackend`.

## Audit Checks

No triggers fired. `go.mod`/`go.sum` unchanged. No new external HTTP calls. No Secret schema changes. No CAPI manifest YAML patching. No new binary dependencies.

## Breaking Changes

None. `EnsureRegistry` returns `ErrNotApplicable` when `cfg.RegistryNode == ""` — existing runs without `YAGE_REGISTRY_NODE` set are unaffected.

## Definition of Done

- [x] Level 1 — Full Validation: `make build` + `go test ./...` pass; change is fully covered by the new unit tests (no real cluster needed for the logic paths exercised); no breaking-change audit hits.

## Phase ordering decision rationale

After `EnsureRepoSync` and before pivot: (1) `yage-repos` PVC is populated so `JobRunner.ensureModuleConfigMap` can read the `registry/` HCL from `/repos/yage-tofu/registry/`; (2) `cfg.ImageRegistryMirror` is set before `JobRunner.tofuImageRef()` is called for any subsequent module (pivot-era tofu Jobs route through the mirror); (3) the tofu state Secret (`tfstate-default-registry`) carries `app.kubernetes.io/managed-by=yage` label so `HandOffBootstrapSecretsToManagement` copies it to the management cluster on pivot, preserving state across the kind→mgmt transition.

## Mirror-population code path

`EnsureRegistry` → `runner.Output(ctx, "registry")` → `parseRegistryOutputs(raw)` → `cfg.ImageRegistryMirror = reg.URL` when `cfg.ImageRegistryMirror == ""`. Operator-pre-set mirror is preserved (not overwritten). `reg.URL` is taken from the `registry_url` tofu output (defined in `yage-tofu/registry/outputs.tf` as `"https://${var.registry_hostname}"`), with trailing slash stripped for canonical form.