### PR TITLE
feat(provider/linode): implement PlanDescriber (#94)

### DIFF
--- a/internal/orchestrator/plan_snapshot_test.go
+++ b/internal/orchestrator/plan_snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	// Provider self-registrations for tests.
 	_ "github.com/lpasquali/yage/internal/provider/aws"
 	_ "github.com/lpasquali/yage/internal/provider/hetzner"
+	_ "github.com/lpasquali/yage/internal/provider/linode"
 	_ "github.com/lpasquali/yage/internal/provider/proxmox"
 )
 
@@ -102,6 +103,40 @@ func TestPlanDelegation_Hetzner(t *testing.T) {
 	}
 	if !sliceEq(cw.Sections(), wantSec) {
 		t.Fatalf("Hetzner sections:\n got:  %v\n want: %v", cw.Sections(), wantSec)
+	}
+}
+
+// TestPlanDelegation_Linode confirms the Linode provider emits its
+// own named sections (not Proxmox-shaped) and that the pivot section
+// is a Skip (no PivotTarget yet).
+func TestPlanDelegation_Linode(t *testing.T) {
+	cfg := minCfg()
+	cfg.InfraProvider = "linode"
+	cfg.Providers.Linode.Region = "us-east"
+	cfg.Providers.Linode.ControlPlaneType = "g6-standard-4"
+	cfg.Providers.Linode.NodeType = "g6-standard-2"
+	cw := plan.NewCapturingWriter()
+	prov, err := provider.For(cfg)
+	if err != nil {
+		t.Fatalf("provider.For: %v", err)
+	}
+	prov.DescribeIdentity(cw, cfg)
+	prov.DescribeWorkload(cw, cfg)
+	prov.DescribePivot(cw, cfg)
+
+	wantSec := []string{
+		"Identity bootstrap — Linode",
+		"Workload Cluster — Linode",
+		"Pivot to managed mgmt cluster",
+	}
+	if !sliceEq(cw.Sections(), wantSec) {
+		t.Fatalf("Linode sections:\n got:  %v\n want: %v", cw.Sections(), wantSec)
+	}
+
+	for _, e := range cw.Events {
+		if e.Kind == plan.EventSection && strings.Contains(e.Text, "Proxmox") {
+			t.Fatalf("Linode plan contains Proxmox-shaped section: %q", e.Text)
+		}
 	}
 }
 

--- a/internal/provider/linode/plan.go
+++ b/internal/provider/linode/plan.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package linode
+
+// Linode provider plan-output hooks (PlanDescriber).
+//
+// LINODE_TOKEN is operator-supplied and consumed directly by the CAPL
+// controller — yage never mints or rotates it. The identity section
+// therefore emits a Skip line explaining the operator's responsibility,
+// matching Hetzner's HCLOUD_TOKEN precedent.
+
+import (
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/provider"
+)
+
+// DescribeIdentity for Linode: skip (operator-supplied token).
+func (p *Provider) DescribeIdentity(w provider.PlanWriter, cfg *config.Config) {
+	w.Section("Identity bootstrap — Linode")
+	w.Skip("LINODE_TOKEN supplied via env (operator-managed, not minted by yage)")
+	w.Skip("CAPL controller reads LINODE_TOKEN directly from its own Secret/env")
+}
+
+// DescribeWorkload emits the Linode workload-cluster section.
+func (p *Provider) DescribeWorkload(w provider.PlanWriter, cfg *config.Config) {
+	region := orDefault(cfg.Providers.Linode.Region, "us-east")
+
+	w.Section("Workload Cluster — Linode")
+	w.Bullet("Cluster: %s/%s, k8s %s, region %s",
+		cfg.WorkloadClusterNamespace, cfg.WorkloadClusterName,
+		cfg.WorkloadKubernetesVersion, region)
+
+	cpType := orDefault(cfg.Providers.Linode.ControlPlaneType, "g6-standard-2")
+	w.Bullet("control plane: %s × %s (LinodeMachineTemplate)",
+		cfg.ControlPlaneMachineCount, cpType)
+
+	if cfg.WorkerMachineCount != "" && cfg.WorkerMachineCount != "0" {
+		nodeType := orDefault(cfg.Providers.Linode.NodeType, "g6-standard-2")
+		w.Bullet("workers: %s × %s (LinodeMachineTemplate)",
+			cfg.WorkerMachineCount, nodeType)
+	}
+
+	if tier := orDefault(cfg.Providers.Linode.OverheadTier, "prod"); tier != "" {
+		w.Bullet("overhead tier: %s (NodeBalancer / volume / transfer counts → see Cost section)", tier)
+	}
+
+	w.Skip("Linode CSI (linode-blockstorage-csi) installed by operator via Helm — out of scope for yage")
+}
+
+// DescribePivot for Linode: no pivot target (kind remains the mgmt cluster).
+func (p *Provider) DescribePivot(w provider.PlanWriter, cfg *config.Config) {
+	w.Section("Pivot to managed mgmt cluster")
+	w.Skip("Linode provider has no PivotTarget yet (kind remains the mgmt cluster)")
+}

