### PR TITLE
chore(config): bump default ManifestsRef from v0.2.0 to v0.4.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1297,7 +1297,7 @@ func Load() *Config {
 	c.TofuRepo = getenv("YAGE_TOFU_REPO", "https://github.com/lpasquali/yage-tofu")
 	c.TofuRef = getenv("YAGE_TOFU_REF", "main")
 	c.ManifestsRepo = getenv("YAGE_MANIFESTS_REPO", "https://github.com/lpasquali/yage-manifests")
-	c.ManifestsRef = getenv("YAGE_MANIFESTS_REF", "v0.2.0")
+	c.ManifestsRef = getenv("YAGE_MANIFESTS_REF", "v0.4.0")
 	c.ReposPVCSize = getenv("YAGE_REPOS_PVC_SIZE", "500Mi")
 
 	// --- On-prem platform services (Phase H, ADR 0009) ---


### PR DESCRIPTION
## Summary

- Bumps default `c.ManifestsRef` from `v0.2.0` → `v0.4.0` in `internal/config/config.go:1300`.
- Resolves the operator-facing runtime gap surfaced in #194: with `v0.2.0`, any non-Proxmox CSI driver hits a Fetcher render error because `csi/<driver>/values.yaml.tmpl` files were not yet present in the manifests repo at that tag.

## Why v0.4.0 (skipping v0.3.0 as default)

- `v0.2.0` — addons templates only.
- `v0.3.0` — added 14 CSI driver `values.yaml.tmpl` (yage-manifests PR #9).
- `v0.4.0` — added 14 wlargocd `application.yaml.tmpl` (yage-manifests PR #10), completing the ADR 0012 migration.

`v0.4.0` is the first tag where every template the renderer needs is present, so it's the right operator default. `v0.3.0` remains tagged for traceability but is not the operator default.

## Definition of Done

- [x] Default updated.
- [x] `go build ./...` clean.
- [x] `go test ./internal/config/...` green.
- [x] Sweep for stale `v0.2.0` / `v0.3.0` references in `internal/` returned empty.

## Acceptance Criteria Evidence

Evidence pending — fully exercises only against a live yage-manifests fetch from a workload bootstrap; configuration default change verified at unit level.

## Audit Checks

- `govulncheck`: no go.mod change, no audit needed.

## Breaking Changes

None — operators with `YAGE_MANIFESTS_REF` set explicitly are unaffected. Operators relying on the default move from `v0.2.0` to `v0.4.0`.

Closes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)