### PR TITLE
feat(postsync): migrate to yage-manifests _partials templates (#139)

### DIFF
--- a/internal/capi/postsync/postsync.go
+++ b/internal/capi/postsync/postsync.go
@@ -13,7 +13,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/lpasquali/yage/internal/capi/templates"
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/platform/shell"
 )
 
@@ -132,6 +134,21 @@ func KustomizeBlockForJob(cfg *config.Config, job string) string {
 `, ns, job, img)
 }
 
+// KustomizeBlockForJobTemplate renders the kustomize block for the named
+// Job via the yage-manifests template (ADR 0012 §3, issue #139).
+func KustomizeBlockForJobTemplate(f *manifests.Fetcher, cfg *config.Config, job string) (string, error) {
+	ns := cfg.WorkloadPostsyncNamespace
+	if ns == "" {
+		ns = "workload-smoke"
+	}
+	return f.Render("postsync/_partials/job-image-override.kustomize.tmpl", templates.KustomizePartialData{
+		Cfg:          cfg,
+		Namespace:    ns,
+		JobName:      job,
+		KubectlImage: ResolveKubectlImage(cfg),
+	})
+}
+
 // SmokeK8sVersionForImage returns the Kubernetes version to use for
 // the Proxmox CSI smoke-test image. Scans CAPI_MANIFEST for a
 // Cluster-topology.version, else KubeadmControlPlane.spec.version;
@@ -218,6 +235,20 @@ func SmokeRenderKustomizeBlock(cfg *config.Config) string {
               path: /spec/template/spec/containers/0/env/1/value
               value: "%s"
 `, ns, img, ns, sc)
+}
+
+// SmokeRenderKustomizeBlockTemplate renders the kustomize block for the
+// proxmox-csi-smoke Job via the yage-manifests template (ADR 0012 §3, issue #139).
+func SmokeRenderKustomizeBlockTemplate(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	ns := cfg.Providers.Proxmox.CSINamespace
+	sc := cfg.Providers.Proxmox.CSIStorageClassName
+	return f.Render("postsync/_partials/proxmox-csi-smoke.kustomize.tmpl", templates.KustomizePartialData{
+		Cfg:          cfg,
+		Namespace:    ns,
+		JobName:      "proxmox-csi-smoke",
+		KubectlImage: ResolveKubectlImage(cfg),
+		Extra:        map[string]string{"storageClass": sc},
+	})
 }
 
 // Silence unused-import of exec if we end up not needing it.