--- a/internal/provider/linode/plan_test.go
+++ b/internal/provider/linode/plan_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package linode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/ui/plan"
+)
+
+// TestDescribeIdentity confirms the identity section title is emitted
+// and the body explains the operator-managed token pattern.
+func TestDescribeIdentity(t *testing.T) {
+	p := &Provider{}
+	cw := plan.NewCapturingWriter()
+	p.DescribeIdentity(cw, &config.Config{})
+
+	sections := cw.Sections()
+	if len(sections) != 1 || sections[0] != "Identity bootstrap — Linode" {
+		t.Fatalf("DescribeIdentity sections: got %v, want [Identity bootstrap — Linode]", sections)
+	}
+
+	var skips []string
+	for _, e := range cw.Events {
+		if e.Kind == plan.EventSkip {
+			skips = append(skips, e.Text)
+		}
+	}
+	if len(skips) == 0 {
+		t.Fatal("DescribeIdentity: expected at least one Skip line, got none")
+	}
+	found := false
+	for _, s := range skips {
+		if strings.Contains(s, "LINODE_TOKEN") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DescribeIdentity: no Skip line mentions LINODE_TOKEN; got %v", skips)
+	}
+}
+
+// TestDescribeWorkload confirms the workload section emits cluster
+// coordinates, control-plane bullet, and at least one Skip for CSI.
+func TestDescribeWorkload(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.WorkloadClusterNamespace = "default"
+	cfg.WorkloadClusterName = "demo"
+	cfg.WorkloadKubernetesVersion = "v1.32.0"
+	cfg.ControlPlaneMachineCount = "3"
+	cfg.WorkerMachineCount = "2"
+	cfg.Providers.Linode.Region = "us-east"
+	cfg.Providers.Linode.ControlPlaneType = "g6-standard-4"
+	cfg.Providers.Linode.NodeType = "g6-standard-2"
+	cfg.Providers.Linode.OverheadTier = "prod"
+
+	p := &Provider{}
+	cw := plan.NewCapturingWriter()
+	p.DescribeWorkload(cw, cfg)
+
+	sections := cw.Sections()
+	if len(sections) != 1 || sections[0] != "Workload Cluster — Linode" {
+		t.Fatalf("DescribeWorkload sections: got %v", sections)
+	}
+
+	var bullets, skips []string
+	for _, e := range cw.Events {
+		switch e.Kind {
+		case plan.EventBullet:
+			bullets = append(bullets, e.Text)
+		case plan.EventSkip:
+			skips = append(skips, e.Text)
+		}
+	}
+
+	if len(bullets) == 0 {
+		t.Fatal("DescribeWorkload: expected bullets, got none")
+	}
+	if len(skips) == 0 {
+		t.Fatal("DescribeWorkload: expected at least one Skip (CSI), got none")
+	}
+
+	clusterBullet := bullets[0]
+	for _, want := range []string{"default", "demo", "v1.32.0", "us-east"} {
+		if !strings.Contains(clusterBullet, want) {
+			t.Errorf("cluster bullet missing %q: %q", want, clusterBullet)
+		}
+	}
+}
+
+// TestDescribeWorkload_NoWorkers confirms the workers bullet is
+// suppressed when WorkerMachineCount is "0".
+func TestDescribeWorkload_NoWorkers(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.WorkloadClusterName = "single-cp"
+	cfg.ControlPlaneMachineCount = "1"
+	cfg.WorkerMachineCount = "0"
+
+	p := &Provider{}
+	cw := plan.NewCapturingWriter()
+	p.DescribeWorkload(cw, cfg)
+
+	for _, e := range cw.Events {
+		if e.Kind == plan.EventBullet && strings.Contains(e.Text, "workers:") {
+			t.Errorf("workers bullet present with count 0: %q", e.Text)
+		}
+	}
+}
+
+// TestDescribePivot confirms the pivot section is emitted with a
+// Skip line (Linode has no PivotTarget yet).
+func TestDescribePivot(t *testing.T) {
+	p := &Provider{}
+	cw := plan.NewCapturingWriter()
+	p.DescribePivot(cw, &config.Config{})
+
+	sections := cw.Sections()
+	if len(sections) != 1 || sections[0] != "Pivot to managed mgmt cluster" {
+		t.Fatalf("DescribePivot sections: got %v", sections)
+	}
+
+	var skips []string
+	for _, e := range cw.Events {
+		if e.Kind == plan.EventSkip {
+			skips = append(skips, e.Text)
+		}
+	}
+	if len(skips) == 0 {
+		t.Fatal("DescribePivot: expected a Skip line, got none")
+	}
+}


