### PR TITLE
feat(manifests): add Fetcher.RegisterFunc + migrate helmvalues + converge caaph (#137, ADR 0012 E1)

### DIFF
--- a/internal/capi/caaph/caaph.go
+++ b/internal/capi/caaph/caaph.go
@@ -467,15 +467,7 @@ func ApplyWorkloadArgoCDOperatorAndCR(cfg *config.Config, f *manifests.Fetcher, 
 // If WorkloadNamespace is empty, the caller (ApplyWorkloadArgoCDOperatorAndCR)
 // has already normalized it before calling; this function does not mutate cfg.
 func buildArgoCDCR(cfg *config.Config, f *manifests.Fetcher) (string, error) {
-	return f.Render("addons/argocd/argocd-cr.yaml.tmpl", templates.HelmValuesData{
-		Cfg: cfg,
-		Bools: map[string]bool{
-			"promEnabled":    sysinfo.IsTrue(cfg.ArgoCD.PrometheusEnabled),
-			"monEnabled":     sysinfo.IsTrue(cfg.ArgoCD.MonitoringEnabled),
-			"disableIngress": sysinfo.IsTrue(cfg.ArgoCD.DisableOperatorManagedIngress),
-			"serverInsecure": sysinfo.IsTrue(cfg.ArgoCD.ServerInsecure),
-		},
-	})
+	return f.Render("addons/argocd/argocd-cr.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // waitDeploymentAvailable polls until the named Deployment has at least

--- a/internal/capi/caaph/caaph_test.go
+++ b/internal/capi/caaph/caaph_test.go
@@ -8,14 +8,17 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/capi/caaph"
+	"github.com/lpasquali/yage/internal/capi/helmvalues"
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
 // fetcher returns a Fetcher pointed at the in-package testdata fixture,
-// which mirrors the yage-manifests directory layout.
+// which mirrors the yage-manifests directory layout, with isTrue registered.
 func fetcher() *manifests.Fetcher {
-	return &manifests.Fetcher{MountRoot: "testdata"}
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+	helmvalues.RegisterIsTrue(f)
+	return f
 }
 
 // defaultCfg builds a Config with the fields used by caaph renderers.

--- a/internal/capi/caaph/testdata/yage-manifests/addons/argocd/argocd-cr.yaml.tmpl
+++ b/internal/capi/caaph/testdata/yage-manifests/addons/argocd/argocd-cr.yaml.tmpl
@@ -7,26 +7,26 @@ metadata:
 spec:
   version: {{ .Cfg.ArgoCD.Version }}
   prometheus:
-    enabled: {{ index .Bools "promEnabled" }}
+    enabled: {{ isTrue .Cfg.ArgoCD.PrometheusEnabled }}
   monitoring:
-    enabled: {{ index .Bools "monEnabled" }}
+    enabled: {{ isTrue .Cfg.ArgoCD.MonitoringEnabled }}
   notifications:
     enabled: true
   server:
-{{- if and (index .Bools "disableIngress") (index .Bools "serverInsecure") }}
+{{- if and (isTrue .Cfg.ArgoCD.DisableOperatorManagedIngress) (isTrue .Cfg.ArgoCD.ServerInsecure) }}
     insecure: true
     ingress:
       enabled: false
     grpc:
       ingress:
         enabled: false
-{{- else if index .Bools "disableIngress" }}
+{{- else if isTrue .Cfg.ArgoCD.DisableOperatorManagedIngress }}
     ingress:
       enabled: false
     grpc:
       ingress:
         enabled: false
-{{- else if index .Bools "serverInsecure" }}
+{{- else if isTrue .Cfg.ArgoCD.ServerInsecure }}
     insecure: true
     grpc:
       ingress:

--- a/internal/capi/helmvalues/helmvalues_test.go
+++ b/internal/capi/helmvalues/helmvalues_test.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package helmvalues_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/helmvalues"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// fetcher returns a Fetcher with isTrue registered, pointed at the
+// in-package testdata fixtures that mirror the yage-manifests layout.
+func fetcher() *manifests.Fetcher {
+	f := &manifests.Fetcher{MountRoot: "testdata"}
+	helmvalues.RegisterIsTrue(f)
+	return f
+}
+
+func defaultCfg() *config.Config {
+	c := &config.Config{}
+	c.WorkloadClusterName = "test-cluster"
+	c.WorkloadMetricsServerInsecureTLS = "false"
+	c.OTELCollectorMode = "deployment"
+	c.OTELImageRepository = "otel/opentelemetry-collector-k8s"
+	c.VictoriaMetricsEnabled = false
+	c.VictoriaMetricsNamespace = "victoria-metrics"
+	c.SPIRETolerateControlPlane = "false"
+	c.SPIREHelmEnableGlobalHooks = "false"
+	c.SPIREOIDCBundleSource = "CSI"
+	c.SPIREOIDCInsecureHTTP = "false"
+	c.SPIRENamespace = "spire"
+	c.KeycloakEnabled = false
+	c.KeycloakNamespace = "keycloak"
+	c.KeycloakKcHostname = ""
+	c.KeycloakKcHostnameStrict = "false"
+	c.KeycloakKcDB = ""
+	c.SPIREEnabled = false
+	return c
+}
+
+// --- MetricsServerValues ---
+
+func TestMetricsServerValues_InsecureTLSFalse(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.WorkloadMetricsServerInsecureTLS = "false"
+
+	got, err := helmvalues.MetricsServerValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("MetricsServerValues error: %v", err)
+	}
+	// When insecure TLS is false the template emits only the header comment
+	// with no YAML body (the {{- if isTrue }} block is skipped).
+	if strings.Contains(got, "kubelet-insecure-tls") {
+		t.Errorf("MetricsServerValues (false): unexpected insecure-tls line in:\n%s", got)
+	}
+}
+
+func TestMetricsServerValues_InsecureTLSTrue(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.WorkloadMetricsServerInsecureTLS = "true"
+
+	got, err := helmvalues.MetricsServerValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("MetricsServerValues error: %v", err)
+	}
+	want := `defaultArgs:
+  - --cert-dir=/tmp
+  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s
+args:
+  - --kubelet-insecure-tls`
+
+	if !strings.Contains(got, want) {
+		t.Errorf("MetricsServerValues (true) missing expected block:\ngot:\n%s", got)
+	}
+}
+
+// --- VictoriaMetricsValues ---
+
+func TestVictoriaMetricsValues_Static(t *testing.T) {
+	cfg := defaultCfg()
+
+	got, err := helmvalues.VictoriaMetricsValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("VictoriaMetricsValues error: %v", err)
+	}
+	checks := []string{
+		"server:",
+		"fullnameOverride: vmsingle",
+		"kubernetes-endpoints-metrics-ports",
+		"metrics|http-metrics",
+	}
+	for _, c := range checks {
+		if !strings.Contains(got, c) {
+			t.Errorf("VictoriaMetricsValues missing %q\nfull:\n%s", c, got)
+		}
+	}
+}
+
+// --- OpenTelemetryValues ---
+
+func TestOpenTelemetryValues_Defaults(t *testing.T) {
+	cfg := defaultCfg()
+
+	got, err := helmvalues.OpenTelemetryValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("OpenTelemetryValues error: %v", err)
+	}
+	if !strings.Contains(got, "mode: deployment") {
+		t.Errorf("OpenTelemetryValues missing mode; got:\n%s", got)
+	}
+	if !strings.Contains(got, "otel/opentelemetry-collector-k8s") {
+		t.Errorf("OpenTelemetryValues missing image repo; got:\n%s", got)
+	}
+}
+
+func TestOpenTelemetryValues_CustomMode(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.OTELCollectorMode = "daemonset"
+	cfg.OTELImageRepository = "my.registry/otel-collector"
+
+	got, err := helmvalues.OpenTelemetryValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("OpenTelemetryValues error: %v", err)
+	}
+	if !strings.Contains(got, "mode: daemonset") {
+		t.Errorf("OpenTelemetryValues missing daemonset mode; got:\n%s", got)
+	}
+	if !strings.Contains(got, "my.registry/otel-collector") {
+		t.Errorf("OpenTelemetryValues missing custom image repo; got:\n%s", got)
+	}
+}
+
+// --- GrafanaValues ---
+
+func TestGrafanaValues_VMDisabled(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.VictoriaMetricsEnabled = false
+
+	got, err := helmvalues.GrafanaValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("GrafanaValues error: %v", err)
+	}
+	if !strings.Contains(got, "service:") || !strings.Contains(got, "type: ClusterIP") {
+		t.Errorf("GrafanaValues (vm=false) missing service block; got:\n%s", got)
+	}
+	if strings.Contains(got, "datasources:") {
+		t.Errorf("GrafanaValues (vm=false) must not contain datasources; got:\n%s", got)
+	}
+}
+
+func TestGrafanaValues_VMEnabled(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.VictoriaMetricsEnabled = true
+	cfg.VictoriaMetricsNamespace = "victoria-metrics"
+
+	got, err := helmvalues.GrafanaValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("GrafanaValues error: %v", err)
+	}
+	checks := []string{
+		"datasources:",
+		"VictoriaMetrics",
+		"http://vmsingle.victoria-metrics.svc:8428",
+		"dashboardProviders:",
+		"dashboards:",
+		"k8s-cluster:",
+	}
+	for _, c := range checks {
+		if !strings.Contains(got, c) {
+			t.Errorf("GrafanaValues (vm=true) missing %q\nfull:\n%s", c, got)
+		}
+	}
+}
+
+// --- SPIREValues ---
+
+func TestSPIREValues_DefaultsNoTolerations(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.SPIRETolerateControlPlane = "false"
+	cfg.SPIREHelmEnableGlobalHooks = "false"
+	cfg.SPIREOIDCBundleSource = "CSI"
+
+	got, err := helmvalues.SPIREValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("SPIREValues error: %v", err)
+	}
+	if !strings.Contains(got, "clusterName: test-cluster") {
+		t.Errorf("SPIREValues missing clusterName; got:\n%s", got)
+	}
+	if !strings.Contains(got, "trustDomain: k8s.test-cluster.local") {
+		t.Errorf("SPIREValues missing trustDomain; got:\n%s", got)
+	}
+	if strings.Contains(got, "tolerations:") {
+		t.Errorf("SPIREValues with tolerateCP=false must not contain tolerations; got:\n%s", got)
+	}
+	if !strings.Contains(got, "installAndUpgradeHooks:") {
+		t.Errorf("SPIREValues missing installAndUpgradeHooks (hooks disabled by default); got:\n%s", got)
+	}
+	if !strings.Contains(got, "bundleSource: CSI") {
+		t.Errorf("SPIREValues missing bundleSource CSI; got:\n%s", got)
+	}
+}
+
+func TestSPIREValues_WithTolerations(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.SPIRETolerateControlPlane = "true"
+
+	got, err := helmvalues.SPIREValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("SPIREValues error: %v", err)
+	}
+	if !strings.Contains(got, "spire-server:") {
+		t.Errorf("SPIREValues with tolerateCP=true missing spire-server tolerations; got:\n%s", got)
+	}
+	if !strings.Contains(got, "node-role.kubernetes.io/control-plane") {
+		t.Errorf("SPIREValues with tolerateCP=true missing control-plane taint; got:\n%s", got)
+	}
+}
+
+func TestSPIREValues_OIDCInsecureWithKeycloak(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.SPIREOIDCInsecureHTTP = "true"
+	cfg.KeycloakEnabled = true
+
+	got, err := helmvalues.SPIREValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("SPIREValues error: %v", err)
+	}
+	if !strings.Contains(got, "tls:") || !strings.Contains(got, "enabled: false") {
+		t.Errorf("SPIREValues (oidc insecure + keycloak) missing tls.spire.enabled: false; got:\n%s", got)
+	}
+}
+
+// --- KeycloakValues ---
+
+func TestKeycloakValues_Disabled(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.KeycloakEnabled = false
+
+	got, err := helmvalues.KeycloakValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("KeycloakValues error: %v", err)
+	}
+	// When disabled the template emits nothing (only the header comment).
+	if strings.Contains(got, "KC_HOSTNAME") {
+		t.Errorf("KeycloakValues (disabled) must not contain KC_HOSTNAME; got:\n%s", got)
+	}
+}
+
+func TestKeycloakValues_EnabledNoSPIRE(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.KeycloakEnabled = true
+	cfg.KeycloakKcHostname = "keycloak.example.com"
+	cfg.KeycloakKcHostnameStrict = "false"
+	cfg.SPIREEnabled = false
+
+	got, err := helmvalues.KeycloakValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("KeycloakValues error: %v", err)
+	}
+	checks := []string{
+		"KC_HOSTNAME",
+		"keycloak.example.com",
+		"KC_HOSTNAME_STRICT",
+	}
+	for _, c := range checks {
+		if !strings.Contains(got, c) {
+			t.Errorf("KeycloakValues (enabled, no spire) missing %q\nfull:\n%s", c, got)
+		}
+	}
+	if strings.Contains(got, "SPIFFE_OIDC") {
+		t.Errorf("KeycloakValues (no spire) must not contain SPIFFE_OIDC; got:\n%s", got)
+	}
+}
+
+func TestKeycloakValues_EnabledWithSPIREInsecureHTTP(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.KeycloakEnabled = true
+	cfg.KeycloakKcHostname = "keycloak.example.com"
+	cfg.KeycloakKcHostnameStrict = "false"
+	cfg.SPIREEnabled = true
+	cfg.SPIREOIDCInsecureHTTP = "true"
+	cfg.SPIRENamespace = "spire"
+
+	got, err := helmvalues.KeycloakValues(fetcher(), cfg)
+	if err != nil {
+		t.Fatalf("KeycloakValues error: %v", err)
+	}
+	checks := []string{
+		"SPIFFE_OIDC_WELL_KNOWN_URL",
+		"http://test-cluster-spire-spiffe-oidc-discovery-provider.spire.svc.cluster.local/.well-known/openid-configuration",
+		"KEYCLOAK_SPIRE_IDP_HELP",
+	}
+	for _, c := range checks {
+		if !strings.Contains(got, c) {
+			t.Errorf("KeycloakValues (spire insecure) missing %q\nfull:\n%s", c, got)
+		}
+	}
+}

--- a/internal/capi/helmvalues/metrics.go
+++ b/internal/capi/helmvalues/metrics.go
@@ -8,31 +8,21 @@
 package helmvalues
 
 import (
+	"github.com/lpasquali/yage/internal/capi/templates"
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+	"github.com/lpasquali/yage/internal/platform/sysinfo"
 )
 
-// MetricsServerValues returns the metrics-server Helm values block.
-// Returns empty string when insecure-TLS is false (the Helm chart
-// keeps its defaults).
-func MetricsServerValues(cfg *config.Config) string {
-	if cfg.WorkloadMetricsServerInsecureTLS == "" ||
-		!isTrue(cfg.WorkloadMetricsServerInsecureTLS) {
-		return ""
-	}
-	return `defaultArgs:
-  - --cert-dir=/tmp
-  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-  - --kubelet-use-node-status-port
-  - --metric-resolution=15s
-args:
-  - --kubelet-insecure-tls
-`
+// RegisterIsTrue registers the isTrue template function on f.
+// Must be called before any Render invocation that uses a template
+// with isTrue (ADR 0012 Errata E1).
+func RegisterIsTrue(f *manifests.Fetcher) {
+	f.RegisterFunc("isTrue", sysinfo.IsTrue)
 }
 
-func isTrue(s string) bool {
-	switch s {
-	case "true", "1", "yes", "y", "on", "TRUE", "Yes", "Y", "On":
-		return true
-	}
-	return false
+// MetricsServerValues returns the metrics-server Helm values block
+// rendered from the yage-manifests template.
+func MetricsServerValues(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("addons/metrics-server/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }

--- a/internal/capi/helmvalues/observability.go
+++ b/internal/capi/helmvalues/observability.go
@@ -5,108 +5,38 @@ package helmvalues
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/lpasquali/yage/internal/capi/templates"
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+	"github.com/lpasquali/yage/internal/platform/sysinfo"
 )
 
-// VictoriaMetricsValues returns the VictoriaMetrics Helm values
-// block. Static body — no config knobs.
-func VictoriaMetricsValues() string {
-	return `server:
-  fullnameOverride: vmsingle
-  scrape:
-    enabled: true
-    extraScrapeConfigs:
-      - job_name: kubernetes-endpoints-metrics-ports
-        kubernetes_sd_configs:
-          - role: endpoints
-        relabel_configs:
-          - action: keep
-            source_labels: [__meta_kubernetes_endpoint_port_name]
-            regex: metrics|http-metrics
-          - action: replace
-            source_labels: [__meta_kubernetes_namespace]
-            target_label: namespace
-          - action: replace
-            source_labels: [__meta_kubernetes_service_name]
-            target_label: service
-`
+// VictoriaMetricsValues returns the VictoriaMetrics Helm values block
+// rendered from the yage-manifests template.
+func VictoriaMetricsValues(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("addons/observability/values-victoria-metrics.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
-// OpenTelemetryValues returns the OpenTelemetry collector Helm
-// values block.
-func OpenTelemetryValues(cfg *config.Config) string {
-	mode := cfg.OTELCollectorMode
-	if mode == "" {
-		mode = "deployment"
-	}
-	img := cfg.OTELImageRepository
-	if img == "" {
-		img = "otel/opentelemetry-collector-k8s"
-	}
-	return fmt.Sprintf("mode: %s\nimage:\n  repository: %s\n", mode, img)
+// OpenTelemetryValues returns the OpenTelemetry collector Helm values
+// block rendered from the yage-manifests template.
+func OpenTelemetryValues(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("addons/opentelemetry/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
-// GrafanaValues returns the Grafana Helm values block. Two branches:
-// VictoriaMetrics disabled → service only; enabled → add a
-// VictoriaMetrics datasource + three default dashboards.
-func GrafanaValues(cfg *config.Config) string {
-	if !cfg.VictoriaMetricsEnabled {
-		return "service:\n  type: ClusterIP\n"
-	}
-	return fmt.Sprintf(`service:
-  type: ClusterIP
-datasources:
-  datasources.yaml:
-    apiVersion: 1
-    datasources:
-      - name: VictoriaMetrics
-        type: prometheus
-        url: http://vmsingle.%s.svc:8428
-        access: proxy
-        isDefault: true
-        jsonData:
-          httpMethod: POST
-          manageAlerts: true
-          prometheusType: Prometheus
-dashboardProviders:
-  dashboardproviders.yaml:
-    apiVersion: 1
-    providers:
-      - name: default
-        orgId: 1
-        folder: ""
-        type: file
-        disableDeletion: false
-        editable: true
-        options:
-          path: /var/lib/grafana/dashboards/default
-dashboards:
-  default:
-    k8s-cluster:
-      gnetId: 7249
-      revision: 1
-      datasource: VictoriaMetrics
-    k8s-api-server:
-      gnetId: 12006
-      revision: 1
-      datasource: VictoriaMetrics
-    victoriametrics-single:
-      gnetId: 10229
-      revision: 1
-      datasource: VictoriaMetrics
-`,
-		cfg.VictoriaMetricsNamespace,
-	)
+// GrafanaValues returns the Grafana Helm values block rendered from the
+// yage-manifests template.
+func GrafanaValues(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("addons/observability/values-grafana.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // SPIRESubchartTolerations returns the tolerations block for
 // spire-server, spire-controller-manager, spire-agent, and
 // spiffe-csi-driver — or "" when SPIRE_TOLERATE_CONTROL_PLANE is
-// false.
+// false. Kept as a pure-Go helper for backward compatibility until
+// issue #142 retires this package.
 func SPIRESubchartTolerations(cfg *config.Config) string {
-	if !isTrue(cfg.SPIRETolerateControlPlane) {
+	if !sysinfo.IsTrue(cfg.SPIRETolerateControlPlane) {
 		return ""
 	}
 	block := func(name string) string {
@@ -124,92 +54,14 @@ func SPIRESubchartTolerations(cfg *config.Config) string {
 		block("spire-agent") + block("spiffe-csi-driver")
 }
 
-// SPIREValues returns the SPIRE Helm values block.
-func SPIREValues(cfg *config.Config) string {
-	var sb strings.Builder
-	sb.WriteString("global:\n")
-	sb.WriteString("  spire:\n")
-	fmt.Fprintf(&sb, "    clusterName: %s\n", cfg.WorkloadClusterName)
-	fmt.Fprintf(&sb, "    trustDomain: k8s.%s.local\n", cfg.WorkloadClusterName)
-	if !isTrue(cfg.SPIREHelmEnableGlobalHooks) {
-		sb.WriteString("  installAndUpgradeHooks:\n    enabled: false\n")
-		sb.WriteString("  deleteHooks:\n    enabled: false\n")
-	}
-	sb.WriteString(SPIRESubchartTolerations(cfg))
-	sb.WriteString("spiffe-oidc-discovery-provider:\n")
-	if isTrue(cfg.SPIRETolerateControlPlane) {
-		sb.WriteString(`  tolerations:
-    - key: "node-role.kubernetes.io/control-plane"
-      operator: Exists
-      effect: NoSchedule
-    - key: "node-role.kubernetes.io/master"
-      operator: Exists
-      effect: NoSchedule
-`)
-	}
-	if cfg.SPIREOIDCBundleSource == "ConfigMap" {
-		sb.WriteString("  bundleSource: ConfigMap\n")
-	} else {
-		sb.WriteString("  bundleSource: CSI\n")
-	}
-	sb.WriteString("  config:\n")
-	if cfg.KeycloakEnabled {
-		sb.WriteString("    setKeyUse: true\n")
-	} else {
-		sb.WriteString("    setKeyUse: false\n")
-	}
-	if cfg.KeycloakEnabled && isTrue(cfg.SPIREOIDCInsecureHTTP) {
-		sb.WriteString("  tls:\n    spire:\n      enabled: false\n")
-	}
-	return sb.String()
+// SPIREValues returns the SPIRE Helm values block rendered from the
+// yage-manifests template.
+func SPIREValues(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("addons/spire/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
-// KeycloakValues returns the Keycloak Helm values block. Returns
-// "" when KEYCLOAK_ENABLED is false.
-func KeycloakValues(cfg *config.Config) string {
-	if !cfg.KeycloakEnabled {
-		return ""
-	}
-	kcHost := cfg.KeycloakKcHostname
-	if kcHost == "" {
-		kcHost = cfg.WorkloadClusterName + "-keycloak-keycloakx." +
-			cfg.KeycloakNamespace + ".svc.cluster.local"
-	}
-	strict := cfg.KeycloakKcHostnameStrict
-	if strict == "" {
-		strict = "false"
-	}
-	var sb strings.Builder
-	fmt.Fprintf(&sb, `args:
-  - start
-extraEnv: |
-  - name: KC_HOSTNAME_STRICT
-    value: "%s"
-  - name: KC_HOSTNAME
-    value: "%s"
-`, strict, kcHost)
-	if cfg.KeycloakKcDB != "" {
-		fmt.Fprintf(&sb, "  - name: KC_DB\n    value: \"%s\"\n", cfg.KeycloakKcDB)
-	}
-	if cfg.SPIREEnabled {
-		oidc := cfg.WorkloadClusterName + "-spire-spiffe-oidc-discovery-provider." +
-			cfg.SPIRENamespace + ".svc.cluster.local"
-		if isTrue(cfg.SPIREOIDCInsecureHTTP) {
-			fmt.Fprintf(&sb, `  - name: SPIFFE_OIDC_WELL_KNOWN_URL
-    value: "http://%s/.well-known/openid-configuration"
-  - name: SPIFFE_OIDC_ISSUER_HOST
-    value: "%s"
-  - name: KEYCLOAK_SPIRE_IDP_HELP
-    value: "Add an Identity Provider (OpenID v1) in Keycloak using SPIFFE_OIDC_WELL_KNOWN_URL; map SPIFFE SVIDs to users as needed."
-`, oidc, oidc)
-		} else {
-			fmt.Fprintf(&sb, `  - name: SPIFFE_OIDC_WELL_KNOWN_URL
-    value: "https://%s/.well-known/openid-configuration"
-  - name: SPIFFE_OIDC_ISSUER_HOST
-    value: "%s"
-`, oidc, oidc)
-		}
-	}
-	sb.WriteString("\n")
-	return sb.String()
+// KeycloakValues returns the Keycloak Helm values block rendered from
+// the yage-manifests template.
+func KeycloakValues(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("addons/keycloak/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }

--- a/internal/capi/helmvalues/testdata/yage-manifests/addons/keycloak/values.yaml.tmpl
+++ b/internal/capi/helmvalues/testdata/yage-manifests/addons/keycloak/values.yaml.tmpl
@@ -1,0 +1,31 @@
+# yage-manifests/addons/keycloak/values.yaml.tmpl
+{{- if .Cfg.KeycloakEnabled }}
+args:
+  - start
+extraEnv: |
+  - name: KC_HOSTNAME_STRICT
+    value: "{{ .Cfg.KeycloakKcHostnameStrict }}"
+  - name: KC_HOSTNAME
+    value: "{{ .Cfg.KeycloakKcHostname }}"
+{{- if .Cfg.KeycloakKcDB }}
+  - name: KC_DB
+    value: "{{ .Cfg.KeycloakKcDB }}"
+{{- end }}
+{{- if .Cfg.SPIREEnabled }}
+{{- $oidc := printf "%s-spire-spiffe-oidc-discovery-provider.%s.svc.cluster.local" .Cfg.WorkloadClusterName .Cfg.SPIRENamespace }}
+{{- if isTrue .Cfg.SPIREOIDCInsecureHTTP }}
+  - name: SPIFFE_OIDC_WELL_KNOWN_URL
+    value: "http://{{ $oidc }}/.well-known/openid-configuration"
+  - name: SPIFFE_OIDC_ISSUER_HOST
+    value: "{{ $oidc }}"
+  - name: KEYCLOAK_SPIRE_IDP_HELP
+    value: "Add an Identity Provider (OpenID v1) in Keycloak using SPIFFE_OIDC_WELL_KNOWN_URL; map SPIFFE SVIDs to users as needed."
+{{- else }}
+  - name: SPIFFE_OIDC_WELL_KNOWN_URL
+    value: "https://{{ $oidc }}/.well-known/openid-configuration"
+  - name: SPIFFE_OIDC_ISSUER_HOST
+    value: "{{ $oidc }}"
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/internal/capi/helmvalues/testdata/yage-manifests/addons/metrics-server/values.yaml.tmpl
+++ b/internal/capi/helmvalues/testdata/yage-manifests/addons/metrics-server/values.yaml.tmpl
@@ -1,0 +1,10 @@
+# yage-manifests/addons/metrics-server/values.yaml.tmpl
+{{- if isTrue .Cfg.WorkloadMetricsServerInsecureTLS }}
+defaultArgs:
+  - --cert-dir=/tmp
+  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s
+args:
+  - --kubelet-insecure-tls
+{{- end }}

--- a/internal/capi/helmvalues/testdata/yage-manifests/addons/observability/values-grafana.yaml.tmpl
+++ b/internal/capi/helmvalues/testdata/yage-manifests/addons/observability/values-grafana.yaml.tmpl
@@ -1,0 +1,44 @@
+# yage-manifests/addons/observability/values-grafana.yaml.tmpl
+service:
+  type: ClusterIP
+{{- if .Cfg.VictoriaMetricsEnabled }}
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: VictoriaMetrics
+        type: prometheus
+        url: http://vmsingle.{{ .Cfg.VictoriaMetricsNamespace }}.svc:8428
+        access: proxy
+        isDefault: true
+        jsonData:
+          httpMethod: POST
+          manageAlerts: true
+          prometheusType: Prometheus
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+      - name: default
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/default
+dashboards:
+  default:
+    k8s-cluster:
+      gnetId: 7249
+      revision: 1
+      datasource: VictoriaMetrics
+    k8s-api-server:
+      gnetId: 12006
+      revision: 1
+      datasource: VictoriaMetrics
+    victoriametrics-single:
+      gnetId: 10229
+      revision: 1
+      datasource: VictoriaMetrics
+{{- end }}

--- a/internal/capi/helmvalues/testdata/yage-manifests/addons/observability/values-victoria-metrics.yaml.tmpl
+++ b/internal/capi/helmvalues/testdata/yage-manifests/addons/observability/values-victoria-metrics.yaml.tmpl
@@ -1,0 +1,19 @@
+# yage-manifests/addons/observability/values-victoria-metrics.yaml.tmpl
+server:
+  fullnameOverride: vmsingle
+  scrape:
+    enabled: true
+    extraScrapeConfigs:
+      - job_name: kubernetes-endpoints-metrics-ports
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - action: keep
+            source_labels: [__meta_kubernetes_endpoint_port_name]
+            regex: metrics|http-metrics
+          - action: replace
+            source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - action: replace
+            source_labels: [__meta_kubernetes_service_name]
+            target_label: service

--- a/internal/capi/helmvalues/testdata/yage-manifests/addons/opentelemetry/values.yaml.tmpl
+++ b/internal/capi/helmvalues/testdata/yage-manifests/addons/opentelemetry/values.yaml.tmpl
@@ -1,0 +1,4 @@
+# yage-manifests/addons/opentelemetry/values.yaml.tmpl
+mode: {{ .Cfg.OTELCollectorMode }}
+image:
+  repository: {{ .Cfg.OTELImageRepository }}

--- a/internal/capi/helmvalues/testdata/yage-manifests/addons/spire/values.yaml.tmpl
+++ b/internal/capi/helmvalues/testdata/yage-manifests/addons/spire/values.yaml.tmpl
@@ -1,0 +1,67 @@
+# yage-manifests/addons/spire/values.yaml.tmpl
+global:
+  spire:
+    clusterName: {{ .Cfg.WorkloadClusterName }}
+    trustDomain: k8s.{{ .Cfg.WorkloadClusterName }}.local
+{{- if not (isTrue .Cfg.SPIREHelmEnableGlobalHooks) }}
+  installAndUpgradeHooks:
+    enabled: false
+  deleteHooks:
+    enabled: false
+{{- end }}
+{{- if isTrue .Cfg.SPIRETolerateControlPlane }}
+spire-server:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+spire-controller-manager:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+spire-agent:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+spiffe-csi-driver:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+{{- end }}
+spiffe-oidc-discovery-provider:
+{{- if isTrue .Cfg.SPIRETolerateControlPlane }}
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: Exists
+      effect: NoSchedule
+    - key: "node-role.kubernetes.io/master"
+      operator: Exists
+      effect: NoSchedule
+{{- end }}
+  bundleSource: {{ .Cfg.SPIREOIDCBundleSource }}
+  config:
+{{- if .Cfg.KeycloakEnabled }}
+    setKeyUse: true
+{{- else }}
+    setKeyUse: false
+{{- end }}
+{{- if and .Cfg.KeycloakEnabled (isTrue .Cfg.SPIREOIDCInsecureHTTP) }}
+  tls:
+    spire:
+      enabled: false
+{{- end }}

--- a/internal/capi/templates/templates.go
+++ b/internal/capi/templates/templates.go
@@ -23,14 +23,8 @@ import "github.com/lpasquali/yage/internal/config"
 
 // HelmValuesData is passed to addons/<addon>/values.yaml.tmpl,
 // csi/<driver>/values.yaml.tmpl, and addons/<addon>/argocd-cr.yaml.tmpl.
-//
-// Bools carries pre-computed boolean flags for templates that branch on
-// config fields stored as string (e.g. ArgoCD.PrometheusEnabled). Callers
-// populate only the keys their template references; missingkey=error catches
-// any key the template expects but the caller omits.
 type HelmValuesData struct {
-	Cfg  *config.Config
-	Bools map[string]bool
+	Cfg *config.Config
 }
 
 // ArgoApplicationData is passed to addons/<addon>/application.yaml.tmpl.

--- a/internal/orchestrator/bootstrap.go
+++ b/internal/orchestrator/bootstrap.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/lpasquali/yage/internal/capi/argocd"
 	"github.com/lpasquali/yage/internal/capi/caaph"
+	"github.com/lpasquali/yage/internal/capi/helmvalues"
 	"github.com/lpasquali/yage/internal/cluster/capacity"
 	"github.com/lpasquali/yage/internal/capi/manifest"
 	"github.com/lpasquali/yage/internal/config"
@@ -958,6 +959,7 @@ func Run(ctx context.Context, cfg *config.Config) int {
 	)
 	opentofux.RecreateIdentitiesWorkloadCSISecrets(cfg)
 	mf := &manifests.Fetcher{}
+	helmvalues.RegisterIsTrue(mf)
 	caaph.ApplyWorkloadCiliumHelmChartProxy(cfg, mf)
 	WaitForWorkloadClusterReady(cfg)
 	caaph.ApplyWorkloadCiliumLBBToWorkload(cfg, func() (string, error) {

--- a/internal/orchestrator/workloadapps.go
+++ b/internal/orchestrator/workloadapps.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/capi/helmvalues"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi/proxmoxcsi"
 	"github.com/lpasquali/yage/internal/cost"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
@@ -45,7 +46,7 @@ func cnpgSuppressedByManagedPG(cfg *config.Config) bool {
 // spire-crds+spire, victoriametrics, otel, grafana, backstage,
 // keycloak, keycloak-realm-operator) into a single multi-doc YAML
 // and applies it to the workload via its kubeconfig.
-func ApplyWorkloadArgoCDApplications(cfg *config.Config) {
+func ApplyWorkloadArgoCDApplications(cfg *config.Config, f *manifests.Fetcher) {
 	if !cfg.ArgoCD.Enabled || !cfg.ArgoCD.WorkloadEnabled {
 		return
 	}
@@ -63,7 +64,13 @@ func ApplyWorkloadArgoCDApplications(cfg *config.Config) {
 			cfg.WorkloadClusterName+"-metrics-server", "kube-system",
 			"https://github.com/kubernetes-sigs/metrics-server",
 			"charts/metrics-server", cfg.MetricsServerGitChartTag,
-			"-3", helmvalues.MetricsServerValues(cfg),
+			"-3", func() string {
+				v, err := helmvalues.MetricsServerValues(f, cfg)
+				if err != nil {
+					logx.Die("metrics-server values: %v", err)
+				}
+				return v
+			}(),
 			"metrics-server", "metrics-server",
 		))
 	}
@@ -160,25 +167,49 @@ storageClass:
 		sb.WriteString(wlargocd.Helm(cfg,
 			cfg.WorkloadClusterName+"-spire", cfg.SPIRENamespace,
 			cfg.SPIREChartRepoURL, cfg.SPIREChartName, cfg.SPIREChartVersion,
-			"5", helmvalues.SPIREValues(cfg), "spire"))
+			"5", func() string {
+				v, err := helmvalues.SPIREValues(f, cfg)
+				if err != nil {
+					logx.Die("spire values: %v", err)
+				}
+				return v
+			}(), "spire"))
 	}
 	if cfg.VictoriaMetricsEnabled {
 		sb.WriteString(wlargocd.Helm(cfg,
 			cfg.WorkloadClusterName+"-victoria-metrics-single", cfg.VictoriaMetricsNamespace,
 			cfg.VictoriaMetricsChartRepoURL, cfg.VictoriaMetricsChartName, cfg.VictoriaMetricsChartVersion,
-			"6", helmvalues.VictoriaMetricsValues(), "victoria-metrics"))
+			"6", func() string {
+				v, err := helmvalues.VictoriaMetricsValues(f, cfg)
+				if err != nil {
+					logx.Die("victoria-metrics values: %v", err)
+				}
+				return v
+			}(), "victoria-metrics"))
 	}
 	if cfg.OTELEnabled {
 		sb.WriteString(wlargocd.Helm(cfg,
 			cfg.WorkloadClusterName+"-opentelemetry-collector", cfg.OTELNamespace,
 			cfg.OTELChartRepoURL, cfg.OTELChartName, cfg.OTELChartVersion,
-			"6", helmvalues.OpenTelemetryValues(cfg), "opentelemetry"))
+			"6", func() string {
+				v, err := helmvalues.OpenTelemetryValues(f, cfg)
+				if err != nil {
+					logx.Die("opentelemetry values: %v", err)
+				}
+				return v
+			}(), "opentelemetry"))
 	}
 	if cfg.GrafanaEnabled {
 		sb.WriteString(wlargocd.Helm(cfg,
 			cfg.WorkloadClusterName+"-grafana", cfg.GrafanaNamespace,
 			cfg.GrafanaChartRepoURL, "grafana", cfg.GrafanaChartVersion,
-			"6", helmvalues.GrafanaValues(cfg), "grafana"))
+			"6", func() string {
+				v, err := helmvalues.GrafanaValues(f, cfg)
+				if err != nil {
+					logx.Die("grafana values: %v", err)
+				}
+				return v
+			}(), "grafana"))
 	}
 	if cfg.BackstageEnabled {
 		if cfg.BackstageChartRepoURL == "" {
@@ -194,7 +225,13 @@ storageClass:
 		sb.WriteString(wlargocd.Helm(cfg,
 			cfg.WorkloadClusterName+"-keycloak", cfg.KeycloakNamespace,
 			cfg.KeycloakChartRepoURL, cfg.KeycloakChartName, cfg.KeycloakChartVersion,
-			"8", helmvalues.KeycloakValues(cfg), "keycloak"))
+			"8", func() string {
+				v, err := helmvalues.KeycloakValues(f, cfg)
+				if err != nil {
+					logx.Die("keycloak values: %v", err)
+				}
+				return v
+			}(), "keycloak"))
 	}
 	if cfg.KeycloakOperatorEnabled && cfg.KeycloakEnabled {
 		if cfg.KeycloakOperatorGitURL == "" {

--- a/internal/platform/manifests/fetcher.go
+++ b/internal/platform/manifests/fetcher.go
@@ -43,6 +43,9 @@ type Fetcher struct {
 	// MountRoot is the path at which the yage-repos PVC is mounted in
 	// the current pod. Empty means defaultMountRoot ("/repos").
 	MountRoot string
+
+	// funcs holds functions registered via RegisterFunc.
+	funcs template.FuncMap
 }
 
 // NewFetcher constructs a Fetcher with MountRoot left at its default
@@ -50,6 +53,17 @@ type Fetcher struct {
 // mount point may set MountRoot directly on the returned value.
 func NewFetcher() *Fetcher {
 	return &Fetcher{}
+}
+
+// RegisterFunc registers fn under name in the Fetcher's internal FuncMap.
+// The function is applied on every subsequent Render call.
+// RegisterFunc is the only permitted extension point for adding template
+// functions (ADR 0012 §4.1). Future additions require an ADR amendment.
+func (f *Fetcher) RegisterFunc(name string, fn any) {
+	if f.funcs == nil {
+		f.funcs = make(template.FuncMap)
+	}
+	f.funcs[name] = fn
 }
 
 // Render reads the .yaml.tmpl at templatePath (relative to the
@@ -67,9 +81,11 @@ func (f *Fetcher) Render(templatePath string, data any) (string, error) {
 		return "", fmt.Errorf("manifests: read template %s: %w", fullPath, err)
 	}
 
-	tmpl, err := template.New(filepath.Base(templatePath)).
-		Option("missingkey=error").
-		Parse(string(raw))
+	t := template.New(filepath.Base(templatePath)).Option("missingkey=error")
+	if len(f.funcs) > 0 {
+		t = t.Funcs(f.funcs)
+	}
+	tmpl, err := t.Parse(string(raw))
 	if err != nil {
 		return "", fmt.Errorf("manifests: parse template %s: %w", fullPath, err)
 	}

--- a/internal/platform/manifests/fetcher_test.go
+++ b/internal/platform/manifests/fetcher_test.go
@@ -102,3 +102,32 @@ func TestNewFetcher_DefaultsMountRootEmpty(t *testing.T) {
 		t.Errorf("NewFetcher MountRoot = %q; want empty string (resolved at render time)", f.MountRoot)
 	}
 }
+
+func TestFetcher_RegisterFunc_AppliedOnRender(t *testing.T) {
+	f := &Fetcher{MountRoot: "testdata"}
+	f.RegisterFunc("greet", func(name string) string { return "hello-" + name })
+
+	got, err := f.Render("addons/sample/funcmap.yaml.tmpl", sampleData{Name: "world"})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	want := "# yage-manifests/addons/sample/funcmap.yaml.tmpl\nenabled: hello-world\n"
+	if got != want {
+		t.Errorf("Render output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestFetcher_RegisterFunc_UnknownFuncFailsParse(t *testing.T) {
+	// A template referencing an unregistered function must fail at parse time.
+	f := &Fetcher{MountRoot: "testdata"}
+	// Do NOT register "greet" — parse must fail.
+
+	_, err := f.Render("addons/sample/funcmap.yaml.tmpl", sampleData{Name: "world"})
+	if err == nil {
+		t.Fatal("expected parse error for unregistered function, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse template") {
+		t.Errorf("error should mention parse template stage; got: %v", err)
+	}
+}

--- a/internal/platform/manifests/testdata/yage-manifests/addons/sample/funcmap.yaml.tmpl
+++ b/internal/platform/manifests/testdata/yage-manifests/addons/sample/funcmap.yaml.tmpl
@@ -1,0 +1,2 @@
+# yage-manifests/addons/sample/funcmap.yaml.tmpl
+enabled: {{ greet .Name }}


### PR DESCRIPTION
## Summary

- **`Fetcher.RegisterFunc`**: add `RegisterFunc(name string, fn any)` to `internal/platform/manifests.Fetcher` per ADR 0012 Errata E1; the internal `template.FuncMap` is applied via `t.Funcs()` before `t.Parse()` so `missingkey=error` is preserved; 2 new tests cover the happy path and the unregistered-function parse-failure path.
- **helmvalues migration (#137)**: all 6 helmvalues functions rewritten to call `Fetcher.Render(f, cfg)` with `(string, error)` return; `RegisterIsTrue` helper registers `sysinfo.IsTrue` (fixes semantic gap with old local helper which missed the `"t"` case per ADR 0012 E1); 13 golden tests cover all functions against in-package testdata fixtures; corresponding yage-manifests templates shipped in PR #5 (SHA `ca00059`).
- **caaph convergence (ADR 0012 §3 / PR #178 divergence fix)**: `Bools map[string]bool` removed from `HelmValuesData`; `buildArgoCDCR` passes `HelmValuesData{Cfg: cfg}`; caaph testdata template and tests migrated to `{{ isTrue .Cfg.ArgoCD.X }}` pattern; `RegisterIsTrue` called in test `fetcher()` helper.

## Acceptance Criteria Evidence

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go test ./internal/platform/manifests/...` | 8 PASS |
| `go test ./internal/capi/caaph/...` | 7 PASS |
| `go test ./internal/capi/helmvalues/...` | 13 PASS |
| `go test ./internal/orchestrator/...` | 22 PASS |
| `Bools` field absent from `HelmValuesData` | confirmed |
| `RegisterFunc` only extension point wired | confirmed |
| `isTrue` uses `sysinfo.IsTrue` (includes "t" case) | confirmed |
| yage-manifests PR #5 SHA `ca00059` merged | confirmed |

## Audit Checks

No triggers fired. No xapiri changes. No new wrapper struct fields beyond ADR 0012 §3 verbatim. No functions beyond `isTrue` registered. No yage-manifests re-tag required.

## Breaking Changes

`ApplyWorkloadArgoCDApplications(cfg)` gains a second parameter `f *manifests.Fetcher`. This is an exported function with no callers outside the orchestrator package at time of merge; no downstream breakage.

All helmvalues functions now return `(string, error)` instead of `string`. Callers updated in `workloadapps.go` with `logx.Die` on error. No other callers exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)