### PR TITLE
feat(wlargocd): migrate render.go to yage-manifests templates (#138)

### DIFF
--- a/internal/capi/templates/argo_application_data_test.go
+++ b/internal/capi/templates/argo_application_data_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 // TestArgoApplicationData_AllFieldsRendered exercises every ADR 0012 §3
-// field on ArgoApplicationData, including the embedded PostSyncBlock
-// reached through the .PostSync path. Fixture template references
-// every leaf field; missingkey=error turns any rename into a render
-// failure.
+// field on ArgoApplicationData, including a populated PostSyncs slice
+// (issue #138 extends ADR 0012 §3 from a single PostSync block to a
+// slice — see PR body). Fixture template references every leaf field;
+// missingkey=error turns any rename into a render failure.
 func TestArgoApplicationData_AllFieldsRendered(t *testing.T) {
 	f := &manifests.Fetcher{MountRoot: "testdata"}
 
@@ -34,11 +34,13 @@ func TestArgoApplicationData_AllFieldsRendered(t *testing.T) {
 		Annotations: map[string]string{
 			"argocd.argoproj.io/compare-options": "ServerSideDiff=true",
 		},
-		PostSync: templates.PostSyncBlock{
-			URL:              "https://github.com/lpasquali/workload-smoketests",
-			Path:             "kustomize/proxmox-csi",
-			Ref:              "main",
-			KustomizePartial: "  patches:\n    - path: image-override.yaml",
+		PostSyncs: []templates.PostSyncBlock{
+			{
+				URL:              "https://github.com/lpasquali/workload-smoketests",
+				Path:             "kustomize/proxmox-csi",
+				Ref:              "main",
+				KustomizePartial: "  patches:\n    - path: image-override.yaml",
+			},
 		},
 	}
 

--- a/internal/capi/templates/templates.go
+++ b/internal/capi/templates/templates.go
@@ -28,6 +28,10 @@ type HelmValuesData struct {
 }
 
 // ArgoApplicationData is passed to addons/<addon>/application.yaml.tmpl.
+//
+// PostSyncs is a slice rather than a single block: HelmOCI's proxmox-csi
+// smoke variant attaches two PostSync hooks together, single-hook flows
+// use one entry, and the no-hook case is nil/empty.
 type ArgoApplicationData struct {
 	Cfg         *config.Config
 	Name        string
@@ -40,7 +44,7 @@ type ArgoApplicationData struct {
 	ReleaseName string
 	ValuesYAML  string
 	Annotations map[string]string
-	PostSync    PostSyncBlock
+	PostSyncs   []PostSyncBlock
 }
 
 // PostSyncBlock is the second-source git+kustomize fields for an Argo

--- a/internal/capi/templates/testdata/yage-manifests/argoapplication.yaml.tmpl
+++ b/internal/capi/templates/testdata/yage-manifests/argoapplication.yaml.tmpl
@@ -10,7 +10,9 @@ syncWave: {{ .SyncWave }}
 releaseName: {{ .ReleaseName }}
 valuesYAML: {{ .ValuesYAML }}
 annotation: {{ index .Annotations "argocd.argoproj.io/compare-options" }}
-postSyncURL: {{ .PostSync.URL }}
-postSyncPath: {{ .PostSync.Path }}
-postSyncRef: {{ .PostSync.Ref }}
-postSyncPartial: {{ .PostSync.KustomizePartial }}
+{{- range $h := .PostSyncs }}
+postSyncURL: {{ $h.URL }}
+postSyncPath: {{ $h.Path }}
+postSyncRef: {{ $h.Ref }}
+postSyncPartial: {{ $h.KustomizePartial }}
+{{- end }}

--- a/internal/capi/wlargocd/render.go
+++ b/internal/capi/wlargocd/render.go
@@ -2,249 +2,130 @@
 // Copyright 2026 Luca Pasquali
 
 // Package wlargocd renders workload Argo CD Application YAML.
-// Each renderer emits a complete `---`-prefixed Application
-// document the orchestrator concatenates into one kubectl-apply
-// stream.
+//
+// Each renderer emits a complete `---`-prefixed Application document
+// the orchestrator concatenates into one kubectl-apply stream.
+// Bodies are produced by yage-manifests templates resolved through
+// internal/platform/manifests.Fetcher (ADR 0008, ADR 0012). The
+// indent / shell-quote / postsync-derivation helpers stay Go-side
+// per ADR 0012 §wlargocd: they prepare the data passed into the
+// wrapper struct, they are not template-shaped.
 package wlargocd
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/lpasquali/yage/internal/config"
-	"github.com/lpasquali/yage/internal/ui/logx"
 	"github.com/lpasquali/yage/internal/capi/postsync"
+	"github.com/lpasquali/yage/internal/capi/templates"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+	"github.com/lpasquali/yage/internal/ui/logx"
 )
 
-// PostSyncBlock holds the optional second-source fields for a
-// PostSync-hook git repo + kustomize patch. Zero value means "no
-// PostSync hook attached".
-type PostSyncBlock struct {
-	URL   string
-	Path  string
-	Ref   string
-	Kz    string // kustomize block (already indented for the `sources:` array)
-}
-
-// Derive PostSyncBlock from the config for a given hook short name.
-// Returns a zero block when hooks are disabled, no short name, or the
-// git URL cannot be discovered.
-func derivePostSync(cfg *config.Config, hookShort string) PostSyncBlock {
+// derivePostSync builds the single-hook PostSyncBlock for hookShort,
+// or returns a zero block when hooks are disabled, the short name is
+// empty, or the git URL cannot be discovered. The kustomize partial
+// is pre-indented by 2 (depth 6 inside `sources:`) so the template
+// can splice it without further indentation.
+func derivePostSync(f *manifests.Fetcher, cfg *config.Config, hookShort string) (templates.PostSyncBlock, error) {
 	if !cfg.ArgoCD.PostsyncHooksEnabled || hookShort == "" {
-		return PostSyncBlock{}
+		return templates.PostSyncBlock{}, nil
 	}
 	url := postsync.DiscoverURL(cfg)
 	if url == "" {
 		logx.Warn("ARGO_WORKLOAD_POSTSYNC_HOOKS: no git URL; skipping PostSync hook for %s (set ARGO_WORKLOAD_POSTSYNC_HOOKS_GIT_URL).", hookShort)
-		return PostSyncBlock{}
+		return templates.PostSyncBlock{}, nil
 	}
-	return PostSyncBlock{
-		URL:  url,
-		Path: postsync.FullRelpath(cfg, hookShort),
-		Ref:  shellQuoteEscape(postsync.DiscoverRef(cfg)),
-		Kz:   postsync.KustomizeBlockForJob(cfg, hookShort+"-smoketest"),
+	kz, err := postsync.KustomizeBlockForJobTemplate(f, cfg, hookShort+"-smoketest")
+	if err != nil {
+		return templates.PostSyncBlock{}, fmt.Errorf("postsync kustomize block for %s: %w", hookShort, err)
 	}
+	return templates.PostSyncBlock{
+		URL:              url,
+		Path:             postsync.FullRelpath(cfg, hookShort),
+		Ref:              shellQuoteEscape(postsync.DiscoverRef(cfg)),
+		KustomizePartial: indent(kz, "  "),
+	}, nil
 }
 
 // HelmGit renders an Argo CD Application that pulls a Helm chart from
-// a Git source. releaseName and hookShort are optional — pass "" to
-// skip them.
-func HelmGit(cfg *config.Config, name, destNS, repoURL, relPath, ref, syncWave, valuesYAML, releaseName, hookShort string) string {
-	safeRef := shellQuoteEscape(ref)
+// a Git source. addonDir is the addons/<addonDir>/ subdirectory that
+// holds application.yaml.tmpl. releaseName and hookShort are optional
+// — pass "" to skip them.
+func HelmGit(f *manifests.Fetcher, cfg *config.Config, addonDir, name, destNS, repoURL, relPath, ref, syncWave, valuesYAML, releaseName, hookShort string) (string, error) {
+	hook, err := derivePostSync(f, cfg, hookShort)
+	if err != nil {
+		return "", err
+	}
 	indented, indentedMS := indentValuesBoth(valuesYAML)
-	hook := derivePostSync(cfg, hookShort)
-	var sb strings.Builder
+	values := indented
+	var hooks []templates.PostSyncBlock
 	if hook.URL != "" {
-		sb.WriteString(headerAnnot(name, cfg.ArgoCD.WorkloadNamespace, syncWave, ""))
-		fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n  sources:\n", destNS)
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "      path: %s\n", relPath)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", safeRef)
-		fmt.Fprintln(&sb, "      helm:")
-		if releaseName != "" {
-			fmt.Fprintf(&sb, "        releaseName: %s\n", releaseName)
-		}
-		fmt.Fprintln(&sb, "        valuesObject:")
-		if indentedMS != "" {
-			sb.WriteString(indentedMS)
-		} else {
-			fmt.Fprintln(&sb, "          {}")
-		}
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", hook.URL)
-		fmt.Fprintf(&sb, "      path: %s\n", hook.Path)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", hook.Ref)
-		sb.WriteString(indent(hook.Kz, "  "))
-		sb.WriteString(syncPolicyTail())
-	} else {
-		sb.WriteString(headerAnnot(name, cfg.ArgoCD.WorkloadNamespace, syncWave, ""))
-		fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n  source:\n", destNS)
-		fmt.Fprintf(&sb, "    repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "    path: %s\n", relPath)
-		fmt.Fprintf(&sb, "    targetRevision: '%s'\n", safeRef)
-		fmt.Fprintln(&sb, "    helm:")
-		if releaseName != "" {
-			fmt.Fprintf(&sb, "      releaseName: %s\n", releaseName)
-		}
-		fmt.Fprintln(&sb, "      valuesObject:")
-		if indented != "" {
-			sb.WriteString(indented)
-		} else {
-			fmt.Fprintln(&sb, "        {}")
-		}
-		sb.WriteString(syncPolicyTail())
+		values = indentedMS
+		hooks = []templates.PostSyncBlock{hook}
 	}
-	return sb.String()
-}
-
-// kyvernoTolerationFragment returns the Kyverno control-plane
-// toleration fragment, pre-indented with 8 spaces.
-func kyvernoTolerationFragment(cfg *config.Config) string {
-	if !isTrue(cfg.KyvernoTolerateControlPlane) {
-		return ""
+	data := templates.ArgoApplicationData{
+		Cfg:         cfg,
+		Name:        name,
+		DestNS:      destNS,
+		RepoURL:     repoURL,
+		Path:        relPath,
+		Ref:         shellQuoteEscape(ref),
+		SyncWave:    syncWave,
+		ReleaseName: releaseName,
+		ValuesYAML:  values,
+		PostSyncs:   hooks,
 	}
-	return `        global:
-          tolerations:
-            - key: "node-role.kubernetes.io/control-plane"
-              operator: Exists
-              effect: NoSchedule
-            - key: "node-role.kubernetes.io/master"
-              operator: Exists
-              effect: NoSchedule
-`
-}
-
-// Kyverno renders the Kyverno workload Argo CD Application YAML.
-func Kyverno(cfg *config.Config, name, ns, repoURL, chart, version, syncWave, hookShort string) string {
-	target := version
-	if target == "" {
-		target = "*"
+	body, err := f.Render("addons/"+addonDir+"/application.yaml.tmpl", data)
+	if err != nil {
+		return "", err
 	}
-	hook := derivePostSync(cfg, hookShort)
-	tolFragment := kyvernoTolerationFragment(cfg)
-
-	var sb strings.Builder
-	sb.WriteString(headerAnnot(name, cfg.ArgoCD.WorkloadNamespace, syncWave,
-		`argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true`))
-	fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n", ns)
-	if hook.URL != "" {
-		sb.WriteString("  sources:\n")
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "      chart: %s\n", chart)
-		fmt.Fprintf(&sb, "      targetRevision: %q\n", target)
-		sb.WriteString("      helm:\n")
-		sb.WriteString("        valuesObject:\n")
-		sb.WriteString("          config:\n")
-		sb.WriteString("            preserve: false\n")
-		sb.WriteString("            webhookLabels:\n")
-		sb.WriteString("              app.kubernetes.io/managed-by: argocd\n")
-		sb.WriteString(indent(tolFragment, "  ")) // bump 8→10 spaces via extra 2
-		sb.WriteString(kyvernoReplicasBlock(false))
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", hook.URL)
-		fmt.Fprintf(&sb, "      path: %s\n", hook.Path)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", hook.Ref)
-		sb.WriteString(indent(hook.Kz, "  "))
-	} else {
-		sb.WriteString("  source:\n")
-		fmt.Fprintf(&sb, "    repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "    chart: %s\n", chart)
-		fmt.Fprintf(&sb, "    targetRevision: %q\n", target)
-		sb.WriteString("    helm:\n")
-		sb.WriteString("      valuesObject:\n")
-		sb.WriteString("        config:\n")
-		sb.WriteString("          preserve: false\n")
-		sb.WriteString("          webhookLabels:\n")
-		sb.WriteString("            app.kubernetes.io/managed-by: argocd\n")
-		sb.WriteString(tolFragment)
-		sb.WriteString(kyvernoReplicasBlock(true))
-	}
-	sb.WriteString(kyvernoIgnoreDiffs())
-	sb.WriteString(syncPolicyTail())
-	return sb.String()
-}
-
-// kyvernoReplicasBlock: ms=true returns the deeper-indented variant
-// (inside `sources:` array).
-func kyvernoReplicasBlock(singleSource bool) string {
-	var i string
-	if singleSource {
-		i = "        "
-	} else {
-		i = "          "
-	}
-	return fmt.Sprintf(`%sadmissionController:
-%s  replicas: 1
-%sbackgroundController:
-%s  replicas: 1
-%scleanupController:
-%s  replicas: 1
-%sreportsController:
-%s  replicas: 1
-`, i, i, i, i, i, i, i, i)
-}
-
-func kyvernoIgnoreDiffs() string {
-	return `  ignoreDifferences:
-    - group: admissionregistration.k8s.io
-      kind: MutatingWebhookConfiguration
-      jqPathExpressions:
-        - .webhooks[]?.clientConfig.caBundle
-    - group: admissionregistration.k8s.io
-      kind: ValidatingWebhookConfiguration
-      jqPathExpressions:
-        - .webhooks[]?.clientConfig.caBundle
-`
+	return "---\n" + body, nil
 }
 
 // Helm renders an Argo CD Application that pulls a chart from an HTTP
 // Helm repository.
-func Helm(cfg *config.Config, name, ns, repoURL, chart, version, syncWave, valuesYAML, hookShort string) string {
+func Helm(f *manifests.Fetcher, cfg *config.Config, addonDir, name, ns, repoURL, chart, version, syncWave, valuesYAML, hookShort string) (string, error) {
 	target := version
 	if target == "" {
 		target = "*"
 	}
 	repoURL = strings.TrimSuffix(repoURL, "/")
-	indented, indentedMS := indentValuesBoth(valuesYAML)
-	hook := derivePostSync(cfg, hookShort)
-
-	var sb strings.Builder
-	sb.WriteString(headerAnnot(name, cfg.ArgoCD.WorkloadNamespace, syncWave, ""))
-	if hook.URL != "" {
-		fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n  sources:\n", ns)
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "      chart: %s\n", chart)
-		fmt.Fprintf(&sb, "      targetRevision: %q\n", target)
-		fmt.Fprintln(&sb, "      helm:")
-		fmt.Fprintln(&sb, "        valuesObject:")
-		if indentedMS != "" {
-			sb.WriteString(indentedMS)
-		} else {
-			fmt.Fprintln(&sb, "          {}")
-		}
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", hook.URL)
-		fmt.Fprintf(&sb, "      path: %s\n", hook.Path)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", hook.Ref)
-		sb.WriteString(indent(hook.Kz, "  "))
-	} else {
-		fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n  source:\n", ns)
-		fmt.Fprintf(&sb, "    repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "    chart: %s\n", chart)
-		fmt.Fprintf(&sb, "    targetRevision: %q\n", target)
-		fmt.Fprintln(&sb, "    helm:")
-		fmt.Fprintln(&sb, "      valuesObject:")
-		if indented != "" {
-			sb.WriteString(indented)
-		} else {
-			fmt.Fprintln(&sb, "        {}")
-		}
+	hook, err := derivePostSync(f, cfg, hookShort)
+	if err != nil {
+		return "", err
 	}
-	sb.WriteString(syncPolicyTail())
-	return sb.String()
+	indented, indentedMS := indentValuesBoth(valuesYAML)
+	values := indented
+	var hooks []templates.PostSyncBlock
+	if hook.URL != "" {
+		values = indentedMS
+		hooks = []templates.PostSyncBlock{hook}
+	}
+	data := templates.ArgoApplicationData{
+		Cfg:        cfg,
+		Name:       name,
+		DestNS:     ns,
+		RepoURL:    repoURL,
+		Chart:      chart,
+		Ref:        target,
+		SyncWave:   syncWave,
+		ValuesYAML: values,
+		PostSyncs:  hooks,
+	}
+	body, err := f.Render("addons/"+addonDir+"/application.yaml.tmpl", data)
+	if err != nil {
+		return "", err
+	}
+	return "---\n" + body, nil
 }
 
 // HelmOCI renders an Argo CD Application that pulls an OCI Helm chart.
 // Optional PostSync hooks: both kustomize blocks must be non-empty for
-// the sources/ multi-source to activate.
-func HelmOCI(cfg *config.Config, name, ns, ociURL, version, syncWave, valuesYAML, hook1Path, hook1Kz, hook2Path, hook2Kz string) string {
+// the multi-source variant to activate, and both hooks are emitted
+// together (slice of length 2).
+func HelmOCI(f *manifests.Fetcher, cfg *config.Config, addonDir, name, ns, ociURL, version, syncWave, valuesYAML, hook1Path, hook1Kz, hook2Path, hook2Kz string) (string, error) {
 	target := version
 	if target == "" {
 		target = "*"
@@ -264,110 +145,106 @@ func HelmOCI(cfg *config.Config, name, ns, ociURL, version, syncWave, valuesYAML
 		}
 	}
 
-	var sb strings.Builder
-	sb.WriteString(headerAnnot(name, cfg.ArgoCD.WorkloadNamespace, syncWave, ""))
+	values := indented
+	var hooks []templates.PostSyncBlock
 	if useMulti {
-		fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n  sources:\n", ns)
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", ociURL)
-		fmt.Fprintln(&sb, `      path: "."`)
-		fmt.Fprintf(&sb, "      targetRevision: %q\n", target)
-		fmt.Fprintln(&sb, "      helm:")
-		fmt.Fprintln(&sb, "        valuesObject:")
-		if indentedMS != "" {
-			sb.WriteString(indentedMS)
-		} else {
-			fmt.Fprintln(&sb, "          {}")
-		}
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", hURL)
-		fmt.Fprintf(&sb, "      path: %s\n", hook1Path)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", sref)
-		sb.WriteString(indent(hook1Kz, "  "))
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", hURL)
-		fmt.Fprintf(&sb, "      path: %s\n", hook2Path)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", sref)
-		sb.WriteString(indent(hook2Kz, "  "))
-	} else {
-		fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n  source:\n", ns)
-		fmt.Fprintf(&sb, "    repoURL: %s\n", ociURL)
-		fmt.Fprintln(&sb, `    path: "."`)
-		fmt.Fprintf(&sb, "    targetRevision: %q\n", target)
-		fmt.Fprintln(&sb, "    helm:")
-		fmt.Fprintln(&sb, "      valuesObject:")
-		if indented != "" {
-			sb.WriteString(indented)
-		} else {
-			fmt.Fprintln(&sb, "        {}")
+		values = indentedMS
+		hooks = []templates.PostSyncBlock{
+			{URL: hURL, Path: hook1Path, Ref: sref, KustomizePartial: indent(hook1Kz, "  ")},
+			{URL: hURL, Path: hook2Path, Ref: sref, KustomizePartial: indent(hook2Kz, "  ")},
 		}
 	}
-	sb.WriteString(syncPolicyTail())
-	return sb.String()
+
+	data := templates.ArgoApplicationData{
+		Cfg:        cfg,
+		Name:       name,
+		DestNS:     ns,
+		RepoURL:    ociURL,
+		Path:       `"."`,
+		Ref:        target,
+		SyncWave:   syncWave,
+		ValuesYAML: values,
+		PostSyncs:  hooks,
+	}
+	body, err := f.Render("addons/"+addonDir+"/application.yaml.tmpl", data)
+	if err != nil {
+		return "", err
+	}
+	return "---\n" + body, nil
+}
+
+// Kyverno renders the Kyverno workload Argo CD Application YAML.
+// Kyverno-specific body shape (extra annotation, valuesObject layout,
+// replicas, ignoreDifferences) lives in addons/kyverno/application.yaml.tmpl.
+// The KyvernoTolerateControlPlane string field is read template-side
+// via the isTrue FuncMap; callers must register isTrue on f before
+// the first Kyverno call (helmvalues.RegisterIsTrue).
+func Kyverno(f *manifests.Fetcher, cfg *config.Config, addonDir, name, ns, repoURL, chart, version, syncWave, hookShort string) (string, error) {
+	target := version
+	if target == "" {
+		target = "*"
+	}
+	hook, err := derivePostSync(f, cfg, hookShort)
+	if err != nil {
+		return "", err
+	}
+	var hooks []templates.PostSyncBlock
+	if hook.URL != "" {
+		hooks = []templates.PostSyncBlock{hook}
+	}
+	data := templates.ArgoApplicationData{
+		Cfg:       cfg,
+		Name:      name,
+		DestNS:    ns,
+		RepoURL:   repoURL,
+		Chart:     chart,
+		Ref:       target,
+		SyncWave:  syncWave,
+		PostSyncs: hooks,
+	}
+	body, err := f.Render("addons/"+addonDir+"/application.yaml.tmpl", data)
+	if err != nil {
+		return "", err
+	}
+	return "---\n" + body, nil
 }
 
 // KustomizeGit renders an Argo CD Application that pulls a kustomize
 // tree from a Git source. kustomizeBlock is expected pre-indented for
-// a `source:` child (4-space indent) — the multi-source branch
-// re-indents it by 2.
-func KustomizeGit(cfg *config.Config, name, destNS, repoURL, relPath, ref, syncWave, kustomizeBlock, hookShort string) string {
-	safeRef := shellQuoteEscape(ref)
-	hook := derivePostSync(cfg, hookShort)
-	var sb strings.Builder
-	sb.WriteString(headerAnnot(name, cfg.ArgoCD.WorkloadNamespace, syncWave, ""))
-	fmt.Fprintf(&sb, "spec:\n  project: default\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: %s\n", destNS)
+// a `source:` child (4-space indent); the multi-source branch
+// re-indents it by 2 here before passing it to the template via
+// ArgoApplicationData.ValuesYAML.
+func KustomizeGit(f *manifests.Fetcher, cfg *config.Config, addonDir, name, destNS, repoURL, relPath, ref, syncWave, kustomizeBlock, hookShort string) (string, error) {
+	hook, err := derivePostSync(f, cfg, hookShort)
+	if err != nil {
+		return "", err
+	}
+	var hooks []templates.PostSyncBlock
+	primaryKz := kustomizeBlock
 	if hook.URL != "" {
-		sb.WriteString("  sources:\n")
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "      path: %s\n", relPath)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", safeRef)
-		sb.WriteString(indent(kustomizeBlock, "  "))
-		fmt.Fprintf(&sb, "    - repoURL: %s\n", hook.URL)
-		fmt.Fprintf(&sb, "      path: %s\n", hook.Path)
-		fmt.Fprintf(&sb, "      targetRevision: '%s'\n", hook.Ref)
-		sb.WriteString(indent(hook.Kz, "  "))
-	} else {
-		sb.WriteString("  source:\n")
-		fmt.Fprintf(&sb, "    repoURL: %s\n", repoURL)
-		fmt.Fprintf(&sb, "    path: %s\n", relPath)
-		fmt.Fprintf(&sb, "    targetRevision: '%s'\n", safeRef)
-		sb.WriteString(kustomizeBlock)
+		primaryKz = indent(kustomizeBlock, "  ")
+		hooks = []templates.PostSyncBlock{hook}
 	}
-	sb.WriteString(syncPolicyTail())
-	return sb.String()
-}
-
-// --- helpers ---
-
-// headerAnnot emits the Application header, optionally with an extra
-// annotation line (whole line including the key).
-func headerAnnot(name, ns, wave, extraAnnot string) string {
-	var sb strings.Builder
-	sb.WriteString("---\n")
-	sb.WriteString("apiVersion: argoproj.io/v1alpha1\n")
-	sb.WriteString("kind: Application\n")
-	sb.WriteString("metadata:\n")
-	fmt.Fprintf(&sb, "  name: %s\n", name)
-	fmt.Fprintf(&sb, "  namespace: %s\n", ns)
-	sb.WriteString("  annotations:\n")
-	fmt.Fprintf(&sb, "    argocd.argoproj.io/sync-wave: %q\n", wave)
-	if extraAnnot != "" {
-		fmt.Fprintf(&sb, "    %s\n", extraAnnot)
+	data := templates.ArgoApplicationData{
+		Cfg:        cfg,
+		Name:       name,
+		DestNS:     destNS,
+		RepoURL:    repoURL,
+		Path:       relPath,
+		Ref:        shellQuoteEscape(ref),
+		SyncWave:   syncWave,
+		ValuesYAML: primaryKz,
+		PostSyncs:  hooks,
 	}
-	return sb.String()
-}
-
-func syncPolicyTail() string {
-	return `  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
-`
+	body, err := f.Render("addons/"+addonDir+"/application.yaml.tmpl", data)
+	if err != nil {
+		return "", err
+	}
+	return "---\n" + body, nil
 }
 
 // indentValuesBoth returns (8-space-indent, 10-space-indent) copies of
-// valuesYAML or empty strings when valuesYAML is empty. Matches bash
-// indented_values and indented_values_ms.
+// valuesYAML or empty strings when valuesYAML is empty.
 func indentValuesBoth(values string) (string, string) {
 	if values == "" {
 		return "", ""
@@ -375,7 +252,7 @@ func indentValuesBoth(values string) (string, string) {
 	return indent(values, "        "), indent(values, "          ")
 }
 
-// indent prefixes every non-empty line of s with `prefix`, preserving a
+// indent prefixes every non-empty line of s with prefix, preserving a
 // trailing newline.
 func indent(s, prefix string) string {
 	if s == "" {
@@ -397,14 +274,5 @@ func indent(s, prefix string) string {
 }
 
 func shellQuoteEscape(s string) string {
-	// bash: sed "s/'/'\"'\"'/g" — replace ' with '"'"'
 	return strings.ReplaceAll(s, `'`, `'"'"'`)
-}
-
-func isTrue(s string) bool {
-	switch s {
-	case "true", "1", "yes", "y", "on", "TRUE":
-		return true
-	}
-	return false
 }

--- a/internal/capi/wlargocd/render_test.go
+++ b/internal/capi/wlargocd/render_test.go
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package wlargocd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/capi/helmvalues"
+	"github.com/lpasquali/yage/internal/capi/wlargocd"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+)
+
+// fetcher returns a Fetcher pointed at the in-package testdata fixture
+// that mirrors the yage-manifests directory layout.
+func fetcher() *manifests.Fetcher {
+	return &manifests.Fetcher{MountRoot: "testdata"}
+}
+
+// defaultCfg builds a Config with the fields used by wlargocd renderers.
+func defaultCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.WorkloadClusterName = "wl-test"
+	cfg.ArgoCD.WorkloadNamespace = "argocd"
+	return cfg
+}
+
+// TestHelm_SingleSource_NoPostSync verifies the most common shape:
+// HTTP Helm-repo source, no PostSync hook, valuesYAML present.
+func TestHelm_SingleSource_NoPostSync(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.Helm(fetcher(), cfg, "cert-manager",
+		"wl-test-cert-manager", "cert-manager",
+		"https://charts.jetstack.io", "cert-manager", "v1.16.1",
+		"1", "crds:\n  enabled: true\n", "")
+	if err != nil {
+		t.Fatalf("Helm: %v", err)
+	}
+	wants := []string{
+		"---\n",
+		"apiVersion: argoproj.io/v1alpha1",
+		"kind: Application",
+		"  name: wl-test-cert-manager",
+		"  namespace: argocd",
+		`    argocd.argoproj.io/sync-wave: "1"`,
+		"    namespace: cert-manager",
+		"  source:",
+		"    repoURL: https://charts.jetstack.io",
+		"    chart: cert-manager",
+		`    targetRevision: "v1.16.1"`,
+		"    helm:",
+		"      valuesObject:",
+		"        crds:",
+		"          enabled: true",
+		"  syncPolicy:",
+		"    automated:",
+		"      prune: true",
+		"      selfHeal: true",
+		"    syncOptions:",
+		"      - CreateNamespace=true",
+		"      - ServerSideApply=true",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Helm output missing %q\nfull:\n%s", w, got)
+		}
+	}
+	// Must not have multi-source structure when no postsync
+	if strings.Contains(got, "sources:") {
+		t.Errorf("Helm should use 'source:' not 'sources:' when no PostSync\nfull:\n%s", got)
+	}
+}
+
+// TestHelm_NoValues_EmptyDict verifies that empty valuesYAML produces
+// the literal `{}` for valuesObject.
+func TestHelm_NoValues_EmptyDict(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.Helm(fetcher(), cfg, "cert-manager",
+		"wl-test-crossplane", "crossplane",
+		"https://charts.crossplane.io/stable", "crossplane", "1.18.0",
+		"2", "", "")
+	if err != nil {
+		t.Fatalf("Helm: %v", err)
+	}
+	if !strings.Contains(got, "        {}") {
+		t.Errorf("expected literal '        {}' for empty valuesYAML\nfull:\n%s", got)
+	}
+}
+
+// TestHelm_TrimsTrailingSlashOnRepoURL verifies that the trailing slash
+// on the repo URL is trimmed (matches original wlargocd.Helm).
+func TestHelm_TrimsTrailingSlashOnRepoURL(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.Helm(fetcher(), cfg, "cert-manager",
+		"x", "cert-manager",
+		"https://charts.example.org/", "cert-manager", "1.0.0",
+		"1", "", "")
+	if err != nil {
+		t.Fatalf("Helm: %v", err)
+	}
+	if strings.Contains(got, "https://charts.example.org/\n") {
+		t.Errorf("repoURL trailing slash should have been trimmed\nfull:\n%s", got)
+	}
+	if !strings.Contains(got, "repoURL: https://charts.example.org\n") {
+		t.Errorf("repoURL line missing\nfull:\n%s", got)
+	}
+}
+
+// TestHelm_DefaultsVersionToStar verifies that empty version → "*".
+func TestHelm_DefaultsVersionToStar(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.Helm(fetcher(), cfg, "cert-manager",
+		"x", "ns", "https://charts.example.org", "cert-manager", "",
+		"0", "", "")
+	if err != nil {
+		t.Fatalf("Helm: %v", err)
+	}
+	if !strings.Contains(got, `targetRevision: "*"`) {
+		t.Errorf("expected `targetRevision: \"*\"` on empty version\nfull:\n%s", got)
+	}
+}
+
+// TestHelm_MultiSource_WithPostSync exercises the postsync-hooks-on
+// branch: the rendered Application uses `sources:` (plural) with the
+// chart and the kustomize hook side-by-side.
+func TestHelm_MultiSource_WithPostSync(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.ArgoCD.PostsyncHooksEnabled = true
+	cfg.ArgoCD.PostsyncHooksGitURL = "https://github.com/lpasquali/workload-smoketests"
+	cfg.ArgoCD.PostsyncHooksGitRef = "main"
+	cfg.ArgoCD.PostsyncHooksGitPath = ""
+	cfg.WorkloadPostsyncNamespace = "workload-smoke"
+
+	got, err := wlargocd.Helm(fetcher(), cfg, "cert-manager",
+		"wl-test-cert-manager", "cert-manager",
+		"https://charts.jetstack.io", "cert-manager", "v1.16.1",
+		"1", "crds:\n  enabled: true\n", "cert-manager")
+	if err != nil {
+		t.Fatalf("Helm: %v", err)
+	}
+	wants := []string{
+		"  sources:",
+		"    - repoURL: https://charts.jetstack.io",
+		"      chart: cert-manager",
+		`      targetRevision: "v1.16.1"`,
+		"      helm:",
+		"        valuesObject:",
+		// values are 10-space indented in the multi-source case
+		"          crds:",
+		"            enabled: true",
+		"    - repoURL: https://github.com/lpasquali/workload-smoketests",
+		"      path: argo-postsync-hooks/cert-manager",
+		"      targetRevision: 'main'",
+		// kustomize partial is pre-indented by 2 inside `sources:`
+		"      kustomize:",
+		"        namespace: workload-smoke",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Helm multi-source output missing %q\nfull:\n%s", w, got)
+		}
+	}
+	if strings.Contains(got, "  source:\n    repoURL") {
+		t.Errorf("Helm multi-source should not contain singular `source:` block\nfull:\n%s", got)
+	}
+}
+
+// fetcherKyverno returns a Fetcher with isTrue registered (Kyverno
+// template uses isTrue on KyvernoTolerateControlPlane).
+func fetcherKyverno() *manifests.Fetcher {
+	f := fetcher()
+	helmvalues.RegisterIsTrue(f)
+	return f
+}
+
+// TestHelmGit_SingleSource_NoPostSync exercises metrics-server-style
+// HelmGit shape: chart pulled from a Git source.
+func TestHelmGit_SingleSource_NoPostSync(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.HelmGit(fetcher(), cfg, "metrics-server",
+		"wl-test-metrics-server", "kube-system",
+		"https://github.com/kubernetes-sigs/metrics-server",
+		"charts/metrics-server", "metrics-server-helm-chart-3.12.2",
+		"-3", "args:\n  - --kubelet-insecure-tls\n",
+		"metrics-server", "")
+	if err != nil {
+		t.Fatalf("HelmGit: %v", err)
+	}
+	wants := []string{
+		"---\n",
+		"  name: wl-test-metrics-server",
+		"    namespace: kube-system",
+		"  source:",
+		"    repoURL: https://github.com/kubernetes-sigs/metrics-server",
+		"    path: charts/metrics-server",
+		"    targetRevision: 'metrics-server-helm-chart-3.12.2'",
+		"    helm:",
+		"      releaseName: metrics-server",
+		"      valuesObject:",
+		"        args:",
+		"          - --kubelet-insecure-tls",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("HelmGit output missing %q\nfull:\n%s", w, got)
+		}
+	}
+}
+
+// TestHelmOCI_SingleSource_NoPostSync exercises proxmox-csi-style OCI
+// chart pull, no PostSync.
+func TestHelmOCI_SingleSource_NoPostSync(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.HelmOCI(fetcher(), cfg, "proxmox-csi",
+		"wl-test-proxmox-csi", "csi-proxmox",
+		"oci://ghcr.io/sergelogvinov/charts/proxmox-csi-plugin", "0.10.5",
+		"-2", "config:\n  features:\n    provider: capmox\n",
+		"", "", "", "")
+	if err != nil {
+		t.Fatalf("HelmOCI: %v", err)
+	}
+	wants := []string{
+		"  source:",
+		"    repoURL: oci://ghcr.io/sergelogvinov/charts/proxmox-csi-plugin",
+		`    path: "."`,
+		`    targetRevision: "0.10.5"`,
+		"    helm:",
+		"      valuesObject:",
+		"        config:",
+		"          features:",
+		"            provider: capmox",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("HelmOCI output missing %q\nfull:\n%s", w, got)
+		}
+	}
+}
+
+// TestHelmOCI_TwoHooks exercises the proxmox-csi smoke-test variant:
+// two PostSync hooks attached together when both kustomize blocks +
+// both paths are non-empty.
+func TestHelmOCI_TwoHooks(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.ArgoCD.PostsyncHooksEnabled = true
+	cfg.ArgoCD.PostsyncHooksGitURL = "https://github.com/lpasquali/workload-smoketests"
+	cfg.ArgoCD.PostsyncHooksGitRef = "main"
+	cfg.Providers.Proxmox.CSISmokeEnabled = true
+
+	got, err := wlargocd.HelmOCI(fetcher(), cfg, "proxmox-csi",
+		"wl-test-proxmox-csi", "csi-proxmox",
+		"oci://ghcr.io/example/proxmox-csi", "1.0.0",
+		"-2", "",
+		"argo-postsync-hooks/proxmox-csi-pvc", "    kustomize:\n      hook1: true\n",
+		"argo-postsync-hooks/proxmox-csi-rollout", "    kustomize:\n      hook2: true\n")
+	if err != nil {
+		t.Fatalf("HelmOCI: %v", err)
+	}
+	wants := []string{
+		"  sources:",
+		"      path: argo-postsync-hooks/proxmox-csi-pvc",
+		"      path: argo-postsync-hooks/proxmox-csi-rollout",
+		"      hook1: true",
+		"      hook2: true",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("HelmOCI two-hooks output missing %q\nfull:\n%s", w, got)
+		}
+	}
+}
+
+// TestKustomizeGit_SingleSource exercises keycloak-realm-operator-style
+// KustomizeGit shape: kustomize tree from a Git source.
+func TestKustomizeGit_SingleSource(t *testing.T) {
+	cfg := defaultCfg()
+	got, err := wlargocd.KustomizeGit(fetcher(), cfg, "keycloak-realm-operator",
+		"wl-test-krealm", "keycloak",
+		"https://github.com/example/keycloak-realm-operator",
+		"deploy/", "v0.5.0",
+		"9", "    kustomize: {}\n", "")
+	if err != nil {
+		t.Fatalf("KustomizeGit: %v", err)
+	}
+	wants := []string{
+		"  source:",
+		"    repoURL: https://github.com/example/keycloak-realm-operator",
+		"    path: deploy/",
+		"    targetRevision: 'v0.5.0'",
+		"    kustomize: {}",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("KustomizeGit output missing %q\nfull:\n%s", w, got)
+		}
+	}
+}
+
+// TestKyverno_SingleSource_NoToleration exercises the Kyverno template:
+// extra annotation, structured valuesObject, no toleration block when
+// KyvernoTolerateControlPlane is empty.
+func TestKyverno_SingleSource_NoToleration(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.KyvernoTolerateControlPlane = ""
+	got, err := wlargocd.Kyverno(fetcherKyverno(), cfg, "kyverno",
+		"wl-test-kyverno", "kyverno",
+		"https://kyverno.github.io/kyverno", "kyverno", "3.2.6",
+		"0", "")
+	if err != nil {
+		t.Fatalf("Kyverno: %v", err)
+	}
+	wants := []string{
+		"argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true",
+		"  source:",
+		"    chart: kyverno",
+		"    targetRevision:",
+		"        config:",
+		"          preserve: false",
+		"          webhookLabels:",
+		"        admissionController:",
+		"          replicas: 1",
+		"  ignoreDifferences:",
+		"    - group: admissionregistration.k8s.io",
+		"      kind: MutatingWebhookConfiguration",
+		"      jqPathExpressions:",
+		"        - .webhooks[]?.clientConfig.caBundle",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Kyverno output missing %q\nfull:\n%s", w, got)
+		}
+	}
+	if strings.Contains(got, `"node-role.kubernetes.io/control-plane"`) {
+		t.Errorf("Kyverno without toleration must not emit control-plane key\nfull:\n%s", got)
+	}
+}
+
+// TestKyverno_WithToleration verifies isTrue switches on the global
+// toleration block when KyvernoTolerateControlPlane is "true".
+func TestKyverno_WithToleration(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.KyvernoTolerateControlPlane = "true"
+	got, err := wlargocd.Kyverno(fetcherKyverno(), cfg, "kyverno",
+		"wl-test-kyverno", "kyverno",
+		"https://kyverno.github.io/kyverno", "kyverno", "3.2.6",
+		"0", "")
+	if err != nil {
+		t.Fatalf("Kyverno: %v", err)
+	}
+	wants := []string{
+		"        global:",
+		"          tolerations:",
+		`            - key: "node-role.kubernetes.io/control-plane"`,
+		`            - key: "node-role.kubernetes.io/master"`,
+		"              effect: NoSchedule",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("Kyverno toleration output missing %q\nfull:\n%s", w, got)
+		}
+	}
+}

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/backstage/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/backstage/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/backstage/application.yaml.tmpl
+Helm-repo Argo CD Application for backstage.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/cert-manager/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/cert-manager/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/cert-manager/application.yaml.tmpl
+Helm-repo Argo CD Application for cert-manager.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/cloudnativepg/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/cloudnativepg/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/cloudnativepg/application.yaml.tmpl
+Helm-repo Argo CD Application for cloudnativepg.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/crossplane/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/crossplane/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/crossplane/application.yaml.tmpl
+Helm-repo Argo CD Application for crossplane.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/external-secrets/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/external-secrets/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/external-secrets/application.yaml.tmpl
+Helm-repo Argo CD Application for external-secrets.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/infisical/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/infisical/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/infisical/application.yaml.tmpl
+Helm-repo Argo CD Application for infisical.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/keycloak-realm-operator/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/keycloak-realm-operator/application.yaml.tmpl
@@ -1,0 +1,44 @@
+{{- /*
+yage-manifests/addons/keycloak-realm-operator/application.yaml.tmpl
+KustomizeGit-shape Argo CD Application: kustomize tree from a Git source.
+.ValuesYAML carries the pre-indented kustomize block (depth 4 single,
+depth 6 multi-source — Go-side picks the correct depth).
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      path: {{ .Path }}
+      targetRevision: '{{ .Ref }}'
+{{ .ValuesYAML -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    path: {{ .Path }}
+    targetRevision: '{{ .Ref }}'
+{{ .ValuesYAML -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/keycloak/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/keycloak/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/keycloak/application.yaml.tmpl
+Helm-repo Argo CD Application for keycloak.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/kyverno/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/kyverno/application.yaml.tmpl
@@ -1,0 +1,103 @@
+{{- /*
+yage-manifests/addons/kyverno/application.yaml.tmpl
+Kyverno Argo CD Application — a Helm-shape source plus Kyverno-specific
+extras: the `compare-options: ServerSideDiff=true,IncludeMutationWebhook=true`
+annotation, the structured valuesObject (config + tolerations +
+4 controller replicas), and the ignoreDifferences for caBundle drift.
+The KyvernoTolerateControlPlane string is read via the isTrue FuncMap;
+the caller (orchestrator) registers isTrue on the Fetcher.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+          config:
+            preserve: false
+            webhookLabels:
+              app.kubernetes.io/managed-by: argocd
+{{- if isTrue .Cfg.KyvernoTolerateControlPlane }}
+          global:
+            tolerations:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: Exists
+                effect: NoSchedule
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+                effect: NoSchedule
+{{- end }}
+          admissionController:
+            replicas: 1
+          backgroundController:
+            replicas: 1
+          cleanupController:
+            replicas: 1
+          reportsController:
+            replicas: 1
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+        config:
+          preserve: false
+          webhookLabels:
+            app.kubernetes.io/managed-by: argocd
+{{- if isTrue .Cfg.KyvernoTolerateControlPlane }}
+        global:
+          tolerations:
+            - key: "node-role.kubernetes.io/control-plane"
+              operator: Exists
+              effect: NoSchedule
+            - key: "node-role.kubernetes.io/master"
+              operator: Exists
+              effect: NoSchedule
+{{- end }}
+        admissionController:
+          replicas: 1
+        backgroundController:
+          replicas: 1
+        cleanupController:
+          replicas: 1
+        reportsController:
+          replicas: 1
+{{- end }}
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/metrics-server/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/metrics-server/application.yaml.tmpl
@@ -1,0 +1,62 @@
+{{- /*
+yage-manifests/addons/metrics-server/application.yaml.tmpl
+HelmGit-shape Argo CD Application: chart pulled from a Git source.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+Ref is shell-quote-escaped Go-side and emitted single-quoted.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      path: {{ .Path }}
+      targetRevision: '{{ .Ref }}'
+      helm:
+{{- if .ReleaseName }}
+        releaseName: {{ .ReleaseName }}
+{{- end }}
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    path: {{ .Path }}
+    targetRevision: '{{ .Ref }}'
+    helm:
+{{- if .ReleaseName }}
+      releaseName: {{ .ReleaseName }}
+{{- end }}
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/observability/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/observability/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/observability/application.yaml.tmpl
+Helm-repo Argo CD Application for observability.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/opentelemetry/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/opentelemetry/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/opentelemetry/application.yaml.tmpl
+Helm-repo Argo CD Application for opentelemetry.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/proxmox-csi/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/proxmox-csi/application.yaml.tmpl
@@ -1,0 +1,57 @@
+{{- /*
+yage-manifests/addons/proxmox-csi/application.yaml.tmpl
+HelmOCI-shape Argo CD Application: chart from an OCI Helm registry.
+PostSyncs slice carries 0, 1, or 2 hooks (the proxmox-csi smoke variant
+uses 2 hooks together: pvc + rollout). The chart is encoded in the OCI
+URL; the template emits `path: "."`.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      path: {{ .Path }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    path: {{ .Path }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{ else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/addons/spire/application.yaml.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/addons/spire/application.yaml.tmpl
@@ -1,0 +1,55 @@
+{{- /*
+yage-manifests/addons/spire/application.yaml.tmpl
+Helm-repo Argo CD Application for spire.
+ValuesYAML and PostSyncs[].KustomizePartial are pre-indented Go-side.
+*/ -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Cfg.ArgoCD.WorkloadNamespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ printf "%q" .SyncWave }}
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .DestNS }}
+{{- if .PostSyncs }}
+  sources:
+    - repoURL: {{ .RepoURL }}
+      chart: {{ .Chart }}
+      targetRevision: {{ printf "%q" .Ref }}
+      helm:
+        valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+          {}
+{{ end -}}
+{{- range $h := .PostSyncs }}
+    - repoURL: {{ $h.URL }}
+      path: {{ $h.Path }}
+      targetRevision: '{{ $h.Ref }}'
+{{ $h.KustomizePartial -}}
+{{- end }}
+{{- else }}
+  source:
+    repoURL: {{ .RepoURL }}
+    chart: {{ .Chart }}
+    targetRevision: {{ printf "%q" .Ref }}
+    helm:
+      valuesObject:
+{{- if .ValuesYAML }}
+{{ .ValuesYAML -}}
+{{- else }}
+        {}
+{{ end -}}
+{{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/internal/capi/wlargocd/testdata/yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
@@ -1,0 +1,13 @@
+# yage-manifests/postsync/_partials/job-image-override.kustomize.tmpl
+    kustomize:
+      namespace: {{ .Namespace }}
+      patches:
+        - target:
+            group: batch
+            version: v1
+            kind: Job
+            name: {{ .JobName }}
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: '{{ .KubectlImage }}'

--- a/internal/capi/wlargocd/testdata/yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
+++ b/internal/capi/wlargocd/testdata/yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
@@ -1,0 +1,19 @@
+# yage-manifests/postsync/_partials/proxmox-csi-smoke.kustomize.tmpl
+    kustomize:
+      namespace: {{ .Namespace }}
+      patches:
+        - target:
+            group: batch
+            version: v1
+            kind: Job
+            name: {{ .JobName }}
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/image
+              value: '{{ .KubectlImage }}'
+            - op: replace
+              path: /spec/template/spec/containers/0/env/0/value
+              value: "{{ .Namespace }}"
+            - op: replace
+              path: /spec/template/spec/containers/0/env/1/value
+              value: "{{ index .Extra "storageClass" }}"

--- a/internal/orchestrator/workloadapps.go
+++ b/internal/orchestrator/workloadapps.go
@@ -13,16 +13,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/capi/helmvalues"
-	"github.com/lpasquali/yage/internal/platform/manifests"
-	"github.com/lpasquali/yage/internal/csi/proxmoxcsi"
-	"github.com/lpasquali/yage/internal/cost"
-	"github.com/lpasquali/yage/internal/platform/k8sclient"
-	"github.com/lpasquali/yage/internal/ui/logx"
 	"github.com/lpasquali/yage/internal/capi/postsync"
-	"github.com/lpasquali/yage/internal/provider/proxmox/api"
 	"github.com/lpasquali/yage/internal/capi/wlargocd"
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/cost"
+	"github.com/lpasquali/yage/internal/csi/proxmoxcsi"
+	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/platform/manifests"
+	"github.com/lpasquali/yage/internal/provider/proxmox/api"
+	"github.com/lpasquali/yage/internal/ui/logx"
 )
 
 // argoAppGVR is reused by waiters and renderers when reaching for the
@@ -59,18 +59,26 @@ func ApplyWorkloadArgoCDApplications(cfg *config.Config, f *manifests.Fetcher) {
 
 	var sb strings.Builder
 
+	mustWrite := func(out string, err error) {
+		if err != nil {
+			logx.Die("workload Argo Application render: %v", err)
+		}
+		sb.WriteString(out)
+	}
+	mustValues := func(label string, fn func() (string, error)) string {
+		v, err := fn()
+		if err != nil {
+			logx.Die("%s values: %v", label, err)
+		}
+		return v
+	}
+
 	if cfg.EnableWorkloadMetricsServer {
-		sb.WriteString(wlargocd.HelmGit(cfg,
+		mustWrite(wlargocd.HelmGit(f, cfg, "metrics-server",
 			cfg.WorkloadClusterName+"-metrics-server", "kube-system",
 			"https://github.com/kubernetes-sigs/metrics-server",
 			"charts/metrics-server", cfg.MetricsServerGitChartTag,
-			"-3", func() string {
-				v, err := helmvalues.MetricsServerValues(f, cfg)
-				if err != nil {
-					logx.Die("metrics-server values: %v", err)
-				}
-				return v
-			}(),
+			"-3", mustValues("metrics-server", func() (string, error) { return helmvalues.MetricsServerValues(f, cfg) }),
 			"metrics-server", "metrics-server",
 		))
 	}
@@ -121,25 +129,25 @@ storageClass:
 				logx.Die("postsync: proxmox-csi-rollout kustomize block: %v", kErr)
 			}
 		}
-		sb.WriteString(wlargocd.HelmOCI(cfg,
+		mustWrite(wlargocd.HelmOCI(f, cfg, "proxmox-csi",
 			cfg.WorkloadClusterName+"-proxmox-csi", cfg.Providers.Proxmox.CSINamespace,
 			oci, cfg.Providers.Proxmox.CSIChartVersion, "-2", csiValues,
 			h1P, h1K, h2P, h2K))
 	}
 
 	if cfg.KyvernoEnabled {
-		sb.WriteString(wlargocd.Kyverno(cfg,
+		mustWrite(wlargocd.Kyverno(f, cfg, "kyverno",
 			cfg.WorkloadClusterName+"-kyverno", cfg.KyvernoNamespace,
 			cfg.KyvernoChartRepoURL, "kyverno", cfg.KyvernoChartVersion, "0", "kyverno"))
 	}
 	if cfg.CertManagerEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "cert-manager",
 			cfg.WorkloadClusterName+"-cert-manager", cfg.CertManagerNamespace,
 			cfg.CertManagerChartRepoURL, "cert-manager", cfg.CertManagerChartVersion,
 			"1", "crds:\n  enabled: true\n", "cert-manager"))
 	}
 	if cfg.CrossplaneEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "crossplane",
 			cfg.WorkloadClusterName+"-crossplane", cfg.CrossplaneNamespace,
 			cfg.CrossplaneChartRepoURL, "crossplane", cfg.CrossplaneChartVersion,
 			"2", "", "crossplane"))
@@ -148,103 +156,73 @@ storageClass:
 		if cnpgSuppressedByManagedPG(cfg) {
 			logx.Log("cnpg skipped: managed Postgres on %s selected (--no-managed-postgres to keep in-cluster cnpg).", cfg.InfraProvider)
 		} else {
-			sb.WriteString(wlargocd.Helm(cfg,
+			mustWrite(wlargocd.Helm(f, cfg, "cloudnativepg",
 				cfg.WorkloadClusterName+"-cnpg", cfg.CNPGNamespace,
 				cfg.CNPGChartRepoURL, cfg.CNPGChartName, cfg.CNPGChartVersion,
 				"2", "", "cnpg"))
 		}
 	}
 	if cfg.ExternalSecretsEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "external-secrets",
 			cfg.WorkloadClusterName+"-external-secrets", cfg.ExternalSecretsNamespace,
 			cfg.ExternalSecretsChartRepoURL, "external-secrets", cfg.ExternalSecretsChartVersion,
 			"3", "", "external-secrets"))
 	}
 	if cfg.InfisicalOperatorEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "infisical",
 			cfg.WorkloadClusterName+"-infisical-secrets-operator", cfg.InfisicalNamespace,
 			cfg.InfisicalChartRepoURL, cfg.InfisicalChartName, cfg.InfisicalChartVersion,
 			"4", "", "infisical"))
 	}
 	if cfg.SPIREEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "spire",
 			cfg.WorkloadClusterName+"-spire-crds", cfg.SPIRENamespace,
 			cfg.SPIREChartRepoURL, cfg.SPIRECRDsChartName, cfg.SPIRECRDsChartVersion,
 			"-3", "", ""))
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "spire",
 			cfg.WorkloadClusterName+"-spire", cfg.SPIRENamespace,
 			cfg.SPIREChartRepoURL, cfg.SPIREChartName, cfg.SPIREChartVersion,
