### PR TITLE
feat(csi): migrate Driver.RenderValues → Render + yage-manifests templates (#141)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1402,7 +1402,7 @@ func Load() *Config {
 	c.Providers.Azure.VNetName = getenv("AZURE_VNET_NAME", "")
 	c.Providers.Azure.SubnetName = getenv("AZURE_SUBNET_NAME", "")
 	c.Providers.Azure.ClientID = getenv("AZURE_CLIENT_ID", "")
-	c.Providers.Azure.IdentityModel = getenv("AZURE_IDENTITY_MODEL", "service-principal")
+	c.Providers.Azure.IdentityModel = strings.ToLower(getenv("AZURE_IDENTITY_MODEL", "service-principal"))
 	c.Providers.GCP.ControlPlaneMachineType = getenv("GCP_CONTROL_PLANE_MACHINE_TYPE", "n2-standard-2")
 	c.Providers.GCP.NodeMachineType = getenv("GCP_NODE_MACHINE_TYPE", "n2-standard-2")
 	c.Providers.GCP.Region = getenv("GCP_REGION", "us-central1")
@@ -1415,7 +1415,7 @@ func Load() *Config {
 	// GOOGLE_APPLICATION_CREDENTIALS path).
 	c.Providers.GCP.Network = getenv("GCP_NETWORK_NAME", "")
 	c.Providers.GCP.ImageFamily = getenv("GCP_IMAGE_FAMILY", "")
-	c.Providers.GCP.IdentityModel = getenv("GCP_IDENTITY_MODEL", "service-account")
+	c.Providers.GCP.IdentityModel = strings.ToLower(getenv("GCP_IDENTITY_MODEL", "service-account"))
 	// OpenStack — canonical spelling is OPENSTACK_*. Empty defaults
 	// across the board: the CAPO manifest needs them set explicitly anyway.
 	c.Providers.OpenStack.Cloud = getenv("OPENSTACK_CLOUD", "")

--- a/internal/csi/awsebs/awsebs.go
+++ b/internal/csi/awsebs/awsebs.go
@@ -15,9 +15,10 @@
 package awsebs
 
 import (
-	"strings"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
@@ -41,41 +42,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The IRSA role
-// ARN is left empty — operators set it via the AWS-side IAM role
-// they pre-create (EKS module / OpenTofu / hand-rolled). The
-// orchestrator can later patch the rendered values in-process; for
-// today, an empty annotation is the safest default that still
-// produces a valid YAML document.
-//
-// Storage class:
-//   - name "ebs-gp3" — the gp3 volume type is the modern AWS
-//     default (faster than gp2, identical price, configurable IOPS
-//     up to 16k). yage labels it default so PVCs without an
-//     explicit storageClassName land here.
-//   - volumeBindingMode WaitForFirstConsumer — required for multi-
-//     AZ clusters so the volume is created in the same AZ as the
-//     pod's node, not the controller's AZ.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/awsebs.\n")
-	b.WriteString("# IRSA: operator pre-creates the IAM role and sets\n")
-	b.WriteString("# controller.serviceAccount.annotations[eks.amazonaws.com/role-arn]\n")
-	b.WriteString("# either via Helm CLI override or out-of-band kubectl annotate.\n")
-	b.WriteString("controller:\n")
-	b.WriteString("  serviceAccount:\n")
-	b.WriteString("    create: true\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      eks.amazonaws.com/role-arn: \"\"\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: ebs-gp3\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    parameters:\n")
-	b.WriteString("      type: gp3\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/aws-ebs/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret returns ErrNotApplicable: AWS EBS CSI uses IRSA, not

--- a/internal/csi/awsebs/testdata/yage-manifests/csi/aws-ebs/values.yaml.tmpl
+++ b/internal/csi/awsebs/testdata/yage-manifests/csi/aws-ebs/values.yaml.tmpl
@@ -1,0 +1,17 @@
+# Rendered by yage-manifests csi/aws-ebs/values.yaml.tmpl.
+# IRSA: operator pre-creates the IAM role and sets
+# controller.serviceAccount.annotations[eks.amazonaws.com/role-arn]
+# either via Helm CLI override or out-of-band kubectl annotate.
+controller:
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: ""
+storageClasses:
+  - name: ebs-gp3
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    parameters:
+      type: gp3
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete

--- a/internal/csi/azuredisk/azuredisk.go
+++ b/internal/csi/azuredisk/azuredisk.go
@@ -40,6 +40,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -67,46 +69,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits Helm values that branch on the configured
-// IdentityModel. Workload-identity leans on the annotated SA;
-// service-principal references the kube-system/azure-cloud-config
-// Secret EnsureSecret apply.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/azuredisk.\n")
-	b.WriteString("controller:\n")
-	b.WriteString("  replicas: 2\n")
-	b.WriteString("linux:\n")
-	b.WriteString("  enabled: true\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: azuredisk-standard-ssd\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    parameters:\n")
-	b.WriteString("      skuName: StandardSSD_LRS\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-
-	if usesWorkloadIdentity(cfg) {
-		b.WriteString("# Workload Identity: SA annotated for AAD federation.\n")
-		b.WriteString("serviceAccount:\n")
-		b.WriteString("  controller:\n")
-		b.WriteString("    create: true\n")
-		b.WriteString("    annotations:\n")
-		b.WriteString(fmt.Sprintf("      azure.workload.identity/client-id: %q\n",
-			cfg.Providers.Azure.ClientID))
-		b.WriteString("    labels:\n")
-		b.WriteString("      azure.workload.identity/use: \"true\"\n")
-	} else {
-		// Service-principal path — chart reads the cloud config
-		// from a kube-system Secret. EnsureSecret() places it.
-		b.WriteString("# Service-Principal: cloud config Secret in kube-system.\n")
-		b.WriteString("cloud: AzurePublicCloud\n")
-		b.WriteString("controller:\n")
-		b.WriteString("  cloudConfigSecretName: " + secretName + "\n")
-		b.WriteString("  cloudConfigSecretNamespace: " + secretNamespace + "\n")
-	}
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/azure-disk/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret writes the kube-system/azure-cloud-config Secret on

--- a/internal/csi/azuredisk/azuredisk_test.go
+++ b/internal/csi/azuredisk/azuredisk_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	if got, want := d.Name(), "azure-disk"; got != want {
@@ -27,28 +34,37 @@ func TestDriverConstants(t *testing.T) {
 	}
 }
 
-func TestRenderValuesIdentityBranch(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
-
-	cfg := &config.Config{}
-	cfg.Providers.Azure.IdentityModel = "service-principal"
-	out, err := d.RenderValues(cfg)
-	if err != nil {
-		t.Fatalf("RenderValues SP err: %v", err)
-	}
-	if !strings.Contains(out, "cloudConfigSecretName: azure-cloud-config") {
-		t.Errorf("SP path missing cloudConfigSecretName: %s", out)
-	}
-
-	cfg.Providers.Azure.IdentityModel = "workload-identity"
-	cfg.Providers.Azure.ClientID = "00000000-0000-0000-0000-000000000000"
-	out, err = d.RenderValues(cfg)
-	if err != nil {
-		t.Fatalf("RenderValues WI err: %v", err)
-	}
-	if !strings.Contains(out, "azure.workload.identity/client-id") {
-		t.Errorf("WI path missing client-id annotation: %s", out)
-	}
+	t.Run("SP", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Providers.Azure.IdentityModel = "service-principal"
+		out, err := d.Render(fetcher(t), cfg)
+		if err != nil {
+			t.Fatalf("Render SP err: %v", err)
+		}
+		if !strings.Contains(out, "azuredisk-standard-ssd") {
+			t.Errorf("Render SP missing storage class: %s", out)
+		}
+		if !strings.Contains(out, "azure-cloud-config") {
+			t.Errorf("Render SP missing cloud-config Secret: %s", out)
+		}
+	})
+	t.Run("WI", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Providers.Azure.IdentityModel = "workload-identity"
+		cfg.Providers.Azure.ClientID = "test-client-id"
+		out, err := d.Render(fetcher(t), cfg)
+		if err != nil {
+			t.Fatalf("Render WI err: %v", err)
+		}
+		if !strings.Contains(out, "azure.workload.identity/client-id") {
+			t.Errorf("Render WI missing client-id annotation: %s", out)
+		}
+		if !strings.Contains(out, "test-client-id") {
+			t.Errorf("Render WI missing client-id: %s", out)
+		}
+	})
 }
 
 func TestEnsureSecretWorkloadIdentityNoOp(t *testing.T) {

--- a/internal/csi/azuredisk/testdata/yage-manifests/csi/azure-disk/values.yaml.tmpl
+++ b/internal/csi/azuredisk/testdata/yage-manifests/csi/azure-disk/values.yaml.tmpl
@@ -1,0 +1,29 @@
+# Rendered by yage-manifests csi/azure-disk/values.yaml.tmpl.
+controller:
+  replicas: 2
+linux:
+  enabled: true
+storageClasses:
+  - name: azuredisk-standard-ssd
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    parameters:
+      skuName: StandardSSD_LRS
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete
+{{ if eq .Cfg.Providers.Azure.IdentityModel "workload-identity" -}}
+# Workload Identity: SA annotated for AAD federation.
+serviceAccount:
+  controller:
+    create: true
+    annotations:
+      azure.workload.identity/client-id: {{ printf "%q" .Cfg.Providers.Azure.ClientID }}
+    labels:
+      azure.workload.identity/use: "true"
+{{ else -}}
+# Service-Principal: cloud config Secret in kube-system.
+cloud: AzurePublicCloud
+controller:
+  cloudConfigSecretName: azure-cloud-config
+  cloudConfigSecretNamespace: kube-system
+{{ end -}}

--- a/internal/csi/cindercsi/cindercsi.go
+++ b/internal/csi/cindercsi/cindercsi.go
@@ -32,8 +32,8 @@ package cindercsi
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +42,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -75,26 +77,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The chart defaults
-// to hostMount=true for credentials; we flip to secret-based auth by
-// setting secret.enabled=true, secret.hostMount=false, and pointing
-// secret.name at the Secret EnsureSecret applies. storageClass.delete
-// is set as default to match DefaultStorageClass().
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/cindercsi.\n")
-	b.WriteString("# Credentials: " + secretName + " Secret in " + secretNamespace + "\n")
-	b.WriteString("# (applied by EnsureSecret from OS_* env / cfg.Providers.OpenStack).\n")
-	b.WriteString("secret:\n")
-	b.WriteString("  enabled: true\n")
-	b.WriteString("  hostMount: false\n")
-	b.WriteString("  create: false\n")
-	b.WriteString("  name: " + secretName + "\n")
-	b.WriteString("storageClass:\n")
-	b.WriteString("  enabled: true\n")
-	b.WriteString("  delete:\n")
-	b.WriteString("    isDefault: true\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/openstack-cinder/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret writes the kube-system/cinder-csi-cloud-config Secret on

--- a/internal/csi/cindercsi/cindercsi_test.go
+++ b/internal/csi/cindercsi/cindercsi_test.go
@@ -8,9 +8,16 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	if got, want := d.Name(), "openstack-cinder"; got != want {
@@ -48,24 +55,24 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
 	cfg := &config.Config{}
-	out, err := d.RenderValues(cfg)
+	out, err := d.Render(fetcher(t), cfg)
 	if err != nil {
-		t.Fatalf("RenderValues err: %v", err)
+		t.Fatalf("Render err: %v", err)
 	}
 	if !strings.Contains(out, secretName) {
-		t.Errorf("RenderValues output missing secret name %q: %s", secretName, out)
+		t.Errorf("Render output missing secret name %q: %s", secretName, out)
 	}
 	if !strings.Contains(out, "secret:") {
-		t.Errorf("RenderValues output missing secret: key: %s", out)
+		t.Errorf("Render output missing secret: key: %s", out)
 	}
 	if !strings.Contains(out, "storageClass:") {
-		t.Errorf("RenderValues output missing storageClass key: %s", out)
+		t.Errorf("Render output missing storageClass key: %s", out)
 	}
 	if !strings.Contains(out, "hostMount: false") {
-		t.Errorf("RenderValues should disable hostMount: %s", out)
+		t.Errorf("Render should disable hostMount: %s", out)
 	}
 }
 

--- a/internal/csi/cindercsi/testdata/yage-manifests/csi/openstack-cinder/values.yaml.tmpl
+++ b/internal/csi/cindercsi/testdata/yage-manifests/csi/openstack-cinder/values.yaml.tmpl
@@ -1,0 +1,12 @@
+# Rendered by yage-manifests csi/openstack-cinder/values.yaml.tmpl.
+# Credentials: cinder-csi-cloud-config Secret in kube-system
+# (applied by EnsureSecret from OS_* env / cfg.Providers.OpenStack).
+secret:
+  enabled: true
+  hostMount: false
+  create: false
+  name: cinder-csi-cloud-config
+storageClass:
+  enabled: true
+  delete:
+    isDefault: true

--- a/internal/csi/doblock/doblock.go
+++ b/internal/csi/doblock/doblock.go
@@ -18,7 +18,6 @@ package doblock
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +26,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -56,28 +57,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The DO CSI driver
-// reads the access-token from the kube-system/digitalocean Secret, which
-// EnsureSecret creates before Helm install. The chart references the
-// Secret by its conventional name; no additional values configuration is
-// required for the token path.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/doblock.\n")
-	b.WriteString("# Auth: DigitalOcean access-token read from Secret ")
-	b.WriteString(secretNamespace + "/" + secretName + " key " + tokenKey + ".\n")
-	b.WriteString("# EnsureSecret must run before `helm install` so the Secret is present.\n")
-	b.WriteString("controller:\n")
-	b.WriteString("  replicas: 1\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: do-block-storage\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    parameters:\n")
-	b.WriteString("      type: pd-ssd\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/do-block-storage/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret writes the kube-system/digitalocean Secret on the workload

--- a/internal/csi/doblock/doblock_test.go
+++ b/internal/csi/doblock/doblock_test.go
@@ -4,11 +4,19 @@
 package doblock
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	if got, want := d.Name(), "do-block-storage"; got != want {
@@ -43,15 +51,18 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
 	cfg := &config.Config{}
-	out, err := d.RenderValues(cfg)
+	out, err := d.Render(fetcher(t), cfg)
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected err: %v", err)
+		t.Fatalf("Render() unexpected err: %v", err)
 	}
 	if out == "" {
-		t.Error("RenderValues() returned empty string")
+		t.Error("Render() returned empty string")
+	}
+	if !strings.Contains(out, "do-block-storage") {
+		t.Errorf("Render() missing do-block-storage: %s", out)
 	}
 }
 

--- a/internal/csi/doblock/testdata/yage-manifests/csi/do-block-storage/values.yaml.tmpl
+++ b/internal/csi/doblock/testdata/yage-manifests/csi/do-block-storage/values.yaml.tmpl
@@ -1,0 +1,13 @@
+# Rendered by yage-manifests csi/do-block-storage/values.yaml.tmpl.
+# Auth: DigitalOcean access-token read from Secret kube-system/digitalocean key access-token.
+# EnsureSecret must run before `helm install` so the Secret is present.
+controller:
+  replicas: 1
+storageClasses:
+  - name: do-block-storage
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    parameters:
+      type: pd-ssd
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete

--- a/internal/csi/driver.go
+++ b/internal/csi/driver.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
 
@@ -75,11 +76,13 @@ type Driver interface {
 	// manifest-based install or surface the gap.
 	HelmChart(cfg *config.Config) (repo, chart, version string, err error)
 
-	// RenderValues produces the Helm values YAML for this driver's
-	// chart, taking the active config (region, instance metadata,
-	// secrets, identity model, etc.). Returned string is fed
-	// verbatim to `helm install -f -` (or the CAAPH equivalent).
-	RenderValues(cfg *config.Config) (string, error)
+	// Render produces the Helm values YAML for this driver's chart
+	// by executing csi/<name>/values.yaml.tmpl from the yage-manifests
+	// PVC via f.  cfg carries the active workload configuration
+	// (region, instance metadata, secrets, identity model, etc.).
+	// Returned string is fed verbatim to `helm install -f -` (or the
+	// CAAPH equivalent).
+	Render(f *manifests.Fetcher, cfg *config.Config) (string, error)
 
 	// EnsureSecret pushes any per-driver Secret to the workload
 	// cluster. Drivers that authenticate via cloud-native identity

--- a/internal/csi/driver_test.go
+++ b/internal/csi/driver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
 
@@ -22,7 +23,7 @@ func (f *fakeDriver) Defaults() []string       { return nil }
 func (f *fakeDriver) HelmChart(*config.Config) (string, string, string, error) {
 	return "https://example.invalid", f.name, "v0.0.0", nil
 }
-func (f *fakeDriver) RenderValues(*config.Config) (string, error) { return "", nil }
+func (f *fakeDriver) Render(*manifests.Fetcher, *config.Config) (string, error) { return "", nil }
 func (f *fakeDriver) EnsureSecret(*config.Config, string) error           { return nil }
 func (f *fakeDriver) DefaultStorageClass() string                          { return "" }
 func (f *fakeDriver) DescribeInstall(plan.Writer, *config.Config)          {}

--- a/internal/csi/gcppd/gcppd.go
+++ b/internal/csi/gcppd/gcppd.go
@@ -45,6 +45,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -73,39 +75,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/gcppd.\n")
-	b.WriteString("controller:\n")
-	b.WriteString("  replicas: 2\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: pd-balanced\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    parameters:\n")
-	b.WriteString("      type: pd-balanced\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-
-	if usesWorkloadIdentity(cfg) {
-		b.WriteString("# Workload Identity: SA annotated for GCP IAM federation.\n")
-		b.WriteString("serviceAccount:\n")
-		b.WriteString("  controller:\n")
-		b.WriteString("    create: true\n")
-		b.WriteString("    annotations:\n")
-		b.WriteString(fmt.Sprintf("      iam.gke.io/gcp-service-account: %q\n",
-			gcpSAEmail(cfg)))
-	} else {
-		b.WriteString("# Service-Account: cloud-sa.json mounted from a Secret.\n")
-		b.WriteString("controller:\n")
-		b.WriteString("  cloudSAVolume:\n")
-		b.WriteString("    secret:\n")
-		b.WriteString("      secretName: " + secretName + "\n")
-	}
-	if cfg.Providers.GCP.Project != "" {
-		b.WriteString("project: " + cfg.Providers.GCP.Project + "\n")
-	}
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/gcp-pd/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret writes the kube-system/gce-conf Secret on the

--- a/internal/csi/gcppd/gcppd_test.go
+++ b/internal/csi/gcppd/gcppd_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	if got, want := d.Name(), "gcp-pd"; got != want {
@@ -27,35 +34,40 @@ func TestDriverConstants(t *testing.T) {
 	}
 }
 
-func TestRenderValuesProjectInjection(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
-	cfg := &config.Config{}
-	cfg.Providers.GCP.Project = "my-test-project"
-	out, err := d.RenderValues(cfg)
-	if err != nil {
-		t.Fatalf("RenderValues err: %v", err)
-	}
-	if !strings.Contains(out, "project: my-test-project") {
-		t.Errorf("missing project line: %s", out)
-	}
-	if !strings.Contains(out, "pd-balanced") {
-		t.Errorf("missing pd-balanced storage class: %s", out)
-	}
+	t.Run("project", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Providers.GCP.Project = "my-gcp-project"
+		out, err := d.Render(fetcher(t), cfg)
+		if err != nil {
+			t.Fatalf("Render err: %v", err)
+		}
+		if !strings.Contains(out, "my-gcp-project") {
+			t.Errorf("Render missing project: %s", out)
+		}
+		if !strings.Contains(out, "gce-conf") {
+			t.Errorf("Render SA mode should reference gce-conf Secret: %s", out)
+		}
+	})
+	t.Run("workload-identity", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Providers.GCP.IdentityModel = "workload-identity"
+		cfg.Providers.GCP.Project = "my-gcp-project"
+		out, err := d.Render(fetcher(t), cfg)
+		if err != nil {
+			t.Fatalf("Render WI err: %v", err)
+		}
+		if !strings.Contains(out, "iam.gke.io/gcp-service-account") {
+			t.Errorf("Render WI missing SA annotation: %s", out)
+		}
+		if !strings.Contains(out, "my-gcp-project") {
+			t.Errorf("Render WI missing project: %s", out)
+		}
+	})
 }
 
-func TestRenderValuesWorkloadIdentity(t *testing.T) {
-	d := driver{}
-	cfg := &config.Config{}
-	cfg.Providers.GCP.Project = "p"
-	cfg.Providers.GCP.IdentityModel = "workload-identity"
-	out, err := d.RenderValues(cfg)
-	if err != nil {
-		t.Fatalf("RenderValues err: %v", err)
-	}
-	if !strings.Contains(out, "iam.gke.io/gcp-service-account") {
-		t.Errorf("WI path missing iam.gke.io/gcp-service-account: %s", out)
-	}
-}
+
 
 func TestEnsureSecretWorkloadIdentityNoOp(t *testing.T) {
 	d := driver{}

--- a/internal/csi/gcppd/testdata/yage-manifests/csi/gcp-pd/values.yaml.tmpl
+++ b/internal/csi/gcppd/testdata/yage-manifests/csi/gcp-pd/values.yaml.tmpl
@@ -1,0 +1,28 @@
+# Rendered by yage-manifests csi/gcp-pd/values.yaml.tmpl.
+controller:
+  replicas: 2
+storageClasses:
+  - name: pd-balanced
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    parameters:
+      type: pd-balanced
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete
+{{ if eq .Cfg.Providers.GCP.IdentityModel "workload-identity" -}}
+# Workload Identity: SA annotated for GCP IAM federation.
+serviceAccount:
+  controller:
+    create: true
+    annotations:
+      iam.gke.io/gcp-service-account: {{ printf "%q" (printf "yage-csi@%s.iam.gserviceaccount.com" .Cfg.Providers.GCP.Project) }}
+{{ else -}}
+# Service-Account: cloud-sa.json mounted from a Secret.
+controller:
+  cloudSAVolume:
+    secret:
+      secretName: gce-conf
+{{ end -}}
+{{ if .Cfg.Providers.GCP.Project -}}
+project: {{ .Cfg.Providers.GCP.Project }}
+{{ end -}}

--- a/internal/csi/hcloud/hcloud.go
+++ b/internal/csi/hcloud/hcloud.go
@@ -18,7 +18,6 @@ package hcloud
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +26,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -57,24 +58,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The API token is
-// read by the controller from the kube-system/hcloud-csi Secret applied
-// by EnsureSecret — this values block points the chart at that Secret
-// rather than inlining the token value.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/hcloud.\n")
-	b.WriteString("# Auth: Kubernetes Secret applied by EnsureSecret\n")
-	b.WriteString("# (kube-system/hcloud-csi, key \"token\").\n")
-	b.WriteString("secret:\n")
-	b.WriteString("  name: " + secretName + "\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: hcloud-volumes\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/hcloud-csi/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret creates (or updates) the kube-system/hcloud-csi Secret

--- a/internal/csi/hcloud/hcloud_test.go
+++ b/internal/csi/hcloud/hcloud_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	if got, want := d.Name(), "hcloud-csi"; got != want {
@@ -44,20 +51,20 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
-	out, err := d.RenderValues(&config.Config{})
+	out, err := d.Render(fetcher(t), &config.Config{})
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected err: %v", err)
+		t.Fatalf("Render() unexpected err: %v", err)
 	}
 	if out == "" {
-		t.Error("RenderValues() returned empty string")
+		t.Error("Render() returned empty string")
 	}
 	if !strings.Contains(out, "hcloud-volumes") {
-		t.Errorf("RenderValues() missing hcloud-volumes: %s", out)
+		t.Errorf("Render() missing hcloud-volumes: %s", out)
 	}
 	if !strings.Contains(out, "secret") {
-		t.Errorf("RenderValues() missing secret reference: %s", out)
+		t.Errorf("Render() missing secret reference: %s", out)
 	}
 }
 

--- a/internal/csi/hcloud/testdata/yage-manifests/csi/hcloud-csi/values.yaml.tmpl
+++ b/internal/csi/hcloud/testdata/yage-manifests/csi/hcloud-csi/values.yaml.tmpl
@@ -1,0 +1,11 @@
+# Rendered by yage-manifests csi/hcloud-csi/values.yaml.tmpl.
+# Auth: Kubernetes Secret applied by EnsureSecret
+# (kube-system/hcloud-csi, key "token").
+secret:
+  name: hcloud-csi
+storageClasses:
+  - name: hcloud-volumes
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer

--- a/internal/csi/ibmvpcblock/ibmvpcblock.go
+++ b/internal/csi/ibmvpcblock/ibmvpcblock.go
@@ -18,7 +18,6 @@ package ibmvpcblock
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +26,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -57,29 +58,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The IBM VPC Block
-// CSI driver requires cluster-level configuration (cluster ID, resource
-// group) that operators typically set via the chart's own ConfigMap or
-// via Helm value overrides at install time.
-//
-// Operators must set the following in their Helm values override:
-//   - clusterInfo.clusterID: the IKS/VPC cluster ID
-//   - clusterInfo.resourceGroupID: the IBM Cloud resource group ID
-//   - image.ibmVpcBlockDriver: the driver image if using a private registry
-//
-// The IBM API key is supplied via the Secret created by EnsureSecret,
-// not through Helm values.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/ibmvpcblock.\n")
-	b.WriteString("# Operator MUST set the following via --csi-values-file or Helm override:\n")
-	b.WriteString("#   clusterInfo.clusterID: <your VPC cluster ID>\n")
-	b.WriteString("#   clusterInfo.resourceGroupID: <your IBM Cloud resource group ID>\n")
-	b.WriteString("# To use a private registry, also set:\n")
-	b.WriteString("#   image.ibmVpcBlockDriver: <registry/ibm-vpc-block-csi-driver:tag>\n")
-	b.WriteString("# The IBM Cloud API key is supplied via the kube-system/")
-	b.WriteString(secretName + " Secret.\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/ibm-vpc-block/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret creates or updates the kube-system/ibm-vpc-block-csi-storageclasses

--- a/internal/csi/ibmvpcblock/ibmvpcblock_test.go
+++ b/internal/csi/ibmvpcblock/ibmvpcblock_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	tests := []struct {
@@ -54,18 +61,18 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
 	cfg := &config.Config{}
-	out, err := d.RenderValues(cfg)
+	out, err := d.Render(fetcher(t), cfg)
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected err: %v", err)
+		t.Fatalf("Render() unexpected err: %v", err)
 	}
 	if !strings.Contains(out, "clusterInfo.clusterID") {
-		t.Errorf("RenderValues missing clusterInfo.clusterID operator note: %s", out)
+		t.Errorf("Render missing clusterInfo.clusterID operator note: %s", out)
 	}
 	if !strings.Contains(out, secretName) {
-		t.Errorf("RenderValues missing Secret name %q: %s", secretName, out)
+		t.Errorf("Render missing Secret name %q: %s", secretName, out)
 	}
 }
 

--- a/internal/csi/ibmvpcblock/testdata/yage-manifests/csi/ibm-vpc-block/values.yaml.tmpl
+++ b/internal/csi/ibmvpcblock/testdata/yage-manifests/csi/ibm-vpc-block/values.yaml.tmpl
@@ -1,0 +1,7 @@
+# Rendered by yage-manifests csi/ibm-vpc-block/values.yaml.tmpl.
+# Operator MUST set the following via --csi-values-file or Helm override:
+#   clusterInfo.clusterID: <your VPC cluster ID>
+#   clusterInfo.resourceGroupID: <your IBM Cloud resource group ID>
+# To use a private registry, also set:
+#   image.ibmVpcBlockDriver: <registry/ibm-vpc-block-csi-driver:tag>
+# The IBM Cloud API key is supplied via the kube-system/ibm-vpc-block-csi-storageclasses Secret.

--- a/internal/csi/linodebs/linodebs.go
+++ b/internal/csi/linodebs/linodebs.go
@@ -25,7 +25,6 @@ package linodebs
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +33,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -66,25 +67,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The chart expects
-// a pre-existing Secret named "linode" in kube-system with a "token"
-// key (ensured by EnsureSecret before Helm install).
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/linodebs.\n")
-	b.WriteString("# Requires kube-system/linode Secret with key 'token' (see EnsureSecret).\n")
-	b.WriteString("secret:\n")
-	b.WriteString("  name: " + secretName + "\n")
-	b.WriteString("  namespace: " + secretNamespace + "\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: linode-block-storage\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    parameters:\n")
-	b.WriteString("      type: namedtype\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/linode-block-storage/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret applies the kube-system/linode Secret to the workload

--- a/internal/csi/linodebs/linodebs_test.go
+++ b/internal/csi/linodebs/linodebs_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	tests := []struct {
 		name string
@@ -54,21 +61,21 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
 	cfg := &config.Config{}
-	out, err := d.RenderValues(cfg)
+	out, err := d.Render(fetcher(t), cfg)
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected error: %v", err)
+		t.Fatalf("Render() unexpected error: %v", err)
 	}
 	if !strings.Contains(out, "linode") {
-		t.Errorf("RenderValues output does not reference the linode secret: %s", out)
+		t.Errorf("Render output does not reference the linode secret: %s", out)
 	}
 	if !strings.Contains(out, "linode-block-storage") {
-		t.Errorf("RenderValues output missing storage class name: %s", out)
+		t.Errorf("Render output missing storage class name: %s", out)
 	}
 	if !strings.Contains(out, "WaitForFirstConsumer") {
-		t.Errorf("RenderValues output missing volumeBindingMode: %s", out)
+		t.Errorf("Render output missing volumeBindingMode: %s", out)
 	}
 }
 

--- a/internal/csi/linodebs/testdata/yage-manifests/csi/linode-block-storage/values.yaml.tmpl
+++ b/internal/csi/linodebs/testdata/yage-manifests/csi/linode-block-storage/values.yaml.tmpl
@@ -1,0 +1,13 @@
+# Rendered by yage-manifests csi/linode-block-storage/values.yaml.tmpl.
+# Requires kube-system/linode Secret with key 'token' (see EnsureSecret).
+secret:
+  name: linode
+  namespace: kube-system
+storageClasses:
+  - name: linode-block-storage
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    parameters:
+      type: namedtype
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete

--- a/internal/csi/longhorn/longhorn.go
+++ b/internal/csi/longhorn/longhorn.go
@@ -20,9 +20,10 @@
 package longhorn
 
 import (
-	"strings"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
@@ -59,21 +60,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. Longhorn's
-// defaults are production-ready out of the box; no required overrides
-// exist for a standard install. The only tunable emitted here is
-// defaultSettings.defaultReplicaCount — set to 3, which is Longhorn's
-// own default and gives one replica per worker node in a three-node
-// cluster. Operators reduce it to 2 on two-node setups or 1 for
-// single-node dev environments via a Helm CLI override.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/longhorn.\n")
-	b.WriteString("# Longhorn defaults are production-ready; no required overrides.\n")
-	b.WriteString("# Adjust defaultReplicaCount to match your cluster's worker node count.\n")
-	b.WriteString("defaultSettings:\n")
-	b.WriteString("  defaultReplicaCount: 3\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/longhorn/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret returns ErrNotApplicable: Longhorn uses local node

--- a/internal/csi/longhorn/longhorn_test.go
+++ b/internal/csi/longhorn/longhorn_test.go
@@ -9,8 +9,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	cases := []struct {
@@ -94,50 +101,17 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
-	cases := []struct {
-		name    string
-		checkFn func(out string, err error)
-	}{
-		{
-			name: "no error",
-			checkFn: func(out string, err error) {
-				if err != nil {
-					t.Fatalf("RenderValues() unexpected err: %v", err)
-				}
-			},
-		},
-		{
-			name: "contains defaultReplicaCount 3",
-			checkFn: func(out string, err error) {
-				if !strings.Contains(out, "defaultReplicaCount: 3") {
-					t.Errorf("RenderValues() missing defaultReplicaCount: 3\n%s", out)
-				}
-			},
-		},
-		{
-			name: "contains no required overrides comment",
-			checkFn: func(out string, err error) {
-				if !strings.Contains(out, "no required overrides") {
-					t.Errorf("RenderValues() missing explanatory comment about no required overrides\n%s", out)
-				}
-			},
-		},
-		{
-			name: "non-empty output",
-			checkFn: func(out string, err error) {
-				if out == "" {
-					t.Errorf("RenderValues() returned empty string")
-				}
-			},
-		},
+	out, err := d.Render(fetcher(t), nil)
+	if err != nil {
+		t.Fatalf("Render() unexpected err: %v", err)
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			out, err := d.RenderValues(nil)
-			c.checkFn(out, err)
-		})
+	if !strings.Contains(out, "defaultReplicaCount: 3") {
+		t.Errorf("Render() missing defaultReplicaCount: 3\n%s", out)
+	}
+	if !strings.Contains(out, "no required overrides") {
+		t.Errorf("Render() missing comment about no required overrides\n%s", out)
 	}
 }
 

--- a/internal/csi/longhorn/testdata/yage-manifests/csi/longhorn/values.yaml.tmpl
+++ b/internal/csi/longhorn/testdata/yage-manifests/csi/longhorn/values.yaml.tmpl
@@ -1,0 +1,5 @@
+# Rendered by yage-manifests csi/longhorn/values.yaml.tmpl.
+# Longhorn defaults are production-ready; no required overrides.
+# Adjust defaultReplicaCount to match your cluster's worker node count.
+defaultSettings:
+  defaultReplicaCount: 3

--- a/internal/csi/ociblock/ociblock.go
+++ b/internal/csi/ociblock/ociblock.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -58,27 +60,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document. The OCI CSI node
-// driver reads cloud credentials from the oci-cloud-controller-manager
-// Secret in kube-system (written by EnsureSecret). The default
-// StorageClass uses the oci-bv provisioner with WaitForFirstConsumer
-// binding so volumes are created in the same AD as the pod's node.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/ociblock.\n")
-	b.WriteString("# OCI credentials are read from the oci-cloud-controller-manager\n")
-	b.WriteString("# Secret in kube-system (written by EnsureSecret).\n")
-	b.WriteString("cloudConfig:\n")
-	b.WriteString("  secretName: " + secretName + "\n")
-	b.WriteString("  secretNamespace: " + secretNamespace + "\n")
-	b.WriteString("storageClasses:\n")
-	b.WriteString("  - name: oci-bv\n")
-	b.WriteString("    annotations:\n")
-	b.WriteString("      storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("    provisioner: blockvolume.csi.oraclecloud.com\n")
-	b.WriteString("    volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/oci-block-storage/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret writes the kube-system/oci-cloud-controller-manager Secret

--- a/internal/csi/ociblock/ociblock_test.go
+++ b/internal/csi/ociblock/ociblock_test.go
@@ -8,9 +8,16 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	tests := []struct {
@@ -59,21 +66,21 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValuesNonEmpty(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
 	cfg := &config.Config{}
-	out, err := d.RenderValues(cfg)
+	out, err := d.Render(fetcher(t), cfg)
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected error: %v", err)
+		t.Fatalf("Render() unexpected error: %v", err)
 	}
 	if out == "" {
-		t.Error("RenderValues() must return non-empty string")
+		t.Error("Render() must return non-empty string")
 	}
 	if !strings.Contains(out, secretName) {
-		t.Errorf("RenderValues() must reference secret name %q, got:\n%s", secretName, out)
+		t.Errorf("Render() must reference secret name %q, got:\n%s", secretName, out)
 	}
 	if !strings.Contains(out, "oci-bv") {
-		t.Errorf("RenderValues() must reference storage class oci-bv, got:\n%s", out)
+		t.Errorf("Render() must reference storage class oci-bv, got:\n%s", out)
 	}
 }
 

--- a/internal/csi/ociblock/testdata/yage-manifests/csi/oci-block-storage/values.yaml.tmpl
+++ b/internal/csi/ociblock/testdata/yage-manifests/csi/oci-block-storage/values.yaml.tmpl
@@ -1,0 +1,13 @@
+# Rendered by yage-manifests csi/oci-block-storage/values.yaml.tmpl.
+# OCI credentials are read from the oci-cloud-controller-manager
+# Secret in kube-system (written by EnsureSecret).
+cloudConfig:
+  secretName: oci-cloud-controller-manager
+  secretNamespace: kube-system
+storageClasses:
+  - name: oci-bv
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: blockvolume.csi.oraclecloud.com
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete

--- a/internal/csi/openebs/openebs.go
+++ b/internal/csi/openebs/openebs.go
@@ -21,9 +21,10 @@
 package openebs
 
 import (
-	"strings"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
@@ -52,33 +53,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document that enables only
-// the hostpath local engine. The LVM and ZFS engines are explicitly
-// disabled to avoid requiring kernel modules on cluster nodes.
-//
-// Operators who need LVM or ZFS can override these values by passing
-// additional Helm values:
-//
-//	engines.local.lvm.enabled: true   # requires LVM kernel module + VGs
-//	engines.local.zfs.enabled: true   # requires ZFS kernel module + zpools
-//
-// The default StorageClass "openebs-hostpath" is set as the cluster
-// default class with WaitForFirstConsumer binding mode so PVCs without
-// an explicit storageClassName land on the local node alongside their
-// consumer pod.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/openebs.\n")
-	b.WriteString("# Hostpath engine only. To enable LVM or ZFS engines, override:\n")
-	b.WriteString("#   engines.local.lvm.enabled: true  (requires LVM kernel module + VGs on nodes)\n")
-	b.WriteString("#   engines.local.zfs.enabled: true  (requires ZFS kernel module + zpools on nodes)\n")
-	b.WriteString("engines:\n")
-	b.WriteString("  local:\n")
-	b.WriteString("    lvm:\n")
-	b.WriteString("      enabled: false\n")
-	b.WriteString("    zfs:\n")
-	b.WriteString("      enabled: false\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/openebs/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret returns ErrNotApplicable: OpenEBS hostpath uses local

--- a/internal/csi/openebs/openebs_test.go
+++ b/internal/csi/openebs/openebs_test.go
@@ -9,8 +9,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	tests := []struct {
 		name string
@@ -58,20 +65,16 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
-	vals, err := d.RenderValues(nil)
+	vals, err := d.Render(fetcher(t), nil)
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected err: %v", err)
+		t.Fatalf("Render() unexpected err: %v", err)
 	}
-	for _, want := range []string{
-		"engines:",
-		"lvm:",
-		"enabled: false",
-		"zfs:",
-	} {
+	wants := []string{"engines:", "local:", "lvm:", "enabled: false", "zfs:"}
+	for _, want := range wants {
 		if !strings.Contains(vals, want) {
-			t.Errorf("RenderValues() missing %q in output:\n%s", want, vals)
+			t.Errorf("Render() missing %q in output:\n%s", want, vals)
 		}
 	}
 }

--- a/internal/csi/openebs/testdata/yage-manifests/csi/openebs/values.yaml.tmpl
+++ b/internal/csi/openebs/testdata/yage-manifests/csi/openebs/values.yaml.tmpl
@@ -1,0 +1,10 @@
+# Rendered by yage-manifests csi/openebs/values.yaml.tmpl.
+# Hostpath engine only. To enable LVM or ZFS engines, override:
+#   engines.local.lvm.enabled: true  (requires LVM kernel module + VGs on nodes)
+#   engines.local.zfs.enabled: true  (requires ZFS kernel module + zpools on nodes)
+engines:
+  local:
+    lvm:
+      enabled: false
+    zfs:
+      enabled: false

--- a/internal/csi/proxmoxcsi/proxmoxcsi.go
+++ b/internal/csi/proxmoxcsi/proxmoxcsi.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/platform/shell"
@@ -49,23 +51,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a thin Helm values document. The bulk of the
-// driver's runtime config (Proxmox URL / token / region / cluster
-// alias) flows in via the Secret applied by EnsureSecret below, not
-// via Helm values — that's how the upstream chart is wired and why
-// yage doesn't need to enumerate fields here.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/proxmoxcsi.\n")
-	b.WriteString("# Auth: Kubernetes Secret applied by EnsureSecret\n")
-	b.WriteString("storageClass:\n")
-	b.WriteString("  - name: ")
-	b.WriteString(cfg.Providers.Proxmox.CSIStorageClassName)
-	b.WriteString("\n")
-	b.WriteString("    storage: data\n")
-	b.WriteString("    reclaimPolicy: Delete\n")
-	b.WriteString("    fstype: xfs\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/proxmox-csi/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret pushes the Proxmox CSI config Secret to the workload

--- a/internal/csi/proxmoxcsi/proxmoxcsi_test.go
+++ b/internal/csi/proxmoxcsi/proxmoxcsi_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package proxmoxcsi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
+
+func TestDriverConstants(t *testing.T) {
+	d := driver{}
+	if got, want := d.Name(), "proxmox-csi"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if got, want := d.K8sCSIDriverName(), "csi.proxmox.sinextra.dev"; got != want {
+		t.Errorf("K8sCSIDriverName() = %q, want %q", got, want)
+	}
+	if got, want := d.DefaultStorageClass(), "proxmox-data-xfs"; got != want {
+		t.Errorf("DefaultStorageClass() = %q, want %q", got, want)
+	}
+	defs := d.Defaults()
+	if len(defs) != 1 || defs[0] != "proxmox" {
+		t.Errorf("Defaults() = %v, want [proxmox]", defs)
+	}
+}
+
+func TestHelmChart(t *testing.T) {
+	d := driver{}
+	cfg := &config.Config{}
+	cfg.Providers.Proxmox.CSIChartRepoURL = "oci://ghcr.io/sergelogvinov/charts"
+	cfg.Providers.Proxmox.CSIChartName = "proxmox-csi-plugin"
+	cfg.Providers.Proxmox.CSIChartVersion = "0.2.10"
+	repo, chart, ver, err := d.HelmChart(cfg)
+	if err != nil {
+		t.Fatalf("HelmChart() unexpected err: %v", err)
+	}
+	if chart != "proxmox-csi-plugin" {
+		t.Errorf("chart = %q, want proxmox-csi-plugin", chart)
+	}
+	if ver != "0.2.10" {
+		t.Errorf("version = %q, want 0.2.10", ver)
+	}
+	if repo != "oci://ghcr.io/sergelogvinov/charts" {
+		t.Errorf("repo = %q", repo)
+	}
+}
+
+func TestRender(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Providers.Proxmox.CSIStorageClassName = "proxmox-xfs"
+	out, err := driver{}.Render(fetcher(t), cfg)
+	if err != nil {
+		t.Fatalf("Render() unexpected err: %v", err)
+	}
+	checks := []string{
+		"proxmox-xfs",
+		"storageClass:",
+		"reclaimPolicy: Delete",
+		"fstype: xfs",
+	}
+	for _, c := range checks {
+		if !strings.Contains(out, c) {
+			t.Errorf("Render() missing %q in output:\n%s", c, out)
+		}
+	}
+}

--- a/internal/csi/proxmoxcsi/testdata/yage-manifests/csi/proxmox-csi/values.yaml.tmpl
+++ b/internal/csi/proxmoxcsi/testdata/yage-manifests/csi/proxmox-csi/values.yaml.tmpl
@@ -1,0 +1,7 @@
+# Rendered by yage-manifests csi/proxmox-csi/values.yaml.tmpl.
+# Auth: Kubernetes Secret applied by EnsureSecret
+storageClass:
+  - name: {{ .Cfg.Providers.Proxmox.CSIStorageClassName }}
+    storage: data
+    reclaimPolicy: Delete
+    fstype: xfs

--- a/internal/csi/rookceph/rookceph.go
+++ b/internal/csi/rookceph/rookceph.go
@@ -23,9 +23,10 @@
 package rookceph
 
 import (
-	"strings"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
@@ -53,28 +54,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document for the Rook
-// operator. The chart deploys the operator and registers the CSI
-// plug-in; a CephCluster CR must be applied separately to bring up
-// the actual storage cluster.
-//
-// csi.cephBlockPools.replicaCount is set to 3 — the recommended
-// minimum for production Ceph (one replica per failure domain). Lower
-// this to 1 or 2 for single-node / dev clusters by overriding the
-// value out-of-band.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/rookceph.\n")
-	b.WriteString("# This chart installs the Rook operator only.\n")
-	b.WriteString("# Post-install: apply a CephCluster CR to create the storage cluster.\n")
-	b.WriteString("# See: https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/\n")
-	b.WriteString("csi:\n")
-	b.WriteString("  cephBlockPools:\n")
-	b.WriteString("    replicaCount: 3\n")
-	b.WriteString("# operator.logLevel: INFO by default; set to DEBUG for troubleshooting.\n")
-	b.WriteString("operator:\n")
-	b.WriteString("  logLevel: INFO\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/rook-ceph/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret returns ErrNotApplicable: Rook-Ceph uses in-cluster

--- a/internal/csi/rookceph/rookceph_test.go
+++ b/internal/csi/rookceph/rookceph_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/csi"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	tests := []struct {
 		name string
@@ -52,20 +59,15 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
-	out, err := driver{}.RenderValues(nil)
+func TestRender(t *testing.T) {
+	out, err := driver{}.Render(fetcher(t), nil)
 	if err != nil {
-		t.Fatalf("RenderValues() unexpected err: %v", err)
+		t.Fatalf("Render() unexpected err: %v", err)
 	}
-	checks := []string{
-		"csi:",
-		"cephBlockPools:",
-		"replicaCount: 3",
-		"operator:",
-	}
-	for _, needle := range checks {
+	wants := []string{"csi:", "cephBlockPools:", "replicaCount: 3", "operator:"}
+	for _, needle := range wants {
 		if !strings.Contains(out, needle) {
-			t.Errorf("RenderValues() missing %q in output:\n%s", needle, out)
+			t.Errorf("Render() missing %q in output:\n%s", needle, out)
 		}
 	}
 }

--- a/internal/csi/rookceph/testdata/yage-manifests/csi/rook-ceph/values.yaml.tmpl
+++ b/internal/csi/rookceph/testdata/yage-manifests/csi/rook-ceph/values.yaml.tmpl
@@ -1,0 +1,10 @@
+# Rendered by yage-manifests csi/rook-ceph/values.yaml.tmpl.
+# This chart installs the Rook operator only.
+# Post-install: apply a CephCluster CR to create the storage cluster.
+# See: https://rook.io/docs/rook/latest/CRDs/Cluster/ceph-cluster-crd/
+csi:
+  cephBlockPools:
+    replicaCount: 3
+# operator.logLevel: INFO by default; set to DEBUG for troubleshooting.
+operator:
+  logLevel: INFO

--- a/internal/csi/vspherecsi/testdata/yage-manifests/csi/vsphere-csi/values.yaml.tmpl
+++ b/internal/csi/vspherecsi/testdata/yage-manifests/csi/vsphere-csi/values.yaml.tmpl
@@ -1,0 +1,15 @@
+# Rendered by yage-manifests csi/vsphere-csi/values.yaml.tmpl.
+# Credentials: INI config mounted from kube-system/vsphere-config-secret.
+# NOTE: config.existingSecretName is the v3.3.1 chart knob for reusing
+# a pre-existing Secret. Verify against the chart's values.yaml if
+# upgrading the pinned version.
+config:
+  existingSecretName: vsphere-config-secret
+  existingSecretNamespace: kube-system
+storageClass:
+  enabled: true
+  name: vsphere-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  volumeBindingMode: WaitForFirstConsumer
+  reclaimPolicy: Delete

--- a/internal/csi/vspherecsi/vspherecsi.go
+++ b/internal/csi/vspherecsi/vspherecsi.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
 	"github.com/lpasquali/yage/internal/ui/plan"
@@ -62,33 +64,8 @@ func (driver) HelmChart(cfg *config.Config) (repo, chart, version string, err er
 		nil
 }
 
-// RenderValues emits a minimal Helm values document referencing the
-// vsphere-config-secret Secret that EnsureSecret places in kube-system.
-// The chart reads vCenter credentials from the INI file in that Secret
-// via the config.existingSecretName knob.
-//
-// StorageClass:
-//   - name "vsphere-sc" — the yage default for vSphere clusters.
-//   - volumeBindingMode WaitForFirstConsumer — ensures volumes are
-//     provisioned in the same datastore as the scheduled pod's node.
-func (driver) RenderValues(cfg *config.Config) (string, error) {
-	var b strings.Builder
-	b.WriteString("# Rendered by yage internal/csi/vspherecsi.\n")
-	b.WriteString("# Credentials: INI config mounted from kube-system/vsphere-config-secret.\n")
-	b.WriteString("# NOTE: config.existingSecretName is the v3.3.1 chart knob for reusing\n")
-	b.WriteString("# a pre-existing Secret. Verify against the chart's values.yaml if\n")
-	b.WriteString("# upgrading the pinned version.\n")
-	b.WriteString("config:\n")
-	b.WriteString("  existingSecretName: " + secretName + "\n")
-	b.WriteString("  existingSecretNamespace: " + secretNamespace + "\n")
-	b.WriteString("storageClass:\n")
-	b.WriteString("  enabled: true\n")
-	b.WriteString("  name: vsphere-sc\n")
-	b.WriteString("  annotations:\n")
-	b.WriteString("    storageclass.kubernetes.io/is-default-class: \"true\"\n")
-	b.WriteString("  volumeBindingMode: WaitForFirstConsumer\n")
-	b.WriteString("  reclaimPolicy: Delete\n")
-	return b.String(), nil
+func (driver) Render(f *manifests.Fetcher, cfg *config.Config) (string, error) {
+	return f.Render("csi/vsphere-csi/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})
 }
 
 // EnsureSecret writes kube-system/vsphere-config-secret on the workload

--- a/internal/csi/vspherecsi/vspherecsi_test.go
+++ b/internal/csi/vspherecsi/vspherecsi_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 )
 
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture.
+func fetcher(t *testing.T) *manifests.Fetcher {
+	t.Helper()
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
 func TestDriverConstants(t *testing.T) {
 	d := driver{}
 	tests := []struct {
@@ -51,22 +58,18 @@ func TestHelmChart(t *testing.T) {
 	}
 }
 
-func TestRenderValues(t *testing.T) {
+func TestRender(t *testing.T) {
 	d := driver{}
 	cfg := &config.Config{}
-	out, err := d.RenderValues(cfg)
+	cfg.Providers.Vsphere.Server = "vcenter.example.com"
+	out, err := d.Render(fetcher(t), cfg)
 	if err != nil {
-		t.Fatalf("RenderValues() error: %v", err)
+		t.Fatalf("Render() error: %v", err)
 	}
-	checks := []string{
-		"existingSecretName: " + secretName,
-		"vsphere-sc",
-		"WaitForFirstConsumer",
-		"storageclass.kubernetes.io/is-default-class",
-	}
-	for _, want := range checks {
+	wants := []string{"vsphere-config-secret", "vsphere-sc", "WaitForFirstConsumer", "storageClass:"}
+	for _, want := range wants {
 		if !strings.Contains(out, want) {
-			t.Errorf("RenderValues() missing %q in:\n%s", want, out)
+			t.Errorf("Render() missing %q in:\n%s", want, out)
 		}
 	}
 }

--- a/internal/orchestrator/pivot_sequence_test.go
+++ b/internal/orchestrator/pivot_sequence_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/csi"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/platform/manifests"
 	"github.com/lpasquali/yage/internal/ui/plan"
 )
 
@@ -102,7 +103,9 @@ func (f fakeCSIDriver) Defaults() []string                                     {
 func (f fakeCSIDriver) HelmChart(_ *config.Config) (string, string, string, error) {
 	return "", "", "", csi.ErrNotApplicable
 }
-func (f fakeCSIDriver) RenderValues(_ *config.Config) (string, error)   { return "", nil }
+func (f fakeCSIDriver) Render(_ *manifests.Fetcher, _ *config.Config) (string, error) {
+	return "", nil
+}
 func (f fakeCSIDriver) EnsureSecret(_ *config.Config, _ string) error   { return csi.ErrNotApplicable }
 func (f fakeCSIDriver) DefaultStorageClass() string                     { return "" }
 func (f fakeCSIDriver) DescribeInstall(_ plan.Writer, _ *config.Config) {}


### PR DESCRIPTION
## Summary

- Renames `Driver.RenderValues(cfg *config.Config) (string, error)` → `Driver.Render(f *manifests.Fetcher, cfg *config.Config) (string, error)` per ADR 0012 §3
- All 14 CSI driver packages now delegate to `f.Render("csi/<name>/values.yaml.tmpl", templates.HelmValuesData{Cfg: cfg})`
- Per-driver `testdata/yage-manifests/csi/<name>/values.yaml.tmpl` fixtures for hermetic tests
- `TestRender` content-assertion tests replace `TestRenderValues` in each driver package
- Normalizes `Azure.IdentityModel` and `GCP.IdentityModel` to lowercase at config-load time so `text/template eq` comparisons match the original `strings.EqualFold` behavior
- Companion yage-manifests PR: lpasquali/yage-manifests#9

**Breaking change**: `Driver` interface method signature changed. All implementations and stubs updated.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 15 csi/* packages + orchestrator + config)
- [x] No new FuncMap entries (templates use standard `eq`/`printf` only)
- [x] No wrapper struct extension needed (`HelmValuesData{Cfg}` sufficient for all 14 drivers)
- [x] `internal/ui/xapiri/` untouched
- [x] `internal/capi/{helmvalues,caaph,templates,wlargocd,postsync}/` untouched
- [x] `.github/workflows/` untouched

## Acceptance Criteria Evidence

**Bold DoD items**:
- **Driver.Render signature**: interface method renamed and all 14 implementations updated
- **Template delegation**: each driver calls `f.Render("csi/<name>/values.yaml.tmpl", ...)`
- **Testdata fixtures**: 14 `testdata/yage-manifests/csi/*/values.yaml.tmpl` files added
- **TestRender tests**: per-driver content-assertion tests using `fetcher(t)` helper
- **CI green**: `go test ./...` exit 0

## Template equivalence spot-checks

Original `RenderValues` bodies traced against testdata fixtures (render-and-diff):

| Driver | Check | Result |
|--------|-------|--------|
| linodebs | `type: namedtype` static field | Match: was `b.WriteString("      type: namedtype\n")` |
| hcloud | `secret.name: hcloud-csi` | Match: `secretName = "hcloud-csi"` constant |
| doblock | `kube-system/digitalocean key access-token` | Match: constants `secretName = "digitalocean"`, `tokenKey = "access-token"` |
| azuredisk | Workload-Identity path: `azure.workload.identity/client-id: %q` | Match: template uses `printf "%q" .Cfg.Providers.Azure.ClientID`; SP path: `secretName = "azure-cloud-config"` matches `cloudConfigSecretName: azure-cloud-config` |
| gcppd | Workload-Identity: `iam.gke.io/gcp-service-account: %q` of `gcpSAEmail` | Match: `printf "%q" (printf "yage-csi@%s.iam.gserviceaccount.com" .Cfg.Providers.GCP.Project)` reproduces exactly; SP path: `secretName = "gce-conf"` matches `secretName: gce-conf` |
| proxmoxcsi | `{{ .Cfg.Providers.Proxmox.CSIStorageClassName }}` dynamic field | Match: original was `b.WriteString(cfg.Providers.Proxmox.CSIStorageClassName)` |

**IdentityModel case-sensitivity fix** (commits `d8bdf6e` → `ce6fbb7`): Original Go used `strings.EqualFold` for both Azure and GCP IdentityModel checks. `text/template eq` is case-sensitive. Fixed by normalizing both fields to `strings.ToLower` at config-load time in `internal/config/config.go` — consistent behavior across all downstream consumers.

## Dependencies / Follow-ups

Production wiring of `Render` requires all three steps before live clusters use the templates:

1. **lpasquali/yage-manifests#9 must merge** into `init` — the 14 `csi/*/values.yaml.tmpl` files must land in the yage-manifests repo
2. **New yage-manifests release tag** — a new tag (e.g. `v0.x.y`) cut from the merged `init` branch
3. **`cfg.ManifestsRef` bumped** — update to the new tag so `manifests.Fetcher` resolves templates from the correct snapshot

Until step 3 lands, `Render` works correctly in unit tests (testdata fixtures) but will 404 at runtime on clusters where `ManifestsRef` predates yage-manifests#9.

## Audit Checks

No triggers fired.
- No changes to `internal/ui/xapiri/`
- No changes to `internal/capi/{helmvalues,caaph,templates,wlargocd,postsync}/`
- No changes to `.github/workflows/`

## Breaking Changes

`Driver.RenderValues` removed. Any external code implementing `csi.Driver` must rename to `Render(f *manifests.Fetcher, cfg *config.Config) (string, error)`.

`AZURE_IDENTITY_MODEL` and `GCP_IDENTITY_MODEL` env-var values are now lowercased at load time. Mixed-case values (e.g. `Workload-Identity`) now work correctly where they would have silently misbehaved with templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)