### PR DESCRIPTION
## Summary

Implements `PlanDescriber` for the Linode provider (`DescribeIdentity`, `DescribeWorkload`, `DescribePivot`). Identity is Skip-only: `LINODE_TOKEN` is operator-supplied and consumed directly by the CAPL controller (same precedent as Hetzner's `HCLOUD_TOKEN`). Workload emits cluster coordinates, CP/worker sizing, overhead tier, and a CSI skip. Pivot is Skip (no pivot target; kind remains the mgmt cluster).

Closes #94
Epic: #78

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)

## Level 1 Checklist

- [x] `make build` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` — no new findings (if `go.mod` changed; skip otherwise)
- [x] Manually walked affected flow **or** change fully covered by existing tests (cite test name): `TestDescribeIdentity`, `TestDescribeWorkload`, `TestDescribeWorkload_NoWorkers`, `TestDescribePivot` in `internal/provider/linode/plan_test.go`; `TestPlanDelegation_Linode` in `internal/orchestrator/plan_snapshot_test.go`
- [x] Breaking-change audit: Secret schemas, env var renames, CAPI CRD fields, config namespacing

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | go.mod not modified |
| PE review (Secret schema / CAPI YAML) | N/A | no Secret schema or CAPI YAML changes |
| Supply-chain (workflow change) | N/A | no workflow files changed |

## Acceptance Criteria Evidence

- [x] `DescribeIdentity(w plan.Writer, cfg)` emits at least one `Section` + `Skip` describing the provider-specific identity fields — `TestDescribeIdentity` PASS
- [x] `DescribeWorkload(w plan.Writer, cfg)` emits sizing/image/network bullets for the workload cluster — `TestDescribeWorkload` PASS
- [x] `DescribePivot(w plan.Writer, cfg)` emits a `w.Skip()` (pivot not applicable to Linode today) — `TestDescribePivot` PASS
- [x] `go test ./...` green — all packages pass in clean worktree

## Breaking Changes

None.

## Notes for Reviewer

- `DescribeIdentity` follows the Hetzner `HCLOUD_TOKEN` precedent (Skip-only) rather than the Proxmox OpenTofu-mint pattern — Linode has no provider-side identity bootstrap in yage.
- `DescribeClusterctlInit` inherits the `MinStub` no-op; CAPL has nothing extra to add to that section.
- No new config fields introduced.