-			"5", func() string {
-				v, err := helmvalues.SPIREValues(f, cfg)
-				if err != nil {
-					logx.Die("spire values: %v", err)
-				}
-				return v
-			}(), "spire"))
+			"5", mustValues("spire", func() (string, error) { return helmvalues.SPIREValues(f, cfg) }), "spire"))
 	}
 	if cfg.VictoriaMetricsEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "observability",
 			cfg.WorkloadClusterName+"-victoria-metrics-single", cfg.VictoriaMetricsNamespace,
 			cfg.VictoriaMetricsChartRepoURL, cfg.VictoriaMetricsChartName, cfg.VictoriaMetricsChartVersion,
-			"6", func() string {
-				v, err := helmvalues.VictoriaMetricsValues(f, cfg)
-				if err != nil {
-					logx.Die("victoria-metrics values: %v", err)
-				}
-				return v
-			}(), "victoria-metrics"))
+			"6", mustValues("victoria-metrics", func() (string, error) { return helmvalues.VictoriaMetricsValues(f, cfg) }), "victoria-metrics"))
 	}
 	if cfg.OTELEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "opentelemetry",
 			cfg.WorkloadClusterName+"-opentelemetry-collector", cfg.OTELNamespace,
 			cfg.OTELChartRepoURL, cfg.OTELChartName, cfg.OTELChartVersion,
-			"6", func() string {
-				v, err := helmvalues.OpenTelemetryValues(f, cfg)
-				if err != nil {
-					logx.Die("opentelemetry values: %v", err)
-				}
-				return v
-			}(), "opentelemetry"))
+			"6", mustValues("opentelemetry", func() (string, error) { return helmvalues.OpenTelemetryValues(f, cfg) }), "opentelemetry"))
 	}
 	if cfg.GrafanaEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "observability",
 			cfg.WorkloadClusterName+"-grafana", cfg.GrafanaNamespace,
 			cfg.GrafanaChartRepoURL, "grafana", cfg.GrafanaChartVersion,
-			"6", func() string {
-				v, err := helmvalues.GrafanaValues(f, cfg)
-				if err != nil {
-					logx.Die("grafana values: %v", err)
-				}
-				return v
-			}(), "grafana"))
+			"6", mustValues("grafana", func() (string, error) { return helmvalues.GrafanaValues(f, cfg) }), "grafana"))
 	}
 	if cfg.BackstageEnabled {
 		if cfg.BackstageChartRepoURL == "" {
 			logx.Warn("BACKSTAGE_ENABLED but BACKSTAGE_CHART_REPO_URL is empty — set a Helm repo and chart name, or set BACKSTAGE_ENABLED=false. Skipping Backstage.")
 		} else {
-			sb.WriteString(wlargocd.Helm(cfg,
+			mustWrite(wlargocd.Helm(f, cfg, "backstage",
 				cfg.WorkloadClusterName+"-backstage", cfg.BackstageNamespace,
 				cfg.BackstageChartRepoURL, cfg.BackstageChartName, cfg.BackstageChartVersion,
 				"7", "", "backstage"))
 		}
 	}
 	if cfg.KeycloakEnabled {
-		sb.WriteString(wlargocd.Helm(cfg,
+		mustWrite(wlargocd.Helm(f, cfg, "keycloak",
 			cfg.WorkloadClusterName+"-keycloak", cfg.KeycloakNamespace,
 			cfg.KeycloakChartRepoURL, cfg.KeycloakChartName, cfg.KeycloakChartVersion,
-			"8", func() string {
-				v, err := helmvalues.KeycloakValues(f, cfg)
-				if err != nil {
-					logx.Die("keycloak values: %v", err)
-				}
-				return v
-			}(), "keycloak"))
+			"8", mustValues("keycloak", func() (string, error) { return helmvalues.KeycloakValues(f, cfg) }), "keycloak"))
 	}
 	if cfg.KeycloakOperatorEnabled && cfg.KeycloakEnabled {
 		if cfg.KeycloakOperatorGitURL == "" {
 			logx.Warn("KEYCLOAK_OPERATOR_ENABLED but KEYCLOAK_OPERATOR_GIT_URL is empty — skipping Keycloak operator Application.")
 		} else {
-			sb.WriteString(wlargocd.KustomizeGit(cfg,
+			mustWrite(wlargocd.KustomizeGit(f, cfg, "keycloak-realm-operator",
 				cfg.WorkloadClusterName+"-keycloak-realm-operator", cfg.KeycloakOperatorNS,
 				cfg.KeycloakOperatorGitURL, cfg.KeycloakOperatorGitPath, cfg.KeycloakOperatorGitRef,
 				"9", "    kustomize: {}\n", ""))


### PR DESCRIPTION
## Summary

Migrates `internal/capi/wlargocd/render.go` (409 LOC of inline `fmt.Fprintf` /
`strings.Builder` Argo CD Application renderers) to template-driven rendering
through `internal/platform/manifests.Fetcher` against per-addon
`addons/<addon>/application.yaml.tmpl` files in yage-manifests
(ADR 0008, ADR 0012).

Closes #138
Epic: #133

## DoD Level

- [x] **Level 1 — Full Validation**

## Level 1 Checklist

- [x] `make build` passes (verified via `go build ./...`)
- [x] `go test ./...` passes (full suite green)
- [x] `govulncheck ./...` — N/A (no `go.mod` changes)
- [x] Manually walked affected flow **or** change fully covered by existing tests — covered by 11 new tests in `internal/capi/wlargocd/render_test.go` (`TestHelm_*`, `TestHelmGit_*`, `TestHelmOCI_*`, `TestKustomizeGit_*`, `TestKyverno_*`)
- [x] Breaking-change audit: `wlargocd.{HelmGit,Helm,HelmOCI,Kyverno,KustomizeGit}` signatures changed — see Breaking Changes below

## What changed

- **`internal/capi/wlargocd/render.go`** rewritten: 5 public renderers
  (`HelmGit`, `Helm`, `HelmOCI`, `Kyverno`, `KustomizeGit`) now accept a
  `*manifests.Fetcher` + `addonDir string`, return `(string, error)`, and
  delegate the YAML body to `f.Render("addons/<addonDir>/application.yaml.tmpl", data)`.
  Go-side helpers retained per ADR 0012 §wlargocd: `indent`, `indentValuesBoth`,
  `shellQuoteEscape`, and a new `derivePostSync` that returns the wrapper-struct
  `templates.PostSyncBlock` directly (calls `postsync.KustomizeBlockForJobTemplate`
  for the partial).

- **`internal/capi/templates/templates.go`** — `ArgoApplicationData.PostSync PostSyncBlock`
  → `PostSyncs []PostSyncBlock`. The HelmOCI proxmox-csi smoke variant attaches
  two PostSync hooks together (pvc + rollout); single-hook flows use one entry;
  no-hook is nil/empty. Precedent: PR #178 added `Bools` to `HelmValuesData` in
  the same migration PR. Companion testdata fixture and `argo_application_data_test.go`
  updated to range over the slice.

- **`internal/orchestrator/workloadapps.go`** — every `wlargocd.*` call site
  updated to pass `f`, the addon-dir name, and consume `(string, error)` via
  two new local helpers (`mustWrite`, `mustValues`) that funnel errors to
  `logx.Die` consistent with the existing `helmvalues.*` callers.

- **Companion yage-manifests PR (lpasquali/yage-manifests#10)** ships 14
  `addons/<addon>/application.yaml.tmpl` files: metrics-server (HelmGit),
  cert-manager / crossplane / cloudnativepg / external-secrets / infisical /
  observability (vm + grafana share dir) / opentelemetry / backstage /
  keycloak / spire (crds + spire share dir) (Helm), kyverno (Helm + extras),
  proxmox-csi (HelmOCI ± 2 PostSync hooks), keycloak-realm-operator
  (KustomizeGit). Per-addon `testdata/yage-manifests/addons/*/application.yaml.tmpl`
  copies under `internal/capi/wlargocd/testdata/` for hermetic tests.

## ADR compliance

- ADR 0008 §1: per-addon directory layout (one application.yaml.tmpl per addon).
- ADR 0008 §wlargocd note: `shellQuoteEscape`, `indent`, `indentValuesBoth`,
  `headerAnnot` (now inlined into templates), `syncPolicyTail` (now inlined into
  templates) — Go helpers prepare data; templates handle YAML shape.
- ADR 0012 §3: wrapper-struct contract; `PostSyncs []PostSyncBlock` extension
  permitted under "migration agent extends the relevant struct in the same PR".
- ADR 0012 §4 / §4.1: `missingkey=error` enforced by Fetcher; only existing
  `isTrue` FuncMap used (Kyverno template branches on `KyvernoTolerateControlPlane`).

## Acceptance Criteria Evidence

| Criterion | Evidence |
|---|---|
| All renderers in `wlargocd/render.go` delegate to `manifests.Fetcher.Render` | `git log -p` on `render.go` shows 5/5 wrappers call `f.Render(...)`. |
| Tests pass with local `testdata/` fixtures | `go test ./internal/capi/wlargocd/... -v` — 11 PASS. |

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` (go.mod changed) | N/A | go.mod unchanged |
| PE review (Secret schema / CAPI YAML) | N/A | no Secret or CAPI manifest schema changes |
| Supply-chain (workflow change) | N/A | no `.github/workflows/` changes |

## Breaking Changes

`internal/capi/wlargocd/{HelmGit,Helm,HelmOCI,Kyverno,KustomizeGit}` signatures
all changed: each gained `f *manifests.Fetcher` + `addonDir string` as the
first two args, and now return `(string, error)` instead of `string`. The only
caller is `internal/orchestrator/workloadapps.go`, updated in this PR.

`templates.ArgoApplicationData.PostSync PostSyncBlock` removed in favour of
`PostSyncs []PostSyncBlock`. No external callers (struct shipped with #178/#193).

## Notes for Reviewer

- **Production wiring depends on lpasquali/yage-manifests#10 merging into `init`**
  and a yage-manifests release tag bump (mirrors the contract from #193). Until
  the tag bump lands, `Render` works in unit tests (testdata fixtures) but will
  404 at runtime on clusters where `cfg.ManifestsRef` predates yage-manifests#10.
- ADR 0012's wlargocd table did not enumerate `cnpg/cloudnativepg`, `backstage`,
  or `keycloak-realm-operator`; templates added under their addon-name directories.
  Flagged in the companion PR body.
- The `_partials/job-image-override.kustomize.tmpl` file (introduced by #139)
  emits a leading `# yage-manifests/...` comment line; the comment is preserved
  through `indent(kz, "  ")` and ends up as a YAML comment in the rendered
  Application — not a behavior change of this PR, but visible in test output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)