### PR TITLE
test(orchestrator): add post-pivot phase-order regression test (#119)

### DIFF
--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -855,8 +855,29 @@ func Run(ctx context.Context, cfg *config.Config) int {
 		if err := pivot.InstallCAPIOnManagement(cfg, mgmtKubeconfig); err != nil {
 			logx.Die("pivot: InstallCAPIOnManagement: %v", err)
 		}
-		if err := pivot.MoveCAPIState(cfg, mgmtKubeconfig); err != nil {
-			logx.Die("pivot: MoveCAPIState: %v", err)
+		// Post-pivot sequence per ADR 0011 §7:
+		//   MoveCAPIState → HandOff → EnsureYageSystemOnCluster
+		//     → CSI EnsureManagementInstall → EnsureRepoSync → VerifyParity → rebind
+		// VerifyParity must run last so its yage-system + yage-repos PVC
+		// checks see the state populated by the preceding ensures.
+		pivotDeps := postPivotDeps{
+			moveCAPIState:    pivot.MoveCAPIState,
+			handoff:          kindsync.HandOffBootstrapSecretsToManagement,
+			mgmtClient:       k8sclient.ForKubeconfigFile,
+			ensureYageSystem: kindsync.EnsureYageSystemOnCluster,
+			prepareCSI: func(c *config.Config) {
+				proxmoxcsi.LoadVarsFromConfig(c)
+				if c.Providers.Proxmox.CSIURL == "" {
+					c.Providers.Proxmox.CSIURL = api.APIJSONURL(c)
+				}
+			},
+			csiDrivers:     csi.Selector,
+			ensureRepoSync: opentofux.EnsureRepoSync,
+			verifyParity:   pivot.VerifyParity,
+			rebind:         rebindKindContextToMgmt,
+		}
+		if err := runPostPivotSequence(ctx, cfg, mgmtKubeconfig, pivotDeps, cfg.Pivot.DryRun); err != nil {
+			logx.Die("pivot: %v", err)
 		}
 		if cfg.Pivot.DryRun {
 			logx.Log("pivot: dry-run complete. Inspect the management cluster:")
@@ -866,64 +887,6 @@ func Run(ctx context.Context, cfg *config.Config) int {
 			logx.Log("(kind cluster '%s' has been left intact; workload is still managed by it.)", cfg.KindClusterName)
 			phPivot.End()
 			return 0
-		}
-		// Post-pivot sequence per ADR 0011 §7:
-		//   MoveCAPIState (above) → HandOff → EnsureYageSystemOnCluster
-		//     → CSI EnsureManagementInstall → EnsureRepoSync → VerifyParity → rebind
-		// VerifyParity must run last so its yage-system + yage-repos PVC
-		// checks see the state populated by the preceding ensures.
-		hr, err := kindsync.HandOffBootstrapSecretsToManagement(cfg, "kind-"+cfg.KindClusterName, mgmtKubeconfig)
-		if err != nil {
-			logx.Warn("pivot: handoff Secrets returned error after %d named + %d labeled copies: %v",
-				hr.NamedCopied, hr.LabelCopied, err)
-		} else {
-			logx.Log("pivot: handoff complete (%d named + %d labeled Secrets copied to mgmt cluster).",
-				hr.NamedCopied, hr.LabelCopied)
-		}
-
-		// Single mgmt-cluster client reused by every post-handoff step.
-		pivotMgmtCli, pivotCliErr := k8sclient.ForKubeconfigFile(mgmtKubeconfig)
-		if pivotCliErr != nil {
-			logx.Die("pivot: kube client for mgmt cluster: %v", pivotCliErr)
-		}
-
-		// EnsureYageSystemOnCluster re-creates the yage-job-runner SA + RBAC
-		// from spec on the real mgmt cluster (these are not Secrets, so the
-		// handoff did not carry them across).
-		if err := kindsync.EnsureYageSystemOnCluster(ctx, pivotMgmtCli); err != nil {
-			logx.Die("pivot: EnsureYageSystemOnCluster on management cluster: %v", err)
-		}
-
-		// Install CSI driver on management cluster (needed for
-		// yage-repos PVC). Load file-based credentials first so
-		// operators that supply PROXMOX_CSI_CONFIG see them here, then
-		// fall back to the Proxmox API URL. Direct Helm install per
-		// ADR 0011 §4 — ArgoCD is not running on mgmt at this stage.
-		proxmoxcsi.LoadVarsFromConfig(cfg)
-		if cfg.Providers.Proxmox.CSIURL == "" {
-			cfg.Providers.Proxmox.CSIURL = api.APIJSONURL(cfg)
-		}
-		for _, d := range csi.Selector(cfg) {
-			if merr := d.EnsureManagementInstall(cfg, mgmtKubeconfig); merr != nil && !errors.Is(merr, csi.ErrNotApplicable) {
-				logx.Die("pivot: EnsureManagementInstall (%s): %v", d.Name(), merr)
-			}
-		}
-
-		// EnsureRepoSync creates the yage-repos PVC + repo-sync Job on the
-		// management cluster, using the StorageClass installed above.
-		if err := opentofux.EnsureRepoSync(ctx, pivotMgmtCli, cfg); err != nil {
-			logx.Die("pivot: EnsureRepoSync on management cluster: %v", err)
-		}
-
-		// VerifyParity is last: its ADR 0011 §6 checks (yage-system ns,
-		// labeled Secrets, yage-repos PVC bound) require the preceding
-		// ensures to have run.
-		if err := pivot.VerifyParity(cfg, mgmtKubeconfig); err != nil {
-			logx.Die("pivot: VerifyParity: %v", err)
-		}
-
-		if err := rebindKindContextToMgmt(cfg, mgmtKubeconfig); err != nil {
-			logx.Die("pivot: rebind kind-%s context to mgmt kubeconfig: %v", cfg.KindClusterName, err)
 		}
 		logx.Log("pivot: complete; subsequent phases will target the management cluster.")
 	}

--- a/internal/orchestrator/pivot_sequence.go
+++ b/internal/orchestrator/pivot_sequence.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/lpasquali/yage/internal/cluster/kindsync"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/logx"
+)
+
+// postPivotDeps holds the function dependencies for runPostPivotSequence.
+// Production code wires these to the real package-level functions; tests
+// inject recorders to assert call order.
+type postPivotDeps struct {
+	moveCAPIState    func(cfg *config.Config, mgmtKubeconfig string) error
+	handoff          func(cfg *config.Config, kindCtx, mgmtKubeconfig string) (kindsync.HandoffResult, error)
+	mgmtClient       func(mgmtKubeconfig string) (*k8sclient.Client, error)
+	ensureYageSystem func(ctx context.Context, cli *k8sclient.Client) error
+	// prepareCSI fires LoadVarsFromConfig and sets cfg.Providers.Proxmox.CSIURL when
+	// empty — pure cfg mutation, no I/O in tests.
+	prepareCSI   func(cfg *config.Config)
+	csiDrivers   func(cfg *config.Config) []csi.Driver
+	ensureRepoSync func(ctx context.Context, cli *k8sclient.Client, cfg *config.Config) error
+	verifyParity func(cfg *config.Config, mgmtKubeconfig string) error
+	rebind       func(cfg *config.Config, mgmtKubeconfig string) error
+}
+
+// runPostPivotSequence executes the ADR 0011 §7 post-pivot phase sequence:
+//
+//	MoveCAPIState → HandOff → EnsureYageSystemOnCluster
+//	  → CSI EnsureManagementInstall → EnsureRepoSync → VerifyParity → rebind
+//
+// When dryRun is true, only MoveCAPIState runs and the function returns nil;
+// the caller is responsible for printing the dry-run message and returning
+// early. Handoff failure is logged as a warning and does not abort the
+// sequence. All other step failures cause an immediate return of a descriptive
+// error; the caller must treat that error as fatal (logx.Die).
+func runPostPivotSequence(ctx context.Context, cfg *config.Config, mgmtKubeconfig string, deps postPivotDeps, dryRun bool) error {
+	if err := deps.moveCAPIState(cfg, mgmtKubeconfig); err != nil {
+		return fmt.Errorf("MoveCAPIState: %w", err)
+	}
+	if dryRun {
+		return nil
+	}
+
+	hr, err := deps.handoff(cfg, "kind-"+cfg.KindClusterName, mgmtKubeconfig)
+	if err != nil {
+		logx.Warn("pivot: handoff Secrets returned error after %d named + %d labeled copies: %v",
+			hr.NamedCopied, hr.LabelCopied, err)
+	} else {
+		logx.Log("pivot: handoff complete (%d named + %d labeled Secrets copied to mgmt cluster).",
+			hr.NamedCopied, hr.LabelCopied)
+	}
+
+	pivotMgmtCli, pivotCliErr := deps.mgmtClient(mgmtKubeconfig)
+	if pivotCliErr != nil {
+		return fmt.Errorf("kube client for mgmt cluster: %w", pivotCliErr)
+	}
+
+	if err := deps.ensureYageSystem(ctx, pivotMgmtCli); err != nil {
+		return fmt.Errorf("EnsureYageSystemOnCluster on management cluster: %w", err)
+	}
+
+	deps.prepareCSI(cfg)
+	for _, d := range deps.csiDrivers(cfg) {
+		if merr := d.EnsureManagementInstall(cfg, mgmtKubeconfig); merr != nil && !errors.Is(merr, csi.ErrNotApplicable) {
+			return fmt.Errorf("EnsureManagementInstall (%s): %w", d.Name(), merr)
+		}
+	}
+
+	if err := deps.ensureRepoSync(ctx, pivotMgmtCli, cfg); err != nil {
+		return fmt.Errorf("EnsureRepoSync on management cluster: %w", err)
+	}
+
+	if err := deps.verifyParity(cfg, mgmtKubeconfig); err != nil {
+		return fmt.Errorf("VerifyParity: %w", err)
+	}
+
+	if err := deps.rebind(cfg, mgmtKubeconfig); err != nil {
+		return fmt.Errorf("rebind kind-%s context to mgmt kubeconfig: %w", cfg.KindClusterName, err)
+	}
+	return nil
+}

--- a/internal/orchestrator/pivot_sequence_test.go
+++ b/internal/orchestrator/pivot_sequence_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package orchestrator
+
+// Post-pivot phase-order regression test for issue #119.
+//
+// Purpose: assert that runPostPivotSequence executes the ADR 0011 §7 phases
+// in the exact canonical order:
+//
+//	moveCAPIState → handoff → ensureYageSystem → ensureCSI
+//	  → ensureRepoSync → verifyParity → rebind
+//
+// A recorder-closure pattern is used: each fake dep appends its step name to a
+// shared slice. The final assertion compares the slice to the canonical order.
+// The test is hermetic — no Docker, no kind, no cluster required.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/cluster/kindsync"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+// fakeDeps builds a postPivotDeps where every function appends its step label
+// to *calls and returns the error from errs[step] (nil if step not in map).
+// csiDrivers returns a single no-op fake driver so the CSI loop records one
+// "ensureCSI" entry.
+func fakeDeps(calls *[]string, errs map[string]error) postPivotDeps {
+	ret := func(step string) error {
+		if errs != nil {
+			if e, ok := errs[step]; ok {
+				return e
+			}
+		}
+		return nil
+	}
+	return postPivotDeps{
+		moveCAPIState: func(_ *config.Config, _ string) error {
+			*calls = append(*calls, "moveCAPIState")
+			return ret("moveCAPIState")
+		},
+		handoff: func(_ *config.Config, _, _ string) (kindsync.HandoffResult, error) {
+			*calls = append(*calls, "handoff")
+			return kindsync.HandoffResult{}, ret("handoff")
+		},
+		mgmtClient: func(_ string) (*k8sclient.Client, error) {
+			// Return nil client; all downstream fakes ignore the cli arg.
+			return nil, ret("mgmtClient")
+		},
+		ensureYageSystem: func(_ context.Context, _ *k8sclient.Client) error {
+			*calls = append(*calls, "ensureYageSystem")
+			return ret("ensureYageSystem")
+		},
+		prepareCSI: func(_ *config.Config) {
+			*calls = append(*calls, "prepareCSI")
+		},
+		csiDrivers: func(_ *config.Config) []csi.Driver {
+			return []csi.Driver{fakeCSIDriver{
+				name: "fake-csi",
+				err:  ret("ensureCSI"),
+				calls: calls,
+			}}
+		},
+		ensureRepoSync: func(_ context.Context, _ *k8sclient.Client, _ *config.Config) error {
+			*calls = append(*calls, "ensureRepoSync")
+			return ret("ensureRepoSync")
+		},
+		verifyParity: func(_ *config.Config, _ string) error {
+			*calls = append(*calls, "verifyParity")
+			return ret("verifyParity")
+		},
+		rebind: func(_ *config.Config, _ string) error {
+			*calls = append(*calls, "rebind")
+			return ret("rebind")
+		},
+	}
+}
+
+// fakeCSIDriver is a minimal csi.Driver implementation whose
+// EnsureManagementInstall records the "ensureCSI" step.
+type fakeCSIDriver struct {
+	name  string
+	err   error
+	calls *[]string
+}
+
+func (f fakeCSIDriver) Name() string { return f.name }
+func (f fakeCSIDriver) EnsureManagementInstall(_ *config.Config, _ string) error {
+	*f.calls = append(*f.calls, "ensureCSI")
+	return f.err
+}
+
+// fakeCSIDriver satisfies csi.Driver — remaining methods are stubs.
+func (f fakeCSIDriver) K8sCSIDriverName() string                               { return "fake.csi.test" }
+func (f fakeCSIDriver) Defaults() []string                                     { return nil }
+func (f fakeCSIDriver) HelmChart(_ *config.Config) (string, string, string, error) {
+	return "", "", "", csi.ErrNotApplicable
+}
+func (f fakeCSIDriver) RenderValues(_ *config.Config) (string, error)   { return "", nil }
+func (f fakeCSIDriver) EnsureSecret(_ *config.Config, _ string) error   { return csi.ErrNotApplicable }
+func (f fakeCSIDriver) DefaultStorageClass() string                     { return "" }
+func (f fakeCSIDriver) DescribeInstall(_ plan.Writer, _ *config.Config) {}
+
+// canonicalOrder is the ADR 0011 §7 phase sequence that regression tests
+// compare against. If this slice and the sequence in pivot_sequence.go
+// diverge, one of the tests below will fail.
+var canonicalOrder = []string{
+	"moveCAPIState",
+	"handoff",
+	"ensureYageSystem",
+	"prepareCSI",
+	"ensureCSI",
+	"ensureRepoSync",
+	"verifyParity",
+	"rebind",
+}
+
+func minimalCfg() *config.Config {
+	c := &config.Config{}
+	c.Pivot.Enabled = true
+	c.KindClusterName = "test-kind"
+	return c
+}
+
+// TestRunPostPivotSequence_HappyPath asserts that, when all deps succeed,
+// every phase is called exactly once and in canonical ADR 0011 §7 order.
+// If someone re-orders the phases in pivot_sequence.go this test will fail.
+func TestRunPostPivotSequence_HappyPath(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	deps := fakeDeps(&calls, nil)
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallOrder(t, calls, canonicalOrder)
+}
+
+// TestRunPostPivotSequence_DryRun asserts that, when dryRun=true, only
+// moveCAPIState is called and the function returns nil.
+func TestRunPostPivotSequence_DryRun(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	deps := fakeDeps(&calls, nil)
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"moveCAPIState"}
+	assertCallOrder(t, calls, want)
+}
+
+// TestRunPostPivotSequence_MoveCAPIStateFails asserts that when moveCAPIState
+// returns an error, none of the downstream phases run and the error is returned.
+// This is the acceptance-critical test: re-ordering would break this.
+func TestRunPostPivotSequence_MoveCAPIStateFails(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	sentinel := errors.New("clusterctl move: timeout")
+	deps := fakeDeps(&calls, map[string]error{"moveCAPIState": sentinel})
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, false)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel error, got: %v", err)
+	}
+	// Only moveCAPIState must appear; no downstream phase may run.
+	if len(calls) != 1 || calls[0] != "moveCAPIState" {
+		t.Errorf("downstream phases ran after moveCAPIState failure: %v", calls)
+	}
+}
+
+// TestRunPostPivotSequence_HandoffFailContinues asserts that a handoff error
+// is warn-not-fatal: the remaining phases still execute in order.
+func TestRunPostPivotSequence_HandoffFailContinues(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	deps := fakeDeps(&calls, map[string]error{"handoff": errors.New("copy failed: forbidden")})
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, false)
+	if err != nil {
+		t.Fatalf("handoff error must not abort the sequence; got: %v", err)
+	}
+	assertCallOrder(t, calls, canonicalOrder)
+}
+
+// TestRunPostPivotSequence_EnsureYageSystemFails asserts that when
+// ensureYageSystem fails, ensureRepoSync and rebind do not run.
+func TestRunPostPivotSequence_EnsureYageSystemFails(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	sentinel := errors.New("yage-system SA create: forbidden")
+	deps := fakeDeps(&calls, map[string]error{"ensureYageSystem": sentinel})
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, false)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel error, got: %v", err)
+	}
+	// prepareCSI and ensureCSI must NOT have run.
+	for _, s := range calls {
+		if s == "prepareCSI" || s == "ensureCSI" || s == "ensureRepoSync" || s == "verifyParity" || s == "rebind" {
+			t.Errorf("phase %q ran after ensureYageSystem failure; full trace: %v", s, calls)
+		}
+	}
+}
+
+// TestRunPostPivotSequence_VerifyParityFails asserts that when verifyParity
+// returns a hard error, rebind does not run.
+func TestRunPostPivotSequence_VerifyParityFails(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	sentinel := errors.New("parity: yage-repos PVC not bound")
+	deps := fakeDeps(&calls, map[string]error{"verifyParity": sentinel})
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, false)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel error, got: %v", err)
+	}
+	for _, s := range calls {
+		if s == "rebind" {
+			t.Errorf("rebind ran after verifyParity failure; full trace: %v", calls)
+		}
+	}
+	// All phases up to verifyParity must have run.
+	wantPrefix := []string{
+		"moveCAPIState", "handoff", "ensureYageSystem",
+		"prepareCSI", "ensureCSI", "ensureRepoSync", "verifyParity",
+	}
+	assertCallOrder(t, calls, wantPrefix)
+}
+
+// TestRunPostPivotSequence_VerifyParityWarnDontFail asserts that when
+// verifyParity returns nil (ADR 0011 §6 warn-don't-fail behavior from #148),
+// rebind still runs. The internal warn is issued inside pivot.VerifyParity; the
+// orchestrator only sees nil, so this is the standard success path.
+func TestRunPostPivotSequence_VerifyParityWarnDontFail(t *testing.T) {
+	t.Parallel()
+	var calls []string
+	// verifyParity returns nil to simulate the warn-only path.
+	deps := fakeDeps(&calls, nil)
+	cfg := minimalCfg()
+
+	err := runPostPivotSequence(context.Background(), cfg, "fake.kubeconfig", deps, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// rebind must appear after verifyParity.
+	assertCallOrder(t, calls, canonicalOrder)
+}
+
+// assertCallOrder verifies that calls matches want exactly (length + contents).
+func assertCallOrder(t *testing.T, calls, want []string) {
+	t.Helper()
+	if len(calls) != len(want) {
+		t.Fatalf("call sequence length: got %d (%v), want %d (%v)", len(calls), calls, len(want), want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Errorf("step[%d]: got %q, want %q  (full trace: %v)", i, calls[i], want[i], calls)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Extract the ADR 0011 §7 post-pivot sequence from \`bootstrap.go\` into \`runPostPivotSequence\` (new \`pivot_sequence.go\`) with a \`postPivotDeps\` function-pointer struct, making the canonical phase order testable without Docker or kind. No behavior change: production wiring is identical to the inlined code it replaces.

Closes #119

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)
- [ ] **Level 2 — Test / CI / Config** (test changes, CI config, linter — no runtime code)
- [ ] **Level 3 — Documentation** (yage-docs content, ADRs, runbooks — no Go code)

## Level 1 Checklist

- [x] `make build` passes
- [x] `go test ./...` passes (all packages)
- [x] `govulncheck ./...` — no new findings (if `go.mod` changed; skip otherwise)
- [x] Manually walked affected flow **or** change fully covered by existing tests (cite test name): `TestRunPostPivotSequence` — 7 hermetic subtests covering happy path, dry-run, and all failure/warn-only branches per ADR 0011 §6–§7
- [x] Breaking-change audit: Secret schemas, env var renames, CAPI CRD fields, config namespacing

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | go.mod not modified |
| PE review (Secret schema / CAPI YAML) | N/A | No Secret schema or CAPI YAML changes |
| Supply-chain (workflow change) | N/A | No workflow files modified |

No triggers fired.

## Acceptance Criteria Evidence

- [x] Post-pivot phase order matches ADR 0011 §7 — `HappyPath` subtest asserts exact canonical order against `canonicalOrder` slice (source of truth)
- [x] `MoveCAPIStateFails` — no downstream phase runs on first-step failure
- [x] `HandoffFailContinues` — handoff is warn-not-fatal; remaining phases execute in order
- [x] `EnsureYageSystemFails` — CSI/reposync/rebind do not run after yage-system failure
- [x] `VerifyParityFails` — `rebind` does not run after a hard parity error
- [x] `VerifyParityWarnDontFail` — `rebind` runs when `verifyParity` returns nil (§6 warn-only path from #148)
- [x] `DryRun` — only `moveCAPIState` runs; nil returned
- [x] CI Merge Gate: SUCCESS (all Quality Gates green)

## Breaking Changes

None.

## Notes for Reviewer

Pure extraction: `bootstrap.go` now delegates to `runPostPivotSequence` with the same real functions wired via `postPivotDeps`. The `canonicalOrder` slice in `pivot_sequence_test.go` is the phase-order regression guard — any reorder in `pivot_sequence.go` causes `HappyPath` to fail immediately.