### PR TITLE
fix(xapiri/security): mask cost-tab + token-overlay secret length per ADR 0013 (#175)

### DIFF
--- a/internal/ui/xapiri/dashboard_overlays.go
+++ b/internal/ui/xapiri/dashboard_overlays.go
@@ -25,7 +25,18 @@ func (m dashModel) renderTokenPromptOverlay(w int) string {
 	lines = append(lines, stMuted.Render("  The admin token is not saved to the kind Secret (security policy)."))
 	lines = append(lines, stMuted.Render("  Enter it now for this session, or press esc to skip."))
 	lines = append(lines, "")
-	lines = append(lines, "  "+m.tokenPromptInput.View())
+	// Unfocused guard (ADR 0013 §2): only call View() when the input is
+	// focused (user is actively typing). Unfocused renders the status indicator
+	// so dot-count cannot leak the token length at rest.
+	var tokenView string
+	if m.tokenPromptInput.Focused() {
+		tokenView = m.tokenPromptInput.View()
+	} else if m.tokenPromptInput.Value() == "" {
+		tokenView = stMuted.Render("[ ] not set")
+	} else {
+		tokenView = stOK.Render("[✓] set")
+	}
+	lines = append(lines, "  "+tokenView)
 	lines = append(lines, "")
 	lines = append(lines, stMuted.Render("  enter  confirm    esc  skip"))
 	return strings.Join(lines, "\n")

--- a/internal/ui/xapiri/tab_costs.go
+++ b/internal/ui/xapiri/tab_costs.go
@@ -291,9 +291,26 @@ func (m dashModel) renderCostsCredsForm() []string {
 	lines = append(lines, "")
 	for i := 0; i < ccCount; i++ {
 		lbl := fmt.Sprintf("  %-22s", ccLabels[i])
-		input := m.costCredsInputs[i].View()
+		isSecret := i != ccAWSKeyID
+		focused := i == m.costCredsFocus
+		var input string
+		switch {
+		case focused:
+			// User is actively typing — EchoPassword masking is acceptable
+			// per ADR 0013 §3 (length-leak is ephemeral and user is the secret-knower).
+			input = m.costCredsInputs[i].View()
+		case isSecret:
+			// Unfocused secret: emit status indicator only (ADR 0013 §2).
+			if m.costCredsInputs[i].Value() == "" {
+				input = stMuted.Render("[ ] not set")
+			} else {
+				input = stOK.Render("[✓] set")
+			}
+		default:
+			input = m.costCredsInputs[i].View()
+		}
 		cursor := " "
-		if i == m.costCredsFocus {
+		if focused {
 			cursor = stAccent.Render("▌")
 		}
 		lines = append(lines, cursor+lbl+" "+input)

--- a/internal/ui/xapiri/xapiri_test.go
+++ b/internal/ui/xapiri/xapiri_test.go
@@ -6,6 +6,7 @@ package xapiri
 import (
 	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -311,6 +312,65 @@ func TestDeployTab_OnPremModePreservesDeployRequested(t *testing.T) {
 	}
 	if !res.deployRequested {
 		t.Error("deployRequested must not be dropped in on-prem mode — was the runDashboard on-prem branch fixed?")
+	}
+}
+
+// TestRenderCostsCredsForm_SecretFieldsNeverLeakValue verifies that unfocused
+// secret inputs in the cost-tab credential form emit the status indicator
+// rather than raw value or dot-count. Regression guard for ADR 0013 §2.
+func TestRenderCostsCredsForm_SecretFieldsNeverLeakValue(t *testing.T) {
+	const sentinel = "SENTINEL-SECRET-DEADBEEF-12345"
+
+	cfg := &config.Config{}
+	cfg.Cost.Credentials.AWSSecretAccessKey = sentinel
+	cfg.Cost.Credentials.GCPAPIKey = sentinel
+	cfg.Cost.Credentials.HetznerToken = sentinel
+	cfg.Cost.Credentials.DigitalOceanToken = sentinel
+	cfg.Cost.Credentials.IBMCloudAPIKey = sentinel
+
+	s := newState(&bytes.Buffer{}, cfg)
+	m := newDashModel(cfg, s)
+	// Force credential form open; focus on AWS Key ID (index 0, non-secret).
+	m.costCredsMode = true
+	m.costCredsFocus = ccAWSKeyID
+
+	lines := m.renderCostsCredsForm()
+	rendered := strings.Join(lines, "\n")
+
+	if bytes.Contains([]byte(rendered), []byte(sentinel)) {
+		t.Errorf("renderCostsCredsForm leaked the secret value in unfocused rows: %q", rendered)
+	}
+	if !bytes.Contains([]byte(rendered), []byte("set")) {
+		t.Errorf("renderCostsCredsForm missing set/not-set indicator for secret fields: %q", rendered)
+	}
+}
+
+// TestRenderTokenPromptOverlay_NeverLeaksWhenUnfocused verifies that the
+// token re-prompt overlay shows the status indicator (not dot-count or
+// cleartext) when the input is not focused. Regression guard for ADR 0013 §2.
+func TestRenderTokenPromptOverlay_NeverLeaksWhenUnfocused(t *testing.T) {
+	const sentinel = "SENTINEL-SECRET-DEADBEEF-12345"
+
+	cfg := &config.Config{}
+	cfg.Providers.Proxmox.AdminUsername = "root@pam"
+
+	s := newState(&bytes.Buffer{}, cfg)
+	m := newDashModel(cfg, s)
+	m.tokenPromptActive = true
+	// tokenPromptInput starts unfocused; set a value to simulate a token
+	// that was typed earlier and would leak length via EchoPassword dots.
+	m.tokenPromptInput.SetValue(sentinel)
+	if m.tokenPromptInput.Focused() {
+		t.Skip("tokenPromptInput is focused; unfocused path cannot be tested here")
+	}
+
+	rendered := m.renderTokenPromptOverlay(80)
+
+	if bytes.Contains([]byte(rendered), []byte(sentinel)) {
+		t.Errorf("renderTokenPromptOverlay leaked the token value when unfocused: %q", rendered)
+	}
+	if !bytes.Contains([]byte(rendered), []byte("set")) {
+		t.Errorf("renderTokenPromptOverlay missing set/not-set indicator when unfocused: %q", rendered)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two TUI surfaces called `textinput.View()` with `EchoPassword` for all states, leaking secret length via dot-count even when the field was not focused. This fixes `renderCostsCredsForm` (cost-tab) and `renderTokenPromptOverlay` (token re-prompt overlay) to apply ADR 0013 §2: unfocused secret fields render `[✓] set` / `[ ] not set` only. Focused (mid-edit) fields retain `EchoPassword` per ADR 0013 §3.

Closes #175

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)

## Level 1 Checklist

- [x] `make build` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` — N/A (`go.mod` not changed)
- [x] Change fully covered by new regression tests:
  - `TestRenderCostsCredsForm_SecretFieldsNeverLeakValue` — unfocused cost-tab secret inputs never emit sentinel value
  - `TestRenderTokenPromptOverlay_NeverLeaksWhenUnfocused` — overlay emits status indicator, not dot-count, when input is unfocused
  - `TestRenderField_SecretFieldsNeverLeakValue` — pre-existing dashboard field test; still passes
- [x] Breaking-change audit: None. TUI render path only; no Secret schema, env var, CRD, or config changes.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | go.mod not changed |
| PE review (Secret schema / CAPI YAML) | N/A | TUI render path only |
| Supply-chain (workflow change) | N/A | No workflow files changed |

## Acceptance Criteria Evidence

- [x] `renderCostsCredsForm` unfocused secret fields show `[✓] set` / `[ ] not set` — `TestRenderCostsCredsForm_SecretFieldsNeverLeakValue` PASS
- [x] `renderTokenPromptOverlay` unfocused input shows `[✓] set` / `[ ] not set` — `TestRenderTokenPromptOverlay_NeverLeaksWhenUnfocused` PASS
- [x] Focused (mid-edit) path retains `EchoPassword` masking — existing `EchoMode` init in `dashboard.go` unchanged

## Breaking Changes

None.

## Notes for Reviewer

**ADR 0013 interpretation:** §2 display contract (unfocused → status indicator only) applies to both surfaces. §3 editing contract (focused → EchoPassword) is explicitly acceptable for mid-edit. The fix branches on `textinput.Focused()` to gate the two paths.

`ccAWSKeyID` (index 0, AWS Access Key ID) is not classified as a secret per ADR 0013 §5 — consistent with existing `dashboard.go` init logic that skips EchoPassword for index 0.

Stays strictly within `tab_costs.go` + `dashboard_overlays.go`. Does not touch `dashboard.go`, `internal/capi/`, `.github/workflows/`, or `internal/platform/manifests/`.