### PR TITLE
feat(pricing): context-scoped pricing.Fetcher (#197)

### DIFF
--- a/internal/cost/compare.go
+++ b/internal/cost/compare.go
@@ -17,6 +17,7 @@
 package cost
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -35,21 +36,23 @@ import (
 // hosted, sunk cost) or when the live API is unreachable.
 //
 // Provider → SKU mapping (cheap tier only):
-//   aws     → "ebs:gp3"  (live Bulk Pricing JSON, region from cfg.Providers.AWS.Region)
-//   azure   → "Standard SSD Managed Disks" (live Retail Prices API,
-//                                            region from cfg.Providers.Azure.Location)
-//   gcp     → "pd:balanced" (live Cloud Billing Catalog,
-//                            region from cfg.Providers.GCP.Region; needs API key)
-//   hetzner → live volume rate from /v1/pricing
-//   anything else → 0, ErrNotApplicable
-func liveBlockStorageUSDPerGBMonth(provName string, cfg *config.Config) (float64, error) {
+//
+//	aws     → "ebs:gp3"  (live Bulk Pricing JSON, region from cfg.Providers.AWS.Region)
+//	azure   → "Standard SSD Managed Disks" (live Retail Prices API,
+//	                                         region from cfg.Providers.Azure.Location)
+//	gcp     → "pd:balanced" (live Cloud Billing Catalog,
+//	                         region from cfg.Providers.GCP.Region; needs API key)
+//	hetzner → live volume rate from /v1/pricing
+//	anything else → 0, ErrNotApplicable
+func liveBlockStorageUSDPerGBMonth(ctx context.Context, provName string, cfg *config.Config) (float64, error) {
+	pf := pricing.FetcherFrom(ctx)
 	switch provName {
 	case "aws":
 		region := cfg.Providers.AWS.Region
 		if region == "" {
 			region = "us-east-1"
 		}
-		it, err := pricing.Fetch("aws", "ebs:gp3", region)
+		it, err := pf.Fetch(ctx, "aws", "ebs:gp3", region)
 		if err != nil {
 			return 0, err
 		}
@@ -65,7 +68,7 @@ func liveBlockStorageUSDPerGBMonth(provName string, cfg *config.Config) (float64
 		if region == "" {
 			region = "us-central1"
 		}
-		it, err := pricing.Fetch("gcp", "pd:balanced", region)
+		it, err := pf.Fetch(ctx, "gcp", "pd:balanced", region)
 		if err != nil {
 			return 0, err
 		}
@@ -80,12 +83,12 @@ func liveBlockStorageUSDPerGBMonth(provName string, cfg *config.Config) (float64
 // provider's cheap-tier block storage. Used by plan.go in the
 // retention section. Live $/GB-month is queried per call and
 // converted into the active taller for display.
-func LiveBlockStorageLabel(provName string, cfg *config.Config) string {
+func LiveBlockStorageLabel(ctx context.Context, provName string, cfg *config.Config) string {
 	tier := blockStorageTierName(provName)
 	if tier == "" {
 		return ""
 	}
-	price, err := liveBlockStorageUSDPerGBMonth(provName, cfg)
+	price, err := liveBlockStorageUSDPerGBMonth(ctx, provName, cfg)
 	if err != nil || price <= 0 {
 		return tier + " (live price unavailable)"
 	}
@@ -114,7 +117,7 @@ func blockStorageTierName(provName string) string {
 // CloudCost is one row in the multi-cloud comparison table.
 type CloudCost struct {
 	ProviderName         string
-	Region               string  // region estimated; empty for on-prem or single-region flows
+	Region               string // region estimated; empty for on-prem or single-region flows
 	Estimate             provider.CostEstimate
 	Err                  error
 	StorageUSDPerGBMonth float64 // 0 when not fetchable
@@ -131,8 +134,8 @@ type CloudCost struct {
 // Skips providers that explicitly disable themselves via
 // ErrNotApplicable in the cost path; surfaces real errors so the
 // user can see missing config or unreachable APIs.
-func CompareClouds(cfg *config.Config, progress io.Writer) []CloudCost {
-	return CompareWithFilter(cfg, ScopeAll, progress)
+func CompareClouds(ctx context.Context, cfg *config.Config, progress io.Writer) []CloudCost {
+	return CompareWithFilter(ctx, cfg, ScopeAll, progress)
 }
 
 // Scope narrows the provider set CompareWithFilter iterates over.
@@ -143,9 +146,9 @@ func CompareClouds(cfg *config.Config, progress io.Writer) []CloudCost {
 type Scope int
 
 const (
-	ScopeAll       Scope = iota // every registered provider (subject to airgap filter)
-	ScopeCloudOnly              // hyperscale + managed-cloud providers only
-	ScopeOnPremOnly             // proxmox / vsphere / openstack / docker (CAPD)
+	ScopeAll        Scope = iota // every registered provider (subject to airgap filter)
+	ScopeCloudOnly               // hyperscale + managed-cloud providers only
+	ScopeOnPremOnly              // proxmox / vsphere / openstack / docker (CAPD)
 )
 
 // StreamWithFilter fans out provider cost fetches in parallel and sends each
@@ -157,7 +160,7 @@ const (
 //
 // Progress is written before any goroutines launch (count header) and after
 // each result arrives (per-provider tick line).
-func StreamWithFilter(cfg *config.Config, scope Scope, progress io.Writer, ch chan<- CloudCost) {
+func StreamWithFilter(ctx context.Context, cfg *config.Config, scope Scope, progress io.Writer, ch chan<- CloudCost) {
 	names := provider.AirgapFilter(provider.Registered(), cfg.Airgapped)
 	names = filterEphemeralTestProviders(names)
 	switch scope {
@@ -199,8 +202,8 @@ func StreamWithFilter(cfg *config.Config, scope Scope, progress io.Writer, ch ch
 			if err != nil {
 				return // skip unknown/unregistered — no send
 			}
-			est, estErr := p.EstimateMonthlyCostUSD(cfg)
-			storagePrice, storageErr := liveBlockStorageUSDPerGBMonth(name, cfg)
+			est, estErr := p.EstimateMonthlyCostUSD(ctx, cfg)
+			storagePrice, storageErr := liveBlockStorageUSDPerGBMonth(ctx, name, cfg)
 			ch <- CloudCost{
 				ProviderName:         name,
 				Estimate:             est,
@@ -251,7 +254,7 @@ func withProviderRegion(cfg *config.Config, provName, region string) config.Conf
 // list) the provider's current region from cfg is used (single estimate).
 // CloudCost.Region is set for every result. Provider / scope filtering is
 // identical to StreamWithFilter.
-func StreamWithRegions(cfg *config.Config, scope Scope, regionsByProvider map[string][]string, progress io.Writer, ch chan<- CloudCost) {
+func StreamWithRegions(ctx context.Context, cfg *config.Config, scope Scope, regionsByProvider map[string][]string, progress io.Writer, ch chan<- CloudCost) {
 	names := provider.AirgapFilter(provider.Registered(), cfg.Airgapped)
 	names = filterEphemeralTestProviders(names)
 	switch scope {
@@ -289,8 +292,8 @@ func StreamWithRegions(cfg *config.Config, scope Scope, regionsByProvider map[st
 				} else {
 					cfgCopy = *cfg
 				}
-				est, estErr := p.EstimateMonthlyCostUSD(&cfgCopy)
-				storagePrice, storageErr := liveBlockStorageUSDPerGBMonth(name, &cfgCopy)
+				est, estErr := p.EstimateMonthlyCostUSD(ctx, &cfgCopy)
+				storagePrice, storageErr := liveBlockStorageUSDPerGBMonth(ctx, name, &cfgCopy)
 				ch <- CloudCost{
 					ProviderName:         name,
 					Region:               region,
@@ -312,9 +315,9 @@ func StreamWithRegions(cfg *config.Config, scope Scope, regionsByProvider map[st
 // provider) is dropped at every scope: it's an ephemeral test path,
 // not a deployment target — pricing it would just confuse the
 // table.
-func CompareWithFilter(cfg *config.Config, scope Scope, progress io.Writer) []CloudCost {
+func CompareWithFilter(ctx context.Context, cfg *config.Config, scope Scope, progress io.Writer) []CloudCost {
 	ch := make(chan CloudCost, 32)
-	StreamWithFilter(cfg, scope, progress, ch)
+	StreamWithFilter(ctx, cfg, scope, progress, ch)
 	var out []CloudCost
 	for r := range ch {
 		out = append(out, r)
@@ -340,8 +343,8 @@ func CompareWithFilter(cfg *config.Config, scope Scope, progress io.Writer) []Cl
 // PrintComparison writes a human-readable comparison table to w.
 // Each row: provider | monthly | live $/GB-mo | retention budget.
 // Footer notes which providers were unpriced or had API failures.
-func PrintComparison(w io.Writer, cfg *config.Config) {
-	rows := CompareClouds(cfg, nil)
+func PrintComparison(ctx context.Context, w io.Writer, cfg *config.Config) {
+	rows := CompareClouds(ctx, cfg, nil)
 	hr := func() {
 		fmt.Fprintln(w, "─────────────────────────────────────────────────────────────────────────────")
 	}
@@ -511,8 +514,8 @@ func retentionDescription(budgetUSD, pricePerGBMonth float64) string {
 // When the cloud's compute estimate exceeds the budget, returns
 // 0 + a "compute alone is over budget" note so the dry-run can
 // warn the user before they think they have storage room.
-func RetentionAtBudget(provName string, cfg *config.Config, budgetUSD, computeUSD float64) (gb float64, note string) {
-	price, err := liveBlockStorageUSDPerGBMonth(provName, cfg)
+func RetentionAtBudget(ctx context.Context, provName string, cfg *config.Config, budgetUSD, computeUSD float64) (gb float64, note string) {
+	price, err := liveBlockStorageUSDPerGBMonth(ctx, provName, cfg)
 	if err != nil || price <= 0 {
 		if err != nil {
 			return 0, "live storage price unavailable: " + err.Error()

--- a/internal/cost/compare_test.go
+++ b/internal/cost/compare_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package cost_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/cost"
+	"github.com/lpasquali/yage/internal/pricing"
+
+	// Side-effect registration: cost.Stream*/Compare* iterates the
+	// provider registry, so the test needs at least one registered
+	// implementation. linode is the smallest cloud provider whose cost
+	// path is fully Fetcher-routed (no bespoke per-vendor helpers in
+	// the priced rows), making it the cleanest fixture for the
+	// context-isolation property.
+	_ "github.com/lpasquali/yage/internal/provider/linode"
+)
+
+// TestStreamWithFilter_PropagatesContextFetcher verifies that two
+// concurrent StreamWithFilter calls carrying different StaticFetchers
+// on their contexts do not see each other's data — the parallel-test
+// safety property gated by issue #197 / ADR 0016 §"Pricing seam".
+//
+// Construction: each goroutine builds a StaticFetcher with a unique
+// hourly rate for the same (vendor, region, sku) triple, drives
+// StreamWithFilter with cost.ScopeCloudOnly, and asserts every priced row's
+// totals were computed from its own rate (never the sibling's).
+//
+// Linode is the single cost.ScopeCloudOnly provider whose EstimateMonthlyCostUSD
+// is mostly Fetcher-routed (no bespoke per-vendor helpers in the hot
+// path), so it is the only row guaranteed to be priced from the stub.
+// Other providers are allowed to error out with ErrNotApplicable when
+// their bespoke helpers (AWSEKSControlPlaneUSDPerMonth, …) hit the
+// real network and fail; what matters is that the priced rows reflect
+// the per-context rate, not a leak from the sibling context.
+func TestStreamWithFilter_PropagatesContextFetcher(t *testing.T) {
+	const (
+		region = "us-east"
+		sku    = "g6-standard-2"
+	)
+
+	cfg := func() *config.Config {
+		c := &config.Config{
+			ControlPlaneMachineCount: "1",
+			WorkerMachineCount:       "0",
+			InfraProvider:            "linode",
+			SkipProviders:            "aws,azure,gcp,hetzner,digitalocean,oci,ibmcloud",
+		}
+		c.Providers.Linode.Region = region
+		c.Providers.Linode.ControlPlaneType = sku
+		c.Providers.Linode.NodeType = sku
+		return c
+	}
+
+	run := func(rate float64) float64 {
+		stub := pricing.StaticFetcher{"linode/" + region + "/" + sku: rate}
+		ctx := pricing.WithFetcher(context.Background(), stub)
+		ch := make(chan cost.CloudCost, 16)
+		cost.StreamWithFilter(ctx, cfg(), cost.ScopeCloudOnly, nil, ch)
+		var got float64
+		for row := range ch {
+			if row.ProviderName != "linode" {
+				continue
+			}
+			if row.Err != nil {
+				t.Errorf("rate=%v linode row err: %v", rate, row.Err)
+				continue
+			}
+			got = row.Estimate.TotalUSDMonthly
+		}
+		return got
+	}
+
+	var wg sync.WaitGroup
+	type result struct {
+		rate, total float64
+	}
+	results := make(chan result, 2)
+
+	for _, rate := range []float64{0.05, 0.99} {
+		rate := rate
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- result{rate: rate, total: run(rate)}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	for r := range results {
+		want := r.rate * pricing.MonthlyHours // 1 cp × hours × rate
+		if r.total != want {
+			t.Errorf("rate=%v: total=%v want %v (cross-context leak?)", r.rate, r.total, want)
+		}
+	}
+}
+
+// TestCompareWithFilter_AcceptsContext is a smoke test confirming the
+// signature accepts a ctx and propagates it. With a StaticFetcher on
+// the context, the linode row is priced from the stub while skipped
+// providers are filtered out.
+func TestCompareWithFilter_AcceptsContext(t *testing.T) {
+	const region = "us-east"
+	const sku = "g6-standard-2"
+	stub := pricing.StaticFetcher{"linode/" + region + "/" + sku: 0.10}
+	ctx := pricing.WithFetcher(context.Background(), stub)
+
+	cfg := &config.Config{
+		ControlPlaneMachineCount: "1",
+		InfraProvider:            "linode",
+		SkipProviders:            "aws,azure,gcp,hetzner,digitalocean,oci,ibmcloud",
+	}
+	cfg.Providers.Linode.Region = region
+	cfg.Providers.Linode.ControlPlaneType = sku
+	cfg.Providers.Linode.NodeType = sku
+
+	rows := cost.CompareWithFilter(ctx, cfg, cost.ScopeCloudOnly, nil)
+	var found bool
+	for _, r := range rows {
+		if r.ProviderName == "linode" && r.Err == nil {
+			found = true
+			want := 0.10 * pricing.MonthlyHours
+			if r.Estimate.TotalUSDMonthly != want {
+				t.Errorf("linode total = %v, want %v", r.Estimate.TotalUSDMonthly, want)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no priced linode row in %d results: %+v", len(rows), rows)
+	}
+}

--- a/internal/operator/cost/runner.go
+++ b/internal/operator/cost/runner.go
@@ -73,7 +73,7 @@ func (r *Runner) Start(ctx context.Context) error {
 func (r *Runner) runOnce(ctx context.Context) {
 	cfg := r.resolveConfig(ctx)
 	r.Log.Info("polling pricing APIs", "interval", r.Interval)
-	results := cost.CompareWithFilter(cfg, cost.ScopeAll, nil)
+	results := cost.CompareWithFilter(ctx, cfg, cost.ScopeAll, nil)
 	ok := 0
 	for _, row := range results {
 		if row.Err != nil {

--- a/internal/orchestrator/plan.go
+++ b/internal/orchestrator/plan.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -25,10 +26,10 @@ import (
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/cost"
 	"github.com/lpasquali/yage/internal/platform/k8sclient"
+	"github.com/lpasquali/yage/internal/platform/shell"
 	"github.com/lpasquali/yage/internal/pricing"
 	"github.com/lpasquali/yage/internal/provider"
 	"github.com/lpasquali/yage/internal/ui/plan"
-	"github.com/lpasquali/yage/internal/platform/shell"
 )
 
 // PrintPlan writes a structured "would do" plan to stdout based on cfg.
@@ -71,9 +72,13 @@ func PrintPlanTo(w io.Writer, cfg *config.Config) {
 	planFinal(w, cfg)
 	planCapacity(w, cfg)
 	planAllocations(w, cfg)
-	planMonthlyCost(w, cfg)
-	planCostCompare(w, cfg)
-	planRetention(w, cfg)
+	// Cost / pricing sections route through pricing.FetcherFrom(ctx)
+	// per ADR 0016 §"Pricing seam". The dry-run uses a background ctx
+	// (no override) so production hits the live catalog as before.
+	ctx := context.Background()
+	planMonthlyCost(ctx, w, cfg)
+	planCostCompare(ctx, w, cfg)
+	planRetention(ctx, w, cfg)
 
 	fmt.Fprintln(w, hr)
 	fmt.Fprintln(w, "✅ Dry run complete — NO state was changed.")
@@ -407,12 +412,12 @@ func planAllocations(w io.Writer, cfg *config.Config) {
 // providers (Proxmox, vSphere, CAPD) and ones with too-variable
 // pricing (OpenStack) return ErrNotApplicable and the section is
 // skipped silently — see docs/aws-cost-tiers.md for the AWS table.
-func planMonthlyCost(w io.Writer, cfg *config.Config) {
+func planMonthlyCost(ctx context.Context, w io.Writer, cfg *config.Config) {
 	p, err := provider.For(cfg)
 	if err != nil {
 		return
 	}
-	est, err := p.EstimateMonthlyCostUSD(cfg)
+	est, err := p.EstimateMonthlyCostUSD(ctx, cfg)
 	if err != nil {
 		if errors.Is(err, provider.ErrNotApplicable) {
 			// Even when the provider opted out, surface the
@@ -449,17 +454,17 @@ func planMonthlyCost(w io.Writer, cfg *config.Config) {
 // rightmost column shows what the same total budget would buy as
 // persistent block storage on each cloud — handy for picking where
 // observability + DB go when storage is the dominant cost driver.
-func planCostCompare(w io.Writer, cfg *config.Config) {
+func planCostCompare(ctx context.Context, w io.Writer, cfg *config.Config) {
 	if !cfg.CostCompare {
 		return
 	}
-	cost.PrintComparison(w, cfg)
+	cost.PrintComparison(ctx, w, cfg)
 }
 
 // planRetention prints how many GB of cheap-tier block storage the
 // user's budget buys AFTER paying for compute on the active provider.
 // No-op when --budget-usd-month is unset.
-func planRetention(w io.Writer, cfg *config.Config) {
+func planRetention(ctx context.Context, w io.Writer, cfg *config.Config) {
 	if cfg.BudgetUSDMonth <= 0 {
 		return
 	}
@@ -467,13 +472,13 @@ func planRetention(w io.Writer, cfg *config.Config) {
 	if err != nil {
 		return
 	}
-	est, err := p.EstimateMonthlyCostUSD(cfg)
+	est, err := p.EstimateMonthlyCostUSD(ctx, cfg)
 	if err != nil {
 		return
 	}
 	budgetStr := pricing.FormatTaller(cfg.BudgetUSDMonth, "USD")
 	section(w, fmt.Sprintf("Storage retention at %s / month budget (%s)", budgetStr, p.Name()))
-	gb, note := cost.RetentionAtBudget(p.Name(), cfg, cfg.BudgetUSDMonth, est.TotalUSDMonthly)
+	gb, note := cost.RetentionAtBudget(ctx, p.Name(), cfg, cfg.BudgetUSDMonth, est.TotalUSDMonthly)
 	if note != "" {
 		bullet(w, "❌ %s", note)
 		bullet(w, "   compute estimate (%s): %s / month", p.Name(), pricing.FormatTaller(est.TotalUSDMonthly, "USD"))
@@ -481,7 +486,7 @@ func planRetention(w io.Writer, cfg *config.Config) {
 		return
 	}
 	leftover := cfg.BudgetUSDMonth - est.TotalUSDMonthly
-	label := cost.LiveBlockStorageLabel(p.Name(), cfg)
+	label := cost.LiveBlockStorageLabel(ctx, p.Name(), cfg)
 	bullet(w, "compute estimate:        %s / month", pricing.FormatTaller(est.TotalUSDMonthly, "USD"))
 	bullet(w, "leftover for storage:    %s / month", pricing.FormatTaller(leftover, "USD"))
 	if gb >= 1024 {

--- a/internal/pricing/fetcher.go
+++ b/internal/pricing/fetcher.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package pricing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Fetcher is the context-scoped pricing seam introduced by ADR 0016
+// §"Pricing seam". It abstracts the package-global catalog lookup so
+// parallel test scenarios can pin a frozen catalog (StaticFetcher)
+// instead of racing on the per-vendor live fetchers registered via
+// Register().
+//
+// Production code receives the package's defaultFetcher (which routes
+// through the existing live fetchers + 24h disk cache). Tests inject
+// a StaticFetcher (or any Fetcher implementation) on the context they
+// pass to cost.Stream*/cost.Compare* and Provider.EstimateMonthlyCostUSD.
+//
+// The interface is intentionally narrow: Fetch covers every existing
+// pricing.Fetch(vendor, sku, region) call site (most provider cost.go
+// paths), and USDPerHour is a convenience for callers that only need
+// the hourly rate. Bespoke per-vendor helpers (AWSEKSControlPlaneUSDPerMonth,
+// AzureManagedDiskUSDPerGBMonth, …) remain package-level functions in
+// this PR; their full migration onto Fetcher is tracked as follow-up
+// per the issue #197 DoD scope.
+type Fetcher interface {
+	// Fetch returns the live (or cache-fresh) Item for (vendor, sku,
+	// region). Mirrors the package-level pricing.Fetch contract:
+	// returns ErrUnavailable wrapped with detail when no fetcher is
+	// registered for the vendor, the API is unreachable, the cache
+	// is stale and refresh failed, or the orchestrator is in
+	// airgapped mode.
+	Fetch(ctx context.Context, vendor, sku, region string) (Item, error)
+
+	// USDPerHour returns the live USD-per-hour rate for (vendor, region,
+	// sku). Convenience wrapper over Fetch for callers that only need
+	// the hourly figure (the harness DSL's primary consumer). Returns
+	// ErrUnavailable on the same conditions as Fetch.
+	USDPerHour(ctx context.Context, vendor, region, sku string) (float64, error)
+}
+
+// StaticFetcher is a deterministic in-memory catalog used by tests.
+// Keys take the form "vendor/region/sku"; values are the USD-per-hour
+// rate for that triple. Fetch synthesises an Item with USDPerHour and
+// USDPerMonth = USDPerHour × MonthlyHours so existing call sites that
+// read it.USDPerMonth keep working unchanged.
+//
+// Lookup is exact: the same (vendor, region, sku) triple a provider's
+// cost path passes must be present in the map, otherwise StaticFetcher
+// returns ErrUnavailable wrapped with the missing key. This is by
+// design — silent fallback would mask test/setup mismatches.
+type StaticFetcher map[string]float64
+
+// USDPerHour returns the rate stored for (vendor, region, sku) or
+// ErrUnavailable if absent.
+func (s StaticFetcher) USDPerHour(_ context.Context, vendor, region, sku string) (float64, error) {
+	if rate, ok := s[staticKey(vendor, region, sku)]; ok {
+		return rate, nil
+	}
+	return 0, fmt.Errorf("%w: StaticFetcher: no entry for %s/%s/%s", ErrUnavailable, vendor, region, sku)
+}
+
+// Fetch returns an Item synthesised from the StaticFetcher's stored
+// hourly rate. USDPerMonth is computed via MonthlyHours so existing
+// call sites that read .USDPerMonth keep working.
+func (s StaticFetcher) Fetch(_ context.Context, vendor, sku, region string) (Item, error) {
+	if rate, ok := s[staticKey(vendor, region, sku)]; ok {
+		return Item{
+			Vendor:      vendor,
+			SKU:         sku,
+			Region:      region,
+			USDPerHour:  rate,
+			USDPerMonth: rate * MonthlyHours,
+		}, nil
+	}
+	return Item{}, fmt.Errorf("%w: StaticFetcher: no entry for %s/%s/%s", ErrUnavailable, vendor, region, sku)
+}
+
+// staticKey is the canonical map key shape for StaticFetcher. Kept
+// private so callers cannot construct keys with a different separator
+// and miss lookups.
+func staticKey(vendor, region, sku string) string {
+	return vendor + "/" + region + "/" + sku
+}
+
+// liveFetcher is the production Fetcher implementation. It delegates
+// to the package-level Fetch function so the existing live fetchers,
+// 24h disk cache, airgap short-circuit, and Register-based routing
+// all keep working unchanged. Stateless; the singleton lives in
+// defaultFetcher.
+type liveFetcher struct{}
+
+// Fetch routes through the existing package-level pricing.Fetch path
+// (per-vendor live fetcher + 24h disk cache). Context is accepted for
+// the interface contract but not yet propagated — the underlying
+// vendor fetchers do not currently take a context. Future work tracked
+// as a separate issue.
+func (liveFetcher) Fetch(_ context.Context, vendor, sku, region string) (Item, error) {
+	return Fetch(vendor, sku, region)
+}
+
+// USDPerHour delegates to Fetch and returns the hourly rate.
+func (l liveFetcher) USDPerHour(ctx context.Context, vendor, region, sku string) (float64, error) {
+	it, err := l.Fetch(ctx, vendor, sku, region)
+	if err != nil {
+		return 0, err
+	}
+	return it.USDPerHour, nil
+}
+
+// defaultFetcher is the singleton returned by FetcherFrom when the
+// context carries no override. Allocated once via sync.Once so repeated
+// FetcherFrom calls on a context without a fetcher are zero-allocation
+// after the first.
+var (
+	defaultFetcherOnce sync.Once
+	defaultFetcherInst Fetcher
+)
+
+// DefaultFetcher returns the production Fetcher singleton (live
+// per-vendor catalog + 24h disk cache). Exported for callers that need
+// to wrap or compose it (e.g. a test harness that wants to fall back to
+// live data when a Static map misses).
+func DefaultFetcher() Fetcher {
+	defaultFetcherOnce.Do(func() {
+		defaultFetcherInst = liveFetcher{}
+	})
+	return defaultFetcherInst
+}
+
+// fetcherCtxKey is the unexported context key under which a Fetcher
+// override is stored. The unexported key prevents accidental
+// cross-package clashes — only WithFetcher can write it.
+type fetcherCtxKey struct{}
+
+// WithFetcher returns a derived context that carries f as the active
+// Fetcher. Callers (typically test harnesses, but also future per-call
+// production overrides) pass the returned context through to
+// cost.Stream*/cost.Compare* / Provider.EstimateMonthlyCostUSD.
+//
+// Passing a nil Fetcher returns the parent context unchanged so callers
+// can `ctx = pricing.WithFetcher(ctx, maybeNil)` without a guard.
+func WithFetcher(ctx context.Context, f Fetcher) context.Context {
+	if f == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, fetcherCtxKey{}, f)
+}
+
+// FetcherFrom returns the Fetcher carried by ctx, or the production
+// DefaultFetcher() singleton when ctx carries no override (or ctx is
+// nil). Hot-path safe: the absent-override branch is one map lookup +
+// type assertion + one sync.Once first-call cost.
+func FetcherFrom(ctx context.Context) Fetcher {
+	if ctx == nil {
+		return DefaultFetcher()
+	}
+	if f, ok := ctx.Value(fetcherCtxKey{}).(Fetcher); ok && f != nil {
+		return f
+	}
+	return DefaultFetcher()
+}

--- a/internal/pricing/fetcher_test.go
+++ b/internal/pricing/fetcher_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package pricing
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestFetcherFrom_DefaultsToLiveFetcherWhenAbsent(t *testing.T) {
+	got := FetcherFrom(context.Background())
+	if got == nil {
+		t.Fatal("FetcherFrom returned nil for empty context")
+	}
+	if _, ok := got.(liveFetcher); !ok {
+		t.Fatalf("FetcherFrom on empty context returned %T, want liveFetcher", got)
+	}
+}
+
+func TestFetcherFrom_NilContextReturnsDefault(t *testing.T) {
+	//nolint:staticcheck // intentionally passing nil to exercise the guard.
+	got := FetcherFrom(nil)
+	if _, ok := got.(liveFetcher); !ok {
+		t.Fatalf("FetcherFrom(nil) returned %T, want liveFetcher", got)
+	}
+}
+
+func TestWithFetcher_RoundTrip(t *testing.T) {
+	stub := StaticFetcher{"aws/us-east-1/t3.medium": 0.0416}
+	ctx := WithFetcher(context.Background(), stub)
+	got := FetcherFrom(ctx)
+	if got == nil {
+		t.Fatal("FetcherFrom returned nil after WithFetcher")
+	}
+	// Verify it routes to the stub by checking USDPerHour.
+	rate, err := got.USDPerHour(ctx, "aws", "us-east-1", "t3.medium")
+	if err != nil {
+		t.Fatalf("USDPerHour: %v", err)
+	}
+	if rate != 0.0416 {
+		t.Fatalf("USDPerHour = %v, want 0.0416", rate)
+	}
+}
+
+func TestWithFetcher_NilFetcherIsNoOp(t *testing.T) {
+	parent := context.Background()
+	got := WithFetcher(parent, nil)
+	if got != parent {
+		t.Fatal("WithFetcher(ctx, nil) should return ctx unchanged")
+	}
+}
+
+func TestStaticFetcher_FetchSynthesizesUSDPerMonth(t *testing.T) {
+	s := StaticFetcher{"linode/us-east/g6-standard-2": 0.03}
+	it, err := s.Fetch(context.Background(), "linode", "g6-standard-2", "us-east")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if it.USDPerHour != 0.03 {
+		t.Errorf("USDPerHour = %v, want 0.03", it.USDPerHour)
+	}
+	wantMonth := 0.03 * MonthlyHours
+	if it.USDPerMonth != wantMonth {
+		t.Errorf("USDPerMonth = %v, want %v", it.USDPerMonth, wantMonth)
+	}
+	if it.Vendor != "linode" || it.SKU != "g6-standard-2" || it.Region != "us-east" {
+		t.Errorf("metadata mismatch: %+v", it)
+	}
+}
+
+func TestStaticFetcher_MissingEntryReturnsErrUnavailable(t *testing.T) {
+	s := StaticFetcher{}
+	_, err := s.Fetch(context.Background(), "aws", "ghost", "nowhere")
+	if err == nil {
+		t.Fatal("Fetch on missing key returned nil error")
+	}
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want wrap of ErrUnavailable", err)
+	}
+	_, err = s.USDPerHour(context.Background(), "aws", "nowhere", "ghost")
+	if err == nil {
+		t.Fatal("USDPerHour on missing key returned nil error")
+	}
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want wrap of ErrUnavailable", err)
+	}
+}
+
+// TestParallelFetcherIsolation verifies that two contexts carrying
+// different StaticFetchers do not see each other's data — the
+// parallel-test safety property called out in issue #197.
+func TestParallelFetcherIsolation(t *testing.T) {
+	t.Parallel()
+	a := StaticFetcher{"aws/us-east-1/t3.medium": 0.05}
+	b := StaticFetcher{"aws/us-east-1/t3.medium": 0.99}
+
+	ctxA := WithFetcher(context.Background(), a)
+	ctxB := WithFetcher(context.Background(), b)
+
+	rateA, err := FetcherFrom(ctxA).USDPerHour(ctxA, "aws", "us-east-1", "t3.medium")
+	if err != nil {
+		t.Fatalf("ctxA: %v", err)
+	}
+	rateB, err := FetcherFrom(ctxB).USDPerHour(ctxB, "aws", "us-east-1", "t3.medium")
+	if err != nil {
+		t.Fatalf("ctxB: %v", err)
+	}
+	if rateA != 0.05 {
+		t.Errorf("ctxA rate = %v, want 0.05", rateA)
+	}
+	if rateB != 0.99 {
+		t.Errorf("ctxB rate = %v, want 0.99", rateB)
+	}
+}
+
+// TestDefaultFetcher_IsSingleton verifies the sync.Once guard
+// returns the same instance on repeated calls (zero-allocation
+// guarantee for the no-override hot path).
+func TestDefaultFetcher_IsSingleton(t *testing.T) {
+	a := DefaultFetcher()
+	b := DefaultFetcher()
+	if a != b {
+		t.Fatalf("DefaultFetcher returned different instances: %p vs %p", a, b)
+	}
+}

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -8,18 +8,19 @@
 // stale fabricated number.
 //
 // Each vendor implementation lives in its own file:
-//   aws.go      — AWS Bulk Pricing JSON. Files are hosted on the
-//                 pricing.us-east-1.amazonaws.com bucket, but the
-//                 path encodes the priced region:
-//                   /offers/v1.0/aws/AmazonEC2/current/<region>/index.json
-//                 e.g. .../eu-west-1/index.json returns Frankfurt
-//                 prices, .../us-east-1/index.json returns N.Virginia
-//                 prices. The host being us-east-1 is just where the
-//                 static JSON lives; it does NOT constrain priced region.
-//   azure.go    — Azure Retail Prices API (unauth, region in $filter)
-//   gcp.go      — GCP Cloud Billing Catalog API (needs API key)
-//   hetzner.go  — Hetzner Cloud API server_types (unauth, region in
-//                 prices[] array per server type)
+//
+//	aws.go      — AWS Bulk Pricing JSON. Files are hosted on the
+//	              pricing.us-east-1.amazonaws.com bucket, but the
+//	              path encodes the priced region:
+//	                /offers/v1.0/aws/AmazonEC2/current/<region>/index.json
+//	              e.g. .../eu-west-1/index.json returns Frankfurt
+//	              prices, .../us-east-1/index.json returns N.Virginia
+//	              prices. The host being us-east-1 is just where the
+//	              static JSON lives; it does NOT constrain priced region.
+//	azure.go    — Azure Retail Prices API (unauth, region in $filter)
+//	gcp.go      — GCP Cloud Billing Catalog API (needs API key)
+//	hetzner.go  — Hetzner Cloud API server_types (unauth, region in
+//	              prices[] array per server type)
 //
 // Pricing tiers (dev / prod / enterprise) describing service-overhead
 // SHAPE (NAT count, LB count, egress GB, log GB) live in each
@@ -65,25 +66,31 @@ const DefaultTTL = 24 * time.Hour
 // taller — that avoids a round-trip through FX and surfaces the
 // vendor's published list price exactly.
 type Item struct {
-	Vendor          string    // "aws", "azure", "gcp", "hetzner"
-	SKU             string    // "t3.medium", "Standard_D2s_v3", "n2-standard-2", "cx23"
-	Region          string    // "us-east-1", "eastus", "us-central1", "fsn1"
-	USDPerHour      float64   // 0 when only monthly is meaningful
-	USDPerMonth     float64   // = USDPerHour × 730 unless the vendor caps differently (Hetzner)
-	NativeCurrency  string    // ISO-4217 code of the vendor's datacenter currency; "" treated as "USD"
-	NativeAmount    float64   // monthly amount in NativeCurrency; 0 when not separately tracked
-	FetchedAt       time.Time
+	Vendor         string  // "aws", "azure", "gcp", "hetzner"
+	SKU            string  // "t3.medium", "Standard_D2s_v3", "n2-standard-2", "cx23"
+	Region         string  // "us-east-1", "eastus", "us-central1", "fsn1"
+	USDPerHour     float64 // 0 when only monthly is meaningful
+	USDPerMonth    float64 // = USDPerHour × 730 unless the vendor caps differently (Hetzner)
+	NativeCurrency string  // ISO-4217 code of the vendor's datacenter currency; "" treated as "USD"
+	NativeAmount   float64 // monthly amount in NativeCurrency; 0 when not separately tracked
+	FetchedAt      time.Time
 }
 
-// Fetcher fetches a single SKU's price from a vendor API. Each
-// vendor implements this — the package's Fetch() routes by Vendor.
-type Fetcher interface {
+// VendorFetcher fetches a single SKU's price from one vendor's
+// API. Each per-vendor implementation lives in its own file
+// (aws.go, azure.go, gcp.go, …) and self-registers via Register().
+//
+// VendorFetcher is the *vendor-level* plug, not the public ctx-scoped
+// pricing seam — see the package-level [Fetcher] interface and
+// [WithFetcher] / [FetcherFrom] for the ADR 0016 §"Pricing seam"
+// determinism contract used by the xapiri test harness.
+type VendorFetcher interface {
 	Fetch(sku, region string) (Item, error)
 }
 
 var (
 	mu       sync.RWMutex
-	fetchers = map[string]Fetcher{}
+	fetchers = map[string]VendorFetcher{}
 	// disabled toggles all live fetches off; useful for tests + CI
 	// where reaching the public APIs is undesirable.
 	disabled = os.Getenv("YAGE_PRICING_DISABLED") == "true"
@@ -91,7 +98,7 @@ var (
 
 // Register makes a vendor fetcher available to Fetch().
 // Implementations call this from init().
-func Register(vendor string, f Fetcher) {
+func Register(vendor string, f VendorFetcher) {
 	mu.Lock()
 	defer mu.Unlock()
 	fetchers[vendor] = f

--- a/internal/provider/aws/cost.go
+++ b/internal/provider/aws/cost.go
@@ -4,6 +4,7 @@
 package aws
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,7 +30,8 @@ import (
 //   - "unmanaged" (default): self-managed Kubernetes on EC2.
 //   - "eks": EKS-managed control plane (live priced) + EC2 workers.
 //   - "eks-fargate": EKS CP + Fargate workers (live vCPU/GB-hour).
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.AWS.Region, "us-east-1")
 	mode := orDefault(cfg.Providers.AWS.Mode, "unmanaged")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
@@ -40,7 +42,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	cpDiskGB := atoiOr(cfg.Providers.Proxmox.ControlPlaneBootVolumeSize, 30)
 	wkDiskGB := atoiOr(cfg.Providers.Proxmox.WorkerBootVolumeSize, 40)
 
-	gp3GB, err := pricing.Fetch("aws", "ebs:gp3", region)
+	gp3GB, err := pf.Fetch(ctx, "aws", "ebs:gp3", region)
 	if err != nil {
 		return provider.CostEstimate{}, fmt.Errorf("%w: aws ebs gp3 %s: %v", provider.ErrNotApplicable, region, err)
 	}
@@ -63,7 +65,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	default: // unmanaged
 		if cp > 0 {
-			cpPrice, err := liveEC2Monthly(cpType, region)
+			cpPrice, err := liveEC2Monthly(ctx, pf, cpType, region)
 			if err != nil {
 				return provider.CostEstimate{}, fmt.Errorf("%w: aws cp %s/%s: %v", provider.ErrNotApplicable, cpType, region, err)
 			}
@@ -100,7 +102,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 			SubtotalUSD:    perPod * float64(pods),
 		})
 	} else if wk > 0 {
-		wkPrice, err := liveEC2Monthly(wkType, region)
+		wkPrice, err := liveEC2Monthly(ctx, pf, wkType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: aws worker %s/%s: %v", provider.ErrNotApplicable, wkType, region, err)
 		}
@@ -125,7 +127,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	if cfg.Pivot.Enabled {
 		mcp := atoiOr(cfg.Mgmt.ControlPlaneMachineCount, 1)
 		mgmtType := "t3.medium"
-		mgmtPrice, err := liveEC2Monthly(mgmtType, region)
+		mgmtPrice, err := liveEC2Monthly(ctx, pf, mgmtType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: aws mgmt %s/%s: %v", provider.ErrNotApplicable, mgmtType, region, err)
 		}
@@ -231,8 +233,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveEC2Monthly(instanceType, region string) (float64, error) {
-	it, err := pricing.Fetch("aws", instanceType, region)
+func liveEC2Monthly(ctx context.Context, pf pricing.Fetcher, instanceType, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "aws", instanceType, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/azure/cost.go
+++ b/internal/provider/azure/cost.go
@@ -4,6 +4,7 @@
 package azure
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -30,7 +31,8 @@ import (
 //   - "unmanaged" (default): self-managed Kubernetes on Azure VMs.
 //   - "aks": AKS-managed control plane (priced as a flat-fee SKU
 //     in the Retail Prices catalog) plus worker VMs.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.Azure.Location, "eastus")
 	mode := orDefault(cfg.Providers.Azure.Mode, "unmanaged")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
@@ -71,7 +73,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	default: // unmanaged
 		if cp > 0 {
-			cpPrice, err := liveVMMonthly(cpType, region)
+			cpPrice, err := liveVMMonthly(ctx, pf, cpType, region)
 			if err != nil {
 				return provider.CostEstimate{}, fmt.Errorf("%w: azure cp %s/%s: %v", provider.ErrNotApplicable, cpType, region, err)
 			}
@@ -92,7 +94,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	// Workers.
 	if wk > 0 {
-		wkPrice, err := liveVMMonthly(wkType, region)
+		wkPrice, err := liveVMMonthly(ctx, pf, wkType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: azure worker %s/%s: %v", provider.ErrNotApplicable, wkType, region, err)
 		}
@@ -117,7 +119,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	if cfg.Pivot.Enabled {
 		mcp := atoiOr(cfg.Mgmt.ControlPlaneMachineCount, 1)
 		mgmtType := "Standard_B2s"
-		mgmtPrice, err := liveVMMonthly(mgmtType, region)
+		mgmtPrice, err := liveVMMonthly(ctx, pf, mgmtType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: azure mgmt %s/%s: %v", provider.ErrNotApplicable, mgmtType, region, err)
 		}
@@ -215,8 +217,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveVMMonthly(sku, region string) (float64, error) {
-	it, err := pricing.Fetch("azure", sku, region)
+func liveVMMonthly(ctx context.Context, pf pricing.Fetcher, sku, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "azure", sku, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/capd/capd.go
+++ b/internal/provider/capd/capd.go
@@ -23,6 +23,8 @@
 package capd
 
 import (
+	"context"
+
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/provider"
 )
@@ -41,7 +43,9 @@ func (p *Provider) EnsureIdentity(cfg *config.Config) error { return provider.Er
 func (p *Provider) Inventory(cfg *config.Config) (*provider.Inventory, error) {
 	return nil, provider.ErrNotApplicable
 }
-func (p *Provider) EnsureGroup(cfg *config.Config, name string) error { return provider.ErrNotApplicable }
+func (p *Provider) EnsureGroup(cfg *config.Config, name string) error {
+	return provider.ErrNotApplicable
+}
 func (p *Provider) ClusterctlInitArgs(cfg *config.Config) []string {
 	return []string{"--infrastructure", "docker"}
 }
@@ -163,6 +167,6 @@ func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt b
 // (Proxmox), private (vSphere), or pricing-too-variable (OpenStack)
 // providers return ErrNotApplicable; the orchestrator displays the
 // estimate only when it's available.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(_ context.Context, cfg *config.Config) (provider.CostEstimate, error) {
 	return provider.CostEstimate{}, provider.ErrNotApplicable
 }

--- a/internal/provider/digitalocean/cost.go
+++ b/internal/provider/digitalocean/cost.go
@@ -4,6 +4,7 @@
 package digitalocean
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,7 +19,8 @@ import (
 // live /v2/sizes data via internal/pricing. Block storage and load
 // balancers are not folded in yet (overhead-tier wiring would mirror
 // AWS/Azure/GCP — TODO when needed).
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.DigitalOcean.Region, "nyc3")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
 	wk := atoiOr(cfg.WorkerMachineCount, 0)
@@ -27,7 +29,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	items := []provider.CostItem{}
 	if cp > 0 {
-		price, err := liveDropletMonthly(cpType, region)
+		price, err := liveDropletMonthly(ctx, pf, cpType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: digitalocean cp %s/%s: %v",
 				provider.ErrNotApplicable, cpType, region, err)
@@ -40,7 +42,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	}
 	if wk > 0 {
-		price, err := liveDropletMonthly(wkType, region)
+		price, err := liveDropletMonthly(ctx, pf, wkType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: digitalocean worker %s/%s: %v",
 				provider.ErrNotApplicable, wkType, region, err)
@@ -116,8 +118,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveDropletMonthly(slug, region string) (float64, error) {
-	it, err := pricing.Fetch("digitalocean", slug, region)
+func liveDropletMonthly(ctx context.Context, pf pricing.Fetcher, slug, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "digitalocean", slug, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/gcp/cost.go
+++ b/internal/provider/gcp/cost.go
@@ -4,6 +4,7 @@
 package gcp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -30,7 +31,8 @@ import (
 //   - "unmanaged" (default): self-managed Kubernetes on GCE.
 //   - "gke": GKE Standard managed control plane (live-priced) +
 //     GCE worker nodes.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.GCP.Region, "us-central1")
 	mode := orDefault(cfg.Providers.GCP.Mode, "unmanaged")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
@@ -41,7 +43,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	cpDiskGB := atoiOr(cfg.Providers.Proxmox.ControlPlaneBootVolumeSize, 30)
 	wkDiskGB := atoiOr(cfg.Providers.Proxmox.WorkerBootVolumeSize, 40)
 
-	pdBalanced, err := pricing.Fetch("gcp", "pd:balanced", region)
+	pdBalanced, err := pf.Fetch(ctx, "gcp", "pd:balanced", region)
 	if err != nil {
 		return provider.CostEstimate{}, fmt.Errorf("%w: gcp pd-balanced %s: %v", provider.ErrNotApplicable, region, err)
 	}
@@ -64,7 +66,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	default: // unmanaged
 		if cp > 0 {
-			cpPrice, err := liveGCEMonthly(cpType, region)
+			cpPrice, err := liveGCEMonthly(ctx, pf, cpType, region)
 			if err != nil {
 				return provider.CostEstimate{}, fmt.Errorf("%w: gcp cp %s/%s: %v", provider.ErrNotApplicable, cpType, region, err)
 			}
@@ -84,7 +86,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	}
 
 	if wk > 0 {
-		wkPrice, err := liveGCEMonthly(wkType, region)
+		wkPrice, err := liveGCEMonthly(ctx, pf, wkType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: gcp worker %s/%s: %v", provider.ErrNotApplicable, wkType, region, err)
 		}
@@ -109,7 +111,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	if cfg.Pivot.Enabled {
 		mcp := atoiOr(cfg.Mgmt.ControlPlaneMachineCount, 1)
 		mgmtType := "e2-medium"
-		mgmtPrice, err := liveGCEMonthly(mgmtType, region)
+		mgmtPrice, err := liveGCEMonthly(ctx, pf, mgmtType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: gcp mgmt %s/%s: %v", provider.ErrNotApplicable, mgmtType, region, err)
 		}
@@ -206,8 +208,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveGCEMonthly(machineType, region string) (float64, error) {
-	it, err := pricing.Fetch("gcp", machineType, region)
+func liveGCEMonthly(ctx context.Context, pf pricing.Fetcher, machineType, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "gcp", machineType, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/hetzner/cost.go
+++ b/internal/provider/hetzner/cost.go
@@ -4,6 +4,7 @@
 package hetzner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -75,7 +76,8 @@ func hetznerOverheadDefaults(tier string) hetznerOverheadCounts {
 //
 // CAPHV is unmanaged-only (no Hetzner-managed Kubernetes today),
 // so there's no managed-mode switch.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.Hetzner.Location, "fsn1")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
 	wk := atoiOr(cfg.WorkerMachineCount, 0)
@@ -86,7 +88,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	// Control plane: Hetzner servers (boot disk bundled).
 	if cp > 0 {
-		cpPrice, err := liveServerMonthly(cpType, region)
+		cpPrice, err := liveServerMonthly(ctx, pf, cpType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: hetzner: %v", provider.ErrNotApplicable, err)
 		}
@@ -100,7 +102,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	// Workers: Hetzner servers (boot disk bundled).
 	if wk > 0 {
-		wkPrice, err := liveServerMonthly(wkType, region)
+		wkPrice, err := liveServerMonthly(ctx, pf, wkType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: hetzner: %v", provider.ErrNotApplicable, err)
 		}
@@ -116,7 +118,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 	if cfg.Pivot.Enabled {
 		mcp := atoiOr(cfg.Mgmt.ControlPlaneMachineCount, 1)
 		mgmtType := "cx23"
-		mgmtPrice, err := liveServerMonthly(mgmtType, region)
+		mgmtPrice, err := liveServerMonthly(ctx, pf, mgmtType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: hetzner: %v", provider.ErrNotApplicable, err)
 		}
@@ -170,8 +172,8 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 // liveServerMonthly hits the live Hetzner pricing fetcher. Returns
 // the monthly cap (USD) for the (server_type, location) pair.
-func liveServerMonthly(sku, region string) (float64, error) {
-	it, err := pricing.Fetch("hetzner", sku, region)
+func liveServerMonthly(ctx context.Context, pf pricing.Fetcher, sku, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "hetzner", sku, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/ibmcloud/cost.go
+++ b/internal/provider/ibmcloud/cost.go
@@ -4,6 +4,7 @@
 package ibmcloud
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,7 +18,8 @@ import (
 // EstimateMonthlyCostUSD computes an IBM Cloud VPC Gen2 bill from
 // live Global Catalog data. Profile IDs look like "bx2-2x8" (general
 // purpose, 2 vCPU, 8 GB) or "cx2-4x8" (compute optimised).
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.IBMCloud.Region, "us-south")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
 	wk := atoiOr(cfg.WorkerMachineCount, 0)
@@ -26,7 +28,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	items := []provider.CostItem{}
 	if cp > 0 {
-		price, err := liveIBMMonthly(cpProfile, region)
+		price, err := liveIBMMonthly(ctx, pf, cpProfile, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: ibmcloud cp %s/%s: %v",
 				provider.ErrNotApplicable, cpProfile, region, err)
@@ -39,7 +41,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	}
 	if wk > 0 {
-		price, err := liveIBMMonthly(wkProfile, region)
+		price, err := liveIBMMonthly(ctx, pf, wkProfile, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: ibmcloud worker %s/%s: %v",
 				provider.ErrNotApplicable, wkProfile, region, err)
@@ -114,8 +116,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveIBMMonthly(profile, region string) (float64, error) {
-	it, err := pricing.Fetch("ibmcloud", profile, region)
+func liveIBMMonthly(ctx context.Context, pf pricing.Fetcher, profile, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "ibmcloud", profile, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/linode/cost.go
+++ b/internal/provider/linode/cost.go
@@ -4,6 +4,7 @@
 package linode
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,7 +19,8 @@ import (
 // /v4/linode/types data. Type IDs look like "g6-standard-2".
 // Region availability is global for compute (region only matters
 // for transfer pricing); we ignore region in the catalog lookup.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.Linode.Region, "us-east")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
 	wk := atoiOr(cfg.WorkerMachineCount, 0)
@@ -27,7 +29,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	items := []provider.CostItem{}
 	if cp > 0 {
-		price, err := liveLinodeMonthly(cpType, region)
+		price, err := liveLinodeMonthly(ctx, pf, cpType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: linode cp %s: %v",
 				provider.ErrNotApplicable, cpType, err)
@@ -40,7 +42,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	}
 	if wk > 0 {
-		price, err := liveLinodeMonthly(wkType, region)
+		price, err := liveLinodeMonthly(ctx, pf, wkType, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: linode worker %s: %v",
 				provider.ErrNotApplicable, wkType, err)
@@ -115,8 +117,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveLinodeMonthly(typeID, region string) (float64, error) {
-	it, err := pricing.Fetch("linode", typeID, region)
+func liveLinodeMonthly(ctx context.Context, pf pricing.Fetcher, typeID, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "linode", typeID, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/linode/cost_test.go
+++ b/internal/provider/linode/cost_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Luca Pasquali
+
+package linode
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lpasquali/yage/internal/config"
+	"github.com/lpasquali/yage/internal/pricing"
+	"github.com/lpasquali/yage/internal/provider"
+)
+
+// TestEstimateMonthlyCostUSD_UsesContextFetcher verifies the
+// ADR 0016 §"Pricing seam" injection: when a StaticFetcher is on
+// the context, EstimateMonthlyCostUSD must read prices from it
+// (not from the live Linode catalog) and the resulting math must
+// match (rate × MonthlyHours × replicas).
+func TestEstimateMonthlyCostUSD_UsesContextFetcher(t *testing.T) {
+	const (
+		region   = "us-east"
+		machine  = "g6-standard-2"
+		hourly   = 0.05 // $0.05/hr → $36.50/mo
+		expected = hourly * pricing.MonthlyHours
+	)
+
+	stub := pricing.StaticFetcher{
+		"linode/" + region + "/" + machine: hourly,
+	}
+	ctx := pricing.WithFetcher(context.Background(), stub)
+
+	cfg := &config.Config{
+		ControlPlaneMachineCount: "1",
+		WorkerMachineCount:       "2",
+	}
+	cfg.Providers.Linode.Region = region
+	cfg.Providers.Linode.ControlPlaneType = machine
+	cfg.Providers.Linode.NodeType = machine
+
+	p := &Provider{}
+	est, err := p.EstimateMonthlyCostUSD(ctx, cfg)
+	if err != nil {
+		t.Fatalf("EstimateMonthlyCostUSD: %v", err)
+	}
+
+	wantTotal := expected * 3 // 1 cp + 2 workers
+	if est.TotalUSDMonthly != wantTotal {
+		t.Errorf("TotalUSDMonthly = %v, want %v (=%v × 3)", est.TotalUSDMonthly, wantTotal, expected)
+	}
+	if len(est.Items) != 2 {
+		t.Errorf("len(Items) = %d, want 2 (cp + workers)", len(est.Items))
+	}
+	if est.Items[0].Qty != 1 || est.Items[0].UnitUSDMonthly != expected {
+		t.Errorf("cp item = %+v, want Qty=1 Unit=%v", est.Items[0], expected)
+	}
+	if est.Items[1].Qty != 2 || est.Items[1].UnitUSDMonthly != expected {
+		t.Errorf("worker item = %+v, want Qty=2 Unit=%v", est.Items[1], expected)
+	}
+}
+
+// TestEstimateMonthlyCostUSD_StaticFetcherMissReturnsErrNotApplicable
+// confirms that a StaticFetcher miss (no entry for the requested SKU)
+// surfaces as ErrNotApplicable from the provider — the ADR-0016
+// "no fabricated numbers" guarantee carries through to test paths.
+func TestEstimateMonthlyCostUSD_StaticFetcherMissReturnsErrNotApplicable(t *testing.T) {
+	ctx := pricing.WithFetcher(context.Background(), pricing.StaticFetcher{})
+	cfg := &config.Config{ControlPlaneMachineCount: "1"}
+	cfg.Providers.Linode.Region = "us-east"
+	cfg.Providers.Linode.ControlPlaneType = "g6-standard-2"
+
+	p := &Provider{}
+	_, err := p.EstimateMonthlyCostUSD(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected error from missing StaticFetcher entry, got nil")
+	}
+	if !errors.Is(err, provider.ErrNotApplicable) {
+		t.Errorf("err = %v, want wrap of provider.ErrNotApplicable", err)
+	}
+}

--- a/internal/provider/oci/cost.go
+++ b/internal/provider/oci/cost.go
@@ -4,6 +4,7 @@
 package oci
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,7 +19,8 @@ import (
 // auth-free Cost Estimator JSON. Flex shapes (VM.Standard.E4.Flex)
 // are priced per-OCPU + per-GB-hour and we model them at the user-
 // supplied OCPU/memory; fixed shapes price per-hour.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (provider.CostEstimate, error) {
+	pf := pricing.FetcherFrom(ctx)
 	region := orDefault(cfg.Providers.OCI.Region, "us-ashburn-1")
 	cp := atoiOr(cfg.ControlPlaneMachineCount, 1)
 	wk := atoiOr(cfg.WorkerMachineCount, 0)
@@ -27,7 +29,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 
 	items := []provider.CostItem{}
 	if cp > 0 {
-		price, err := liveOCIShapeMonthly(cpShape, region)
+		price, err := liveOCIShapeMonthly(ctx, pf, cpShape, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: oci cp %s/%s: %v",
 				provider.ErrNotApplicable, cpShape, region, err)
@@ -40,7 +42,7 @@ func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEsti
 		})
 	}
 	if wk > 0 {
-		price, err := liveOCIShapeMonthly(wkShape, region)
+		price, err := liveOCIShapeMonthly(ctx, pf, wkShape, region)
 		if err != nil {
 			return provider.CostEstimate{}, fmt.Errorf("%w: oci worker %s/%s: %v",
 				provider.ErrNotApplicable, wkShape, region, err)
@@ -115,8 +117,8 @@ func pgTierFromEnv(env string) cost.PostgresTier {
 	}
 }
 
-func liveOCIShapeMonthly(shape, region string) (float64, error) {
-	it, err := pricing.Fetch("oci", shape, region)
+func liveOCIShapeMonthly(ctx context.Context, pf pricing.Fetcher, shape, region string) (float64, error) {
+	it, err := pf.Fetch(ctx, "oci", shape, region)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/provider/openstack/openstack.go
+++ b/internal/provider/openstack/openstack.go
@@ -40,6 +40,8 @@
 package openstack
 
 import (
+	"context"
+
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/provider"
 )
@@ -235,6 +237,6 @@ func (p *Provider) K3sTemplate(cfg *config.Config, mgmt bool) (string, error) {
 // (Proxmox), private (vSphere), or pricing-too-variable (OpenStack)
 // providers return ErrNotApplicable; the orchestrator displays the
 // estimate only when it's available.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(_ context.Context, cfg *config.Config) (provider.CostEstimate, error) {
 	return provider.CostEstimate{}, provider.ErrNotApplicable
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,6 +29,7 @@
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -141,7 +142,16 @@ type Provider interface {
 	// (private OpenStack, on-prem vSphere). Wrap ErrNotApplicable
 	// when a live API is unreachable so callers can surface "estimate
 	// unavailable" instead of fabricating a number.
-	EstimateMonthlyCostUSD(cfg *config.Config) (CostEstimate, error)
+	//
+	// ctx carries the active pricing.Fetcher (per ADR 0016 §"Pricing
+	// seam"). Implementations that consult internal/pricing should
+	// route through pricing.FetcherFrom(ctx).Fetch(...) so deterministic
+	// test harnesses can pin a frozen catalog. Calls that go through
+	// the bespoke per-vendor helpers (AWSEKSControlPlaneUSDPerMonth,
+	// AzureManagedDiskUSDPerGBMonth, …) continue to hit the package
+	// globals; full migration of those helpers onto Fetcher is tracked
+	// as follow-up.
+	EstimateMonthlyCostUSD(ctx context.Context, cfg *config.Config) (CostEstimate, error)
 
 	// PlanDescriber emits the provider-specific dry-run plan
 	// sections via plan.Writer. Three hooks because the orchestrator
@@ -382,10 +392,10 @@ type CostEstimate struct {
 
 // CostItem is one line in the cost breakdown.
 type CostItem struct {
-	Name            string  // "workload control-plane (3× t3.medium)"
-	UnitUSDMonthly  float64 // per-replica per-month cost
-	Qty             int
-	SubtotalUSD     float64
+	Name           string  // "workload control-plane (3× t3.medium)"
+	UnitUSDMonthly float64 // per-replica per-month cost
+	Qty            int
+	SubtotalUSD    float64
 }
 
 // --- registry ---

--- a/internal/provider/proxmox/proxmox.go
+++ b/internal/provider/proxmox/proxmox.go
@@ -12,6 +12,8 @@
 package proxmox
 
 import (
+	"context"
+
 	"github.com/lpasquali/yage/internal/capi/manifest"
 	"github.com/lpasquali/yage/internal/config"
 	"github.com/lpasquali/yage/internal/platform/opentofux"
@@ -92,6 +94,6 @@ func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt b
 // rate-usd / --hardware-support-usd-month; without those, returns
 // ErrNotApplicable and the orchestrator surfaces "estimate
 // unavailable" rather than fabricate.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(_ context.Context, cfg *config.Config) (provider.CostEstimate, error) {
 	return provider.TCOEstimate(cfg, "proxmox")
 }

--- a/internal/provider/vsphere/vsphere.go
+++ b/internal/provider/vsphere/vsphere.go
@@ -27,6 +27,7 @@
 package vsphere
 
 import (
+	"context"
 	"os"
 	"regexp"
 	"strings"
@@ -256,10 +257,10 @@ func (p *Provider) PatchManifest(cfg *config.Config, manifestPath string, mgmt b
 	vs := cfg.Providers.Vsphere
 
 	type sizing struct {
-		numCPUs          string
+		numCPUs           string
 		numCoresPerSocket string
-		memoryMiB        string
-		diskGiB          string
+		memoryMiB         string
+		diskGiB           string
 	}
 	cp := sizing{vs.ControlPlaneNumCPUs, vs.ControlPlaneNumCoresPerSocket, vs.ControlPlaneMemoryMiB, vs.ControlPlaneDiskGiB}
 	wk := sizing{vs.WorkerNumCPUs, vs.WorkerNumCoresPerSocket, vs.WorkerMemoryMiB, vs.WorkerDiskGiB}
@@ -342,6 +343,6 @@ func replaceFirstField(doc, key, value string) string {
 // (and optionally --hardware-watts / --hardware-kwh-rate-usd /
 // --hardware-support-usd-month for vSphere licensing/support).
 // Without those, returns ErrNotApplicable.
-func (p *Provider) EstimateMonthlyCostUSD(cfg *config.Config) (provider.CostEstimate, error) {
+func (p *Provider) EstimateMonthlyCostUSD(_ context.Context, cfg *config.Config) (provider.CostEstimate, error) {
 	return provider.TCOEstimate(cfg, "vsphere")
 }

--- a/internal/ui/xapiri/dashboard_cost_helpers.go
+++ b/internal/ui/xapiri/dashboard_cost_helpers.go
@@ -11,6 +11,7 @@ package xapiri
 // tab_costs.go can reference them without a circular dependency.
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -39,7 +40,7 @@ var costWindows = []costWindowPreset{
 	{8 * time.Hour, "8 hours", "/8h"},
 	{24 * time.Hour, "1 day", "/day"},
 	{7 * 24 * time.Hour, "1 week", "/wk"},
-	{30 * 24 * time.Hour, "1 month", "/mo"},   // default (index 6)
+	{30 * 24 * time.Hour, "1 month", "/mo"}, // default (index 6)
 	{365 * 24 * time.Hour, "1 year", "/yr"},
 }
 
@@ -47,7 +48,6 @@ const costDefaultPeriodIdx = 6 // 1 month
 
 // costMonthSecs is the number of seconds in the reference month (30 days).
 const costMonthSecs = 30 * 24 * 3600.0
-
 
 // kickRefreshCmd launches streaming cost fetches and returns a cmd that
 // delivers the first result. Subsequent results chain via waitForCostRowCmd.
@@ -111,7 +111,11 @@ func (m dashModel) kickRefreshCmd() tea.Cmd {
 		}
 
 		ch := make(chan cost.CloudCost, 64)
-		cost.StreamWithRegions(&snap, cost.ScopeCloudOnly, regionsByProvider, globalLogRing, ch)
+		// Background context: production hits the live catalog. The
+		// xapiri test harness installs a pricing.Fetcher via
+		// pricing.WithFetcher when scenarios need a frozen catalog
+		// (ADR 0016 §"Pricing seam").
+		cost.StreamWithRegions(context.Background(), &snap, cost.ScopeCloudOnly, regionsByProvider, globalLogRing, ch)
 		row, ok := <-ch
 		return costRowMsg{row: row, ch: ch, done: !ok}
 	}


### PR DESCRIPTION
## Summary

Implement ADR 0016 §"Pricing seam" — the deterministic injection point the xapiri UI simulation harness needs so parallel teatest scenarios can pin a frozen catalog instead of racing on the per-vendor live fetchers registered via `pricing.Register()`.

This change **gates the entire ADR 0016 harness work** (Layer Low / Mid / scenarios) and is the single prerequisite called out in [issue #197](https://github.com/lpasquali/yage/issues/197).

Closes #197.

## DoD Level

- [x] **Level 1 — Full Validation** (orchestrator, provider, config, CSI, kindsync, cluster code)
- [ ] Level 2 — Test / CI / Config
- [ ] Level 3 — Documentation

## Level 1 Checklist

- [x] `make build` passes (`go build ./...` clean)
- [x] `go test ./...` passes (47 packages ok, 0 failures)
- [x] `govulncheck ./...` clean — `No vulnerabilities found.` (`go.mod` unchanged)
- [x] Change covered by new unit tests:
  - `internal/pricing/fetcher_test.go` — round-trip, default singleton, parallel-isolation, missing-key surfaces ErrUnavailable.
  - `internal/cost/compare_test.go` — two concurrent `StreamWithFilter` calls with different StaticFetchers do not see each other's data.
  - `internal/provider/linode/cost_test.go` — `EstimateMonthlyCostUSD` math against a known StaticFetcher rate; miss returns `provider.ErrNotApplicable`.
- [x] Breaking-change audit: `Provider.EstimateMonthlyCostUSD` adds a leading `ctx context.Context` parameter (called out in the ADR §Consequences as a breaking change). All 12 provider implementations updated; all `cost.Stream*` / `cost.Compare*` / `cost.RetentionAtBudget` / `cost.PrintComparison` / `cost.LiveBlockStorageLabel` callers in `internal/orchestrator`, `internal/operator/cost`, and `internal/ui/xapiri` propagate `ctx`.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `govulncheck ./...` | Clean | `No vulnerabilities found.` (no `go.mod` change; ran with `GOTOOLCHAIN=go1.26.2`) |
| PE review (Secret schema / CAPI YAML) | N/A | No CAPI YAML or Secret schema changes |
| Supply-chain (workflow change) | N/A | No `.github/workflows/` changes |

## Acceptance Criteria Evidence

From issue #197 / ADR 0016 §"Pricing seam":

- [x] **`pricing.Fetcher` interface + `WithFetcher`/`FetcherFrom`/`StaticFetcher` shipped** — `internal/pricing/fetcher.go`. The interface carries `Fetch(ctx, vendor, sku, region) (Item, error)` (covers every existing `pricing.Fetch(...)` call site) plus `USDPerHour(ctx, vendor, region, sku) (float64, error)` (the ADR-mandated convenience for harness DSL).
- [x] **All 12 providers' `EstimateMonthlyCostUSD` accept `ctx context.Context` and read fetcher from it** — aws, azure, gcp, hetzner, digitalocean, linode, oci, ibmcloud, plus the four ErrNotApplicable / TCO providers (proxmox, vsphere, openstack, capd).
- [x] **`internal/cost/` callers propagate `ctx` through** — `StreamWithFilter`, `StreamWithRegions`, `CompareWithFilter`, `CompareClouds`, `PrintComparison`, `RetentionAtBudget`, `LiveBlockStorageLabel`, `liveBlockStorageUSDPerGBMonth` all take `ctx` as first parameter and route fetches through `pricing.FetcherFrom(ctx).Fetch(...)`.
- [x] **All existing tests green; new fetcher-injection unit test covers the round-trip** — see test list above.
- [x] **PR body cites ADR 0016 and this issue** — see Summary + this section.

## Interface signature

```go
// internal/pricing/fetcher.go
type Fetcher interface {
    Fetch(ctx context.Context, vendor, sku, region string) (Item, error)
    USDPerHour(ctx context.Context, vendor, region, sku string) (float64, error)
}

type StaticFetcher map[string]float64 // key: vendor+"/"+region+"/"+sku

func WithFetcher(ctx context.Context, f Fetcher) context.Context // nil f returns ctx unchanged
func FetcherFrom(ctx context.Context) Fetcher                    // nil ctx returns DefaultFetcher
func DefaultFetcher() Fetcher                                    // sync.Once-guarded liveFetcher singleton
```

The existing per-vendor `Fetcher` interface (renamed to `VendorFetcher` to free the name) keeps the `Register(vendor, f)` self-registration shape; `liveFetcher.Fetch` delegates to the package-level `pricing.Fetch(...)` so the 24h disk cache + airgap short-circuit + `ErrUnavailable` semantics are preserved unchanged for production.

## Scope notes (per ADR §Consequences)

- **Bespoke per-vendor helpers** (`AWSEKSControlPlaneUSDPerMonth`, `AzureManagedDiskUSDPerGBMonth`, `AWSAuroraPostgresUSDPerMonth`, `HetznerVolumeUSDPerGBMonth`, …) remain package-level functions in this PR — there are ~40 of them with non-uniform shapes, and the issue #197 DoD only requires routed `Fetch(...)` call sites to consult the context fetcher. Full migration of the bespoke helpers is tracked as follow-up.
- **`pricing.SetCredentials`** is intentionally untouched (carries credentials, not catalog data — orthogonal per ADR 0016 §2.1).

## Tests

- `TestFetcherFrom_DefaultsToLiveFetcherWhenAbsent`
- `TestFetcherFrom_NilContextReturnsDefault`
- `TestWithFetcher_RoundTrip`
- `TestWithFetcher_NilFetcherIsNoOp`
- `TestStaticFetcher_FetchSynthesizesUSDPerMonth`
- `TestStaticFetcher_MissingEntryReturnsErrUnavailable`
- `TestParallelFetcherIsolation` (`t.Parallel()`)
- `TestDefaultFetcher_IsSingleton`
- `TestStreamWithFilter_PropagatesContextFetcher` (parallel cross-context isolation)
- `TestCompareWithFilter_AcceptsContext`
- `TestEstimateMonthlyCostUSD_UsesContextFetcher` (linode)
- `TestEstimateMonthlyCostUSD_StaticFetcherMissReturnsErrNotApplicable` (linode)

## Breaking Changes

- `provider.Provider.EstimateMonthlyCostUSD` signature: `(cfg *config.Config) (CostEstimate, error)` → `(ctx context.Context, cfg *config.Config) (CostEstimate, error)`. All 12 in-tree implementations updated. External provider implementations (none known) would need the same one-line change.
- `cost.StreamWithFilter` / `StreamWithRegions` / `CompareWithFilter` / `CompareClouds` / `PrintComparison` / `RetentionAtBudget` / `LiveBlockStorageLabel` add `ctx context.Context` as the first parameter.
- `pricing.Fetcher` (vendor-level interface) renamed to `pricing.VendorFetcher` so the public `Fetcher` name is available for the new ctx-scoped contract. Only `pricing.Register` consumes the renamed interface; per-vendor implementations needed no change because the method shape `Fetch(sku, region) (Item, error)` is structural.

## Notes for Reviewer

- The `liveFetcher.Fetch` delegate intentionally accepts `ctx` but does not propagate it to the underlying vendor fetchers (the existing `pricing.Fetch(...)` package function is sync and does not take ctx). Threading ctx into the per-vendor HTTP clients is a separate refactor and not in scope for #197.
- `internal/orchestrator/plan.go` synthesises `context.Background()` for the dry-run path (no override needed in production); the xapiri test harness will install a `pricing.Fetcher` via `pricing.WithFetcher` in its scenario setup per ADR 0016.
- `internal/ui/xapiri/dashboard_cost_helpers.go` uses `context.Background()` for the live-cost goroutine; a follow-up that threads the harness's `tea.Program` context into the dashboard's `tea.Cmd` factories will let scenarios pin a frozen catalog without changing this site again.

## Module / dependency references

- ADR 0016 §"Pricing seam": https://lpasquali.github.io/yage-docs/architecture/adrs/0016-xapiri-ui-simulation-harness/
- Issue #197: https://github.com/lpasquali/yage/issues/197
- ADR 0005 (pricing/cost subsystem)
- ADR 0015 (test coverage targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)