--- a/internal/capi/postsync/postsync_test.go
+++ b/internal/capi/postsync/postsync_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package postsync_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/postsync"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// testFetcher returns a Fetcher pointed at the in-package testdata fixtures.
+func testFetcher() *manifests.Fetcher {
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
+
+func testCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.WorkloadPostsyncNamespace = "workload-smoke"
+	cfg.Providers.Proxmox.CSINamespace = "csi-namespace"
+	cfg.Providers.Proxmox.CSIStorageClassName = "proxmox-csi"
+	return cfg
+}
+
+// --- KustomizeBlockForJobTemplate ---
+
+func TestKustomizeBlockForJobTemplate_MetricsServerSmoketest(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+
+	got, err := postsync.KustomizeBlockForJobTemplate(f, cfg, "metrics-server-smoketest")
+	if err != nil {
+		t.Fatalf("KustomizeBlockForJobTemplate error: %v", err)
+	}
+
+	wants := []string{
+		"kustomize:",
+		"namespace: workload-smoke",
+		"kind: Job",
+		"name: metrics-server-smoketest",
+		"/spec/template/spec/containers/0/image",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("KustomizeBlockForJobTemplate missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestKustomizeBlockForJobTemplate_ProxmoxCSIRolloutSmoketest(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+
+	got, err := postsync.KustomizeBlockForJobTemplate(f, cfg, "proxmox-csi-rollout-smoketest")
+	if err != nil {
+		t.Fatalf("KustomizeBlockForJobTemplate error: %v", err)
+	}
+
+	if !strings.Contains(got, "name: proxmox-csi-rollout-smoketest") {
+		t.Errorf("KustomizeBlockForJobTemplate missing job name; got:\n%s", got)
+	}
+}
+
+func TestKustomizeBlockForJobTemplate_KyvernoSmoketest(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+
+	got, err := postsync.KustomizeBlockForJobTemplate(f, cfg, "kyverno-smoketest")
+	if err != nil {
+		t.Fatalf("KustomizeBlockForJobTemplate error: %v", err)
+	}
+
+	if !strings.Contains(got, "name: kyverno-smoketest") {
+		t.Errorf("KustomizeBlockForJobTemplate missing kyverno-smoketest job name; got:\n%s", got)
+	}
+}
+
+func TestKustomizeBlockForJobTemplate_DefaultNamespace(t *testing.T) {
+	f := testFetcher()
+	cfg := &config.Config{}
+	// WorkloadPostsyncNamespace is intentionally empty — must default to workload-smoke.
+
+	got, err := postsync.KustomizeBlockForJobTemplate(f, cfg, "some-smoketest")
+	if err != nil {
+		t.Fatalf("KustomizeBlockForJobTemplate error: %v", err)
+	}
+
+	if !strings.Contains(got, "namespace: workload-smoke") {
+		t.Errorf("KustomizeBlockForJobTemplate did not apply default namespace; got:\n%s", got)
+	}
+}
+
+func TestKustomizeBlockForJobTemplate_KubectlImageEmbedded(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+	cfg.ArgoCD.PostsyncHooksKubectlImg = "registry.local/kubectl:v1.31.0"
+
+	got, err := postsync.KustomizeBlockForJobTemplate(f, cfg, "some-smoketest")
+	if err != nil {
+		t.Fatalf("KustomizeBlockForJobTemplate error: %v", err)
+	}
+
+	if !strings.Contains(got, "registry.local/kubectl:v1.31.0") {
+		t.Errorf("KustomizeBlockForJobTemplate missing kubectl image; got:\n%s", got)
+	}
+}
+
+// --- SmokeRenderKustomizeBlockTemplate ---
+
+func TestSmokeRenderKustomizeBlockTemplate_Basic(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+
+	got, err := postsync.SmokeRenderKustomizeBlockTemplate(f, cfg)
+	if err != nil {
+		t.Fatalf("SmokeRenderKustomizeBlockTemplate error: %v", err)
+	}
+
+	wants := []string{
+		"kustomize:",
+		"namespace: csi-namespace",
+		"name: proxmox-csi-smoke",
+		"/spec/template/spec/containers/0/image",
+		"/spec/template/spec/containers/0/env/0/value",
+		"/spec/template/spec/containers/0/env/1/value",
+		"proxmox-csi",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("SmokeRenderKustomizeBlockTemplate missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestSmokeRenderKustomizeBlockTemplate_StorageClassEmbedded(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+	cfg.Providers.Proxmox.CSIStorageClassName = "fast-storage"
+
+	got, err := postsync.SmokeRenderKustomizeBlockTemplate(f, cfg)
+	if err != nil {
+		t.Fatalf("SmokeRenderKustomizeBlockTemplate error: %v", err)
+	}
+
+	if !strings.Contains(got, "fast-storage") {
+		t.Errorf("SmokeRenderKustomizeBlockTemplate missing storage class; got:\n%s", got)
+	}
+}
+
+func TestSmokeRenderKustomizeBlockTemplate_NamespaceInBothPatches(t *testing.T) {
+	f := testFetcher()
+	cfg := testCfg()
+	cfg.Providers.Proxmox.CSINamespace = "my-csi-ns"
+
+	got, err := postsync.SmokeRenderKustomizeBlockTemplate(f, cfg)
+	if err != nil {
+		t.Fatalf("SmokeRenderKustomizeBlockTemplate error: %v", err)
+	}
+
+	count := strings.Count(got, "my-csi-ns")
+	if count < 2 {
+		t.Errorf("SmokeRenderKustomizeBlockTemplate: expected namespace at least 2 times (kustomize.namespace + env/0/value), got %d\nfull:\n%s", count, got)
+	}
+}

--- a/internal/capi/postsync/testdata/yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
+++ b/internal/capi/postsync/testdata/yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
@@ -1,0 +1,13 @@
+# yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
+    kustomize:
+      namespace: {{ .Namespace }}
+      patches:
+        - target:
+            group: batch
+            version: v1
+            kind: Job
+            name: {{ .JobName }}
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: '{{ .KubectlImage }}'

--- a/internal/capi/postsync/testdata/yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
+++ b/internal/capi/postsync/testdata/yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
@@ -1,0 +1,19 @@
+# yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
+    kustomize:
+      namespace: {{ .Namespace }}
+      patches:
+        - target:
+            group: batch
+            version: v1
+            kind: Job
+            name: {{ .JobName }}
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: '{{ .KubectlImage }}'
+            - op: replace
+              path: /spec/template/spec/containers/0/env/0/value
+              value: "{{ .Namespace }}"
+            - op: replace
+              path: /spec/template/spec/containers/0/env/1/value
+              value: "{{ index .Extra "storageClass" }}"

--- a/internal/orchestrator/workloadapps.go
+++ b/internal/orchestrator/workloadapps.go
@@ -111,8 +111,15 @@ storageClass:
 		if cfg.Providers.Proxmox.CSISmokeEnabled && cfg.ArgoCD.PostsyncHooksEnabled {
 			h1P = postsync.FullRelpath(cfg, "proxmox-csi-pvc")
 			h2P = postsync.FullRelpath(cfg, "proxmox-csi-rollout")
-			h1K = postsync.SmokeRenderKustomizeBlock(cfg)
-			h2K = postsync.KustomizeBlockForJob(cfg, "proxmox-csi-rollout-smoketest")
+			var kErr error
+			h1K, kErr = postsync.SmokeRenderKustomizeBlockTemplate(f, cfg)
+			if kErr != nil {
+				logx.Die("postsync: proxmox-csi-smoke kustomize block: %v", kErr)
+			}
+			h2K, kErr = postsync.KustomizeBlockForJobTemplate(f, cfg, "proxmox-csi-rollout-smoketest")
+			if kErr != nil {
+				logx.Die("postsync: proxmox-csi-rollout kustomize block: %v", kErr)
+			}
 		}
 		sb.WriteString(wlargocd.HelmOCI(cfg,
 			cfg.WorkloadClusterName+"-proxmox-csi", cfg.Providers.Proxmox.CSINamespace,


### PR DESCRIPTION
## Summary

- Adds `KustomizeBlockForJobTemplate(f, cfg, job) (string, error)` to `internal/capi/postsync/` — renders via `postsync/_partials/job-image-override.kustomize.tmpl`; covers all job-name callers (metrics-server-smoketest, proxmox-csi-rollout-smoketest, kyverno-smoketest, etc.)
- Adds `SmokeRenderKustomizeBlockTemplate(f, cfg) (string, error)` — renders via `postsync/_partials/proxmox-csi-smoke.kustomize.tmpl`; passes `Extra["storageClass"]` for the env/1 patch
- Updates `internal/orchestrator/workloadapps` proxmox-csi smoke path to call the new template-backed functions; `logx.Die` on render error
- Old `KustomizeBlockForJob` and `SmokeRenderKustomizeBlock` remain for `wlargocd` compatibility until package retirement (#142)

**yage-manifests PR:** lpasquali/yage-manifests#8 (merged `c3aaccb`)

## **Definition of Done**

- **`go build ./...`** passes (CSI Render interface errors are pre-existing from #141, not introduced here)
- **`go test ./internal/capi/postsync/... ./internal/orchestrator/...`** green: 8 new postsync tests pass
- **`go vet ./internal/capi/postsync/... ./internal/orchestrator/...`** clean
- **Two templates only** in yage-manifests: `job-image-override.kustomize.tmpl` and `proxmox-csi-smoke.kustomize.tmpl`
- **`KustomizePartialData` only** — no struct extension
- **No `PostSyncData` consumers created** — no standalone postsync manifests
- **Old package stays** — `postsync.go` not retired (deferred to #142)
- **No xapiri, helmvalues, caaph, wlargocd, or `.github/workflows/` changes**

## Acceptance Criteria Evidence

- 8 golden tests: `TestKustomizeBlockForJobTemplate_MetricsServerSmoketest`, `TestKustomizeBlockForJobTemplate_ProxmoxCSIRolloutSmoketest`, `TestKustomizeBlockForJobTemplate_KyvernoSmoketest`, `TestKustomizeBlockForJobTemplate_DefaultNamespace`, `TestKustomizeBlockForJobTemplate_KubectlImageEmbedded`, `TestSmokeRenderKustomizeBlockTemplate_Basic`, `TestSmokeRenderKustomizeBlockTemplate_StorageClassEmbedded`, `TestSmokeRenderKustomizeBlockTemplate_NamespaceInBothPatches`
- Testdata fixtures in `internal/capi/postsync/testdata/` are byte-for-byte identical to yage-manifests templates (verified via `diff`)
- Pattern matches PR #184 (`d97fb77`): Fetcher.Render with KustomizePartialData wrapper struct

## Audit Checks

No triggers fired.

## Breaking Changes

None. New functions are additive; old `KustomizeBlockForJob` and `SmokeRenderKustomizeBlock` signatures unchanged, `wlargocd` package unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)