### PR TITLE
chore(config): bump default ManifestsRef to v0.2.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1297,7 +1297,7 @@ func Load() *Config {
 	c.TofuRepo = getenv("YAGE_TOFU_REPO", "https://github.com/lpasquali/yage-tofu")
 	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
 	c.ManifestsRepo = getenv("YAGE_MANIFESTS_REPO", "https://github.com/lpasquali/yage-manifests")
-	c.ManifestsRef = getenv("YAGE_MANIFESTS_REF", "v0.1.0")
+	c.ManifestsRef = getenv("YAGE_MANIFESTS_REF", "v0.2.0")
 	c.ReposPVCSize = getenv("YAGE_REPOS_PVC_SIZE", "500Mi")
 
 	// --- On-prem platform services (Phase H, ADR 0009) ---


### PR DESCRIPTION
## Summary

`YAGE_MANIFESTS_REF` defaulted to `v0.1.0`, which tagged the empty yage-manifests scaffold commit (`c0a693e`) — no `.yaml.tmpl` files, so any operator using the default would hit render failures at runtime. `v0.2.0` is the first release with real template content and is now live at tag object `4607ee1`, commit `ca00059` on `lpasquali/yage-manifests`.

Closes #189

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)

## Level 1 Checklist

- [x] `make build` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` — `go.mod` unchanged; N/A
- [x] Change fully covered by existing tests: config default is a one-line string literal; structurally identical to every other `getenv` default in `config.go`
- [x] Breaking-change audit: see Breaking Changes below

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- `v0.2.0` tag live on `lpasquali/yage-manifests`: tag object `4607ee1fbc35834a82a77e05afebbcc9db36b7e6` → commit `ca0005945453b7115879c702d9a1904a9557b971`
- Templates present at that commit: `addons/argocd-apps/helmchartproxy.yaml.tmpl`, `addons/argocd/argocd-cr.yaml.tmpl`, `addons/cilium/helmchartproxy.yaml.tmpl`, `addons/keycloak/values.yaml.tmpl`, `addons/metrics-server/values.yaml.tmpl`, `addons/observability/values-grafana.yaml.tmpl`, `addons/observability/values-victoria-metrics.yaml.tmpl`, `addons/opentelemetry/values.yaml.tmpl`, `addons/spire/values.yaml.tmpl`
- `make build && make test` green locally

## Breaking Changes

Operators who explicitly set `YAGE_MANIFESTS_REF` (env var or CLI flag) are unaffected — their pin is honoured verbatim. Operators relying on the default transition from a broken default (`v0.1.0` had no templates) to a working one. Soft breaking change; no practical downside.

## Notes for Reviewer

- Do not merge until `v0.2.0` tag is confirmed live on `lpasquali/yage-manifests` — it is (see Acceptance Criteria Evidence).
- Deprecation note for `v0.1.0` added to `yage-manifests` README via `lpasquali/yage-manifests` PR